### PR TITLE
[codex] Remove Freepik stock asset references

### DIFF
--- a/packages/core/themes/stock/default.ts
+++ b/packages/core/themes/stock/default.ts
@@ -800,7 +800,7 @@ const theme: StockTheme = {
         image: {
           type: ValueType.EXACT,
           value:
-            "https://img.freepik.com/premium-photo/white-abstract-background-with-subtle-d-texture_947794-79438.jpg",
+            "https://static.seldon.app/background-default-light.jpg",
         },
         repeat: { type: ValueType.OPTION, value: BackgroundRepeat.NO_REPEAT },
         size: { type: ValueType.OPTION, value: ImageFit.COVER },
@@ -813,7 +813,7 @@ const theme: StockTheme = {
         image: {
           type: ValueType.EXACT,
           value:
-            "https://img.freepik.com/premium-photo/white-abstract-background-with-subtle-d-texture_947794-79438.jpg",
+            "https://static.seldon.app/background-default-light.jpg",
         },
         repeat: { type: ValueType.OPTION, value: BackgroundRepeat.REPEAT },
         size: { type: ValueType.OPTION, value: ImageFit.ORIGINAL },

--- a/packages/core/themes/stock/earth.ts
+++ b/packages/core/themes/stock/earth.ts
@@ -777,7 +777,7 @@ const theme: StockTheme = {
         image: {
           type: ValueType.EXACT,
           value:
-            "https://img.freepik.com/premium-photo/white-abstract-background-with-subtle-d-texture_947794-79438.jpg",
+            "https://static.seldon.app/background-default-light.jpg",
         },
         repeat: { type: ValueType.OPTION, value: BackgroundRepeat.NO_REPEAT },
         size: { type: ValueType.OPTION, value: ImageFit.COVER },
@@ -790,7 +790,7 @@ const theme: StockTheme = {
         image: {
           type: ValueType.EXACT,
           value:
-            "https://img.freepik.com/premium-photo/white-abstract-background-with-subtle-d-texture_947794-79438.jpg",
+            "https://static.seldon.app/background-default-light.jpg",
         },
         repeat: { type: ValueType.OPTION, value: BackgroundRepeat.REPEAT },
         size: { type: ValueType.OPTION, value: ImageFit.ORIGINAL },

--- a/packages/core/themes/stock/high-contrast.ts
+++ b/packages/core/themes/stock/high-contrast.ts
@@ -790,7 +790,7 @@ const theme: StockTheme = {
         image: {
           type: ValueType.EXACT,
           value:
-            "https://img.freepik.com/premium-photo/white-abstract-background-with-subtle-d-texture_947794-79438.jpg",
+            "https://static.seldon.app/background-default-light.jpg",
         },
         repeat: { type: ValueType.OPTION, value: BackgroundRepeat.NO_REPEAT },
         size: { type: ValueType.OPTION, value: ImageFit.COVER },
@@ -803,7 +803,7 @@ const theme: StockTheme = {
         image: {
           type: ValueType.EXACT,
           value:
-            "https://img.freepik.com/premium-photo/white-abstract-background-with-subtle-d-texture_947794-79438.jpg",
+            "https://static.seldon.app/background-default-light.jpg",
         },
         repeat: { type: ValueType.OPTION, value: BackgroundRepeat.REPEAT },
         size: { type: ValueType.OPTION, value: ImageFit.ORIGINAL },

--- a/packages/core/themes/stock/industrial.ts
+++ b/packages/core/themes/stock/industrial.ts
@@ -789,7 +789,7 @@ const theme: StockTheme = {
         image: {
           type: ValueType.EXACT,
           value:
-            "https://img.freepik.com/premium-photo/white-abstract-background-with-subtle-d-texture_947794-79438.jpg",
+            "https://static.seldon.app/background-default-light.jpg",
         },
         repeat: { type: ValueType.OPTION, value: BackgroundRepeat.NO_REPEAT },
         size: { type: ValueType.OPTION, value: ImageFit.COVER },
@@ -802,7 +802,7 @@ const theme: StockTheme = {
         image: {
           type: ValueType.EXACT,
           value:
-            "https://img.freepik.com/premium-photo/white-abstract-background-with-subtle-d-texture_947794-79438.jpg",
+            "https://static.seldon.app/background-default-light.jpg",
         },
         repeat: { type: ValueType.OPTION, value: BackgroundRepeat.REPEAT },
         size: { type: ValueType.OPTION, value: ImageFit.ORIGINAL },

--- a/packages/core/themes/stock/material.ts
+++ b/packages/core/themes/stock/material.ts
@@ -775,7 +775,7 @@ const theme: StockTheme = {
         image: {
           type: ValueType.EXACT,
           value:
-            "https://img.freepik.com/premium-photo/white-abstract-background-with-subtle-d-texture_947794-79438.jpg",
+            "https://static.seldon.app/background-default-light.jpg",
         },
         repeat: { type: ValueType.OPTION, value: BackgroundRepeat.NO_REPEAT },
         size: { type: ValueType.OPTION, value: ImageFit.COVER },
@@ -788,7 +788,7 @@ const theme: StockTheme = {
         image: {
           type: ValueType.EXACT,
           value:
-            "https://img.freepik.com/premium-photo/white-abstract-background-with-subtle-d-texture_947794-79438.jpg",
+            "https://static.seldon.app/background-default-light.jpg",
         },
         repeat: { type: ValueType.OPTION, value: BackgroundRepeat.REPEAT },
         size: { type: ValueType.OPTION, value: ImageFit.ORIGINAL },

--- a/packages/core/themes/stock/pop.ts
+++ b/packages/core/themes/stock/pop.ts
@@ -765,7 +765,7 @@ const theme: StockTheme = {
         image: {
           type: ValueType.EXACT,
           value:
-            "https://img.freepik.com/premium-photo/white-abstract-background-with-subtle-d-texture_947794-79438.jpg",
+            "https://static.seldon.app/background-default-light.jpg",
         },
         repeat: { type: ValueType.OPTION, value: BackgroundRepeat.NO_REPEAT },
         size: { type: ValueType.OPTION, value: ImageFit.COVER },
@@ -778,7 +778,7 @@ const theme: StockTheme = {
         image: {
           type: ValueType.EXACT,
           value:
-            "https://img.freepik.com/premium-photo/white-abstract-background-with-subtle-d-texture_947794-79438.jpg",
+            "https://static.seldon.app/background-default-light.jpg",
         },
         repeat: { type: ValueType.OPTION, value: BackgroundRepeat.REPEAT },
         size: { type: ValueType.OPTION, value: ImageFit.ORIGINAL },

--- a/packages/core/themes/stock/royal-azure.ts
+++ b/packages/core/themes/stock/royal-azure.ts
@@ -1238,7 +1238,7 @@ const theme: StockTheme = {
         image: {
           type: ValueType.EXACT,
           value:
-            "https://img.freepik.com/premium-photo/white-abstract-background-with-subtle-d-texture_947794-79438.jpg",
+            "https://static.seldon.app/background-default-light.jpg",
         },
         repeat: {
           type: ValueType.OPTION,
@@ -1257,7 +1257,7 @@ const theme: StockTheme = {
         image: {
           type: ValueType.EXACT,
           value:
-            "https://img.freepik.com/premium-photo/white-abstract-background-with-subtle-d-texture_947794-79438.jpg",
+            "https://static.seldon.app/background-default-light.jpg",
         },
         repeat: {
           type: ValueType.OPTION,

--- a/packages/core/themes/stock/sky.ts
+++ b/packages/core/themes/stock/sky.ts
@@ -772,7 +772,7 @@ const theme: StockTheme = {
         image: {
           type: ValueType.EXACT,
           value:
-            "https://img.freepik.com/premium-photo/white-abstract-background-with-subtle-d-texture_947794-79438.jpg",
+            "https://static.seldon.app/background-default-light.jpg",
         },
         repeat: { type: ValueType.OPTION, value: BackgroundRepeat.NO_REPEAT },
         size: { type: ValueType.OPTION, value: ImageFit.COVER },
@@ -785,7 +785,7 @@ const theme: StockTheme = {
         image: {
           type: ValueType.EXACT,
           value:
-            "https://img.freepik.com/premium-photo/white-abstract-background-with-subtle-d-texture_947794-79438.jpg",
+            "https://static.seldon.app/background-default-light.jpg",
         },
         repeat: { type: ValueType.OPTION, value: BackgroundRepeat.REPEAT },
         size: { type: ValueType.OPTION, value: ImageFit.ORIGINAL },

--- a/packages/core/themes/stock/sunset-blue.ts
+++ b/packages/core/themes/stock/sunset-blue.ts
@@ -1238,7 +1238,7 @@ const theme: StockTheme = {
         image: {
           type: ValueType.EXACT,
           value:
-            "https://img.freepik.com/premium-photo/white-abstract-background-with-subtle-d-texture_947794-79438.jpg",
+            "https://static.seldon.app/background-default-light.jpg",
         },
         repeat: {
           type: ValueType.OPTION,
@@ -1257,7 +1257,7 @@ const theme: StockTheme = {
         image: {
           type: ValueType.EXACT,
           value:
-            "https://img.freepik.com/premium-photo/white-abstract-background-with-subtle-d-texture_947794-79438.jpg",
+            "https://static.seldon.app/background-default-light.jpg",
         },
         repeat: {
           type: ValueType.OPTION,

--- a/packages/core/themes/stock/wildberry.ts
+++ b/packages/core/themes/stock/wildberry.ts
@@ -1238,7 +1238,7 @@ const theme: StockTheme = {
         image: {
           type: ValueType.EXACT,
           value:
-            "https://img.freepik.com/premium-photo/white-abstract-background-with-subtle-d-texture_947794-79438.jpg",
+            "https://static.seldon.app/background-default-light.jpg",
         },
         repeat: {
           type: ValueType.OPTION,
@@ -1257,7 +1257,7 @@ const theme: StockTheme = {
         image: {
           type: ValueType.EXACT,
           value:
-            "https://img.freepik.com/premium-photo/white-abstract-background-with-subtle-d-texture_947794-79438.jpg",
+            "https://static.seldon.app/background-default-light.jpg",
         },
         repeat: {
           type: ValueType.OPTION,

--- a/packages/core/workspace/workspace-sample.v0.json
+++ b/packages/core/workspace/workspace-sample.v0.json
@@ -9448,7 +9448,7 @@
               },
               "image": {
                 "type": "exact",
-                "value": "https://img.freepik.com/premium-photo/white-abstract-background-with-subtle-d-texture_947794-79438.jpg"
+                "value": "https://static.seldon.app/background-default-light.jpg"
               },
               "repeat": {
                 "type": "preset",
@@ -9465,7 +9465,7 @@
               },
               "image": {
                 "type": "exact",
-                "value": "https://img.freepik.com/premium-photo/white-abstract-background-with-subtle-d-texture_947794-79438.jpg"
+                "value": "https://static.seldon.app/background-default-light.jpg"
               },
               "repeat": {
                 "type": "preset",

--- a/packages/factory/styles/css-properties/get-background-image-styles.test.ts
+++ b/packages/factory/styles/css-properties/get-background-image-styles.test.ts
@@ -84,7 +84,7 @@ describe("getBackgroundImageStyles", () => {
 
       expect(result).toEqual({
         backgroundImage:
-          "url(https://img.freepik.com/premium-photo/white-abstract-background-with-subtle-d-texture_947794-79438.jpg)",
+          "url(https://static.seldon.app/background-default-light.jpg)",
         backgroundRepeat: "no-repeat",
         backgroundSize: "contain",
       })
@@ -107,7 +107,7 @@ describe("getBackgroundImageStyles", () => {
 
       expect(result).toEqual({
         backgroundImage:
-          "url(https://img.freepik.com/premium-photo/white-abstract-background-with-subtle-d-texture_947794-79438.jpg)",
+          "url(https://static.seldon.app/background-default-light.jpg)",
         backgroundRepeat: "repeat",
         backgroundSize: "auto",
       })


### PR DESCRIPTION
## Summary

Removes the Freepik premium image hotlink from Seldon stock themes, the sample workspace, and the factory background-image style expectations.

The replacement uses the existing Seldon-owned https://static.seldon.app/background-default-light.jpg asset so shipped theme data no longer points at a third-party premium stock URL.

## Validation

- Freepik scan returns no matches.
- git diff --check passes.
- Focused Bun test is blocked by existing workspace module-resolution error: Cannot find module '@seldon/core/properties' from packages/core/components/constants.ts.