### PR TITLE
[codex] Harden image asset export fetching

### DIFF
--- a/packages/factory/export/react/assets/get-files-to-export-from-images-to-export.test.ts
+++ b/packages/factory/export/react/assets/get-files-to-export-from-images-to-export.test.ts
@@ -1,0 +1,153 @@
+import { afterEach, describe, expect, it } from "bun:test"
+
+import type { ExportOptions, ImageToExportMap } from "../../types"
+import { getFilesToExportFromImagesToExport } from "./get-files-to-export-from-images-to-export"
+
+const originalFetch = globalThis.fetch
+
+const options: ExportOptions = {
+  rootDirectory: "/tmp/seldon-export",
+  token: "secret-token",
+  target: {
+    framework: "react",
+    styles: "css-properties",
+  },
+  output: {
+    assetsFolder: "/public/assets",
+    componentsFolder: "/components",
+    assetPublicPath: "/assets",
+  },
+}
+
+afterEach(() => {
+  globalThis.fetch = originalFetch
+})
+
+describe("getFilesToExportFromImagesToExport", () => {
+  it("fetches image files without forwarding the export token", async () => {
+    let fetchInit: RequestInit | undefined
+    globalThis.fetch = (async (
+      _input: RequestInfo | URL,
+      init?: RequestInit,
+    ) => {
+      fetchInit = init
+      return new Response(new Uint8Array([1, 2, 3]), {
+        headers: {
+          "content-length": "3",
+          "content-type": "image/png",
+        },
+      })
+    }) as typeof fetch
+
+    const images: ImageToExportMap = {
+      "https://93.184.216.34/image.png": {
+        relativePath: "/assets/image.png",
+        uploadPath: "/public/assets/image.png",
+      },
+    }
+
+    const files = await getFilesToExportFromImagesToExport(images, options)
+
+    expect(files).toHaveLength(1)
+    expect(fetchInit?.headers).toBeUndefined()
+    expect(fetchInit?.credentials).toBe("omit")
+    expect(fetchInit?.redirect).toBe("error")
+  })
+
+  it("rejects non-http image URLs", async () => {
+    const images: ImageToExportMap = {
+      "file:///etc/passwd": {
+        relativePath: "/assets/passwd",
+        uploadPath: "/public/assets/passwd",
+      },
+    }
+
+    await expect(
+      getFilesToExportFromImagesToExport(images, options),
+    ).rejects.toThrow('Unsupported image URL protocol "file:"')
+  })
+
+  it("allows image data URLs without fetching", async () => {
+    let fetched = false
+    globalThis.fetch = (async () => {
+      fetched = true
+      return new Response()
+    }) as typeof fetch
+
+    const images: ImageToExportMap = {
+      "data:image/png;base64,AQID": {
+        relativePath: "/assets/image.png",
+        uploadPath: "/public/assets/image.png",
+      },
+    }
+
+    const files = await getFilesToExportFromImagesToExport(images, options)
+    const content = new Uint8Array(files[0]!.content as ArrayBuffer)
+
+    expect(content).toEqual(new Uint8Array([1, 2, 3]))
+    expect(fetched).toBe(false)
+  })
+
+  it("rejects private and local hosts before fetching", async () => {
+    let fetched = false
+    globalThis.fetch = (async () => {
+      fetched = true
+      return new Response(new Uint8Array([1]), {
+        headers: { "content-type": "image/png" },
+      })
+    }) as typeof fetch
+
+    const images: ImageToExportMap = {
+      "http://127.0.0.1/image.png": {
+        relativePath: "/assets/image.png",
+        uploadPath: "/public/assets/image.png",
+      },
+    }
+
+    await expect(
+      getFilesToExportFromImagesToExport(images, options),
+    ).rejects.toThrow("Refusing to fetch image from private host")
+    expect(fetched).toBe(false)
+  })
+
+  it("rejects non-image responses", async () => {
+    globalThis.fetch = (async () => {
+      return new Response("not an image", {
+        headers: { "content-type": "text/html" },
+      })
+    }) as typeof fetch
+
+    const images: ImageToExportMap = {
+      "https://93.184.216.34/image.png": {
+        relativePath: "/assets/image.png",
+        uploadPath: "/public/assets/image.png",
+      },
+    }
+
+    await expect(
+      getFilesToExportFromImagesToExport(images, options),
+    ).rejects.toThrow("Expected image content-type")
+  })
+
+  it("rejects oversized image responses", async () => {
+    globalThis.fetch = (async () => {
+      return new Response(new Uint8Array([1]), {
+        headers: {
+          "content-length": String(26 * 1024 * 1024),
+          "content-type": "image/png",
+        },
+      })
+    }) as typeof fetch
+
+    const images: ImageToExportMap = {
+      "https://93.184.216.34/image.png": {
+        relativePath: "/assets/image.png",
+        uploadPath: "/public/assets/image.png",
+      },
+    }
+
+    await expect(
+      getFilesToExportFromImagesToExport(images, options),
+    ).rejects.toThrow("Image response is too large")
+  })
+})

--- a/packages/factory/export/react/assets/get-files-to-export-from-images-to-export.ts
+++ b/packages/factory/export/react/assets/get-files-to-export-from-images-to-export.ts
@@ -1,4 +1,8 @@
-import { ExportOptions, FileToExport, ImageToExportMap } from "../../types"
+import { isIP } from "node:net"
+
+import type { ExportOptions, FileToExport, ImageToExportMap } from "../../types"
+
+const MAX_IMAGE_BYTES = 25 * 1024 * 1024
 
 /**
  * Fetch the source of the external images to export from the workspace values
@@ -8,13 +12,13 @@ import { ExportOptions, FileToExport, ImageToExportMap } from "../../types"
 
 export async function getFilesToExportFromImagesToExport(
   imagesToExport: ImageToExportMap,
-  options: ExportOptions,
+  _options: ExportOptions,
 ) {
   const filesToExport: FileToExport[] = []
 
   for (const url of Object.keys(imagesToExport)) {
     filesToExport.push({
-      content: await getArrayBuffer(url, options.token),
+      content: await getArrayBuffer(url),
       path: imagesToExport[url].uploadPath,
     })
   }
@@ -22,15 +26,153 @@ export async function getFilesToExportFromImagesToExport(
   return filesToExport
 }
 
-async function getArrayBuffer(url: string, token?: ExportOptions["token"]) {
+async function getArrayBuffer(url: string) {
   try {
-    const headers: HeadersInit = {}
-    if (token) {
-      headers.Authorization = `Bearer ${token}`
+    if (url.startsWith("data:")) {
+      return getDataUrlArrayBuffer(url)
     }
-    const response = await fetch(url, { headers })
-    return response.arrayBuffer()
+
+    const safeUrl = parseSafeImageUrl(url)
+    const response = await fetch(safeUrl, {
+      credentials: "omit",
+      redirect: "error",
+    })
+    if (!response.ok) {
+      throw new Error(`Image request failed with status ${response.status}`)
+    }
+
+    assertImageResponse(url, response)
+    const buffer = await response.arrayBuffer()
+    if (buffer.byteLength > MAX_IMAGE_BYTES) {
+      throw new Error("Image response is too large")
+    }
+
+    return buffer
   } catch (error) {
-    throw new Error(`Unable to fetch image from ${url}`)
+    const reason = error instanceof Error ? `: ${error.message}` : ""
+    throw new Error(`Unable to fetch image from ${url}${reason}`)
   }
+}
+
+function getDataUrlArrayBuffer(value: string): ArrayBuffer {
+  const dataPrefix = "data:"
+  const separatorIndex = value.indexOf(",")
+  if (!value.startsWith(dataPrefix) || separatorIndex === -1) {
+    throw new Error("Invalid image data URL")
+  }
+
+  const metadata = value.slice(dataPrefix.length, separatorIndex)
+  const data = value.slice(separatorIndex + 1)
+  const [mediaType = "", ...parameters] = metadata.split(";")
+  if (!mediaType.toLowerCase().startsWith("image/")) {
+    throw new Error(
+      `Expected image content-type for data URL, received "${mediaType || "missing"}"`,
+    )
+  }
+
+  const isBase64 = parameters.some(
+    (parameter) => parameter.toLowerCase() === "base64",
+  )
+  const bytes = isBase64
+    ? Uint8Array.from(atob(data), (character) => character.charCodeAt(0))
+    : new TextEncoder().encode(decodeURIComponent(data))
+
+  if (bytes.byteLength > MAX_IMAGE_BYTES) {
+    throw new Error("Image response is too large")
+  }
+
+  return bytes.buffer.slice(
+    bytes.byteOffset,
+    bytes.byteOffset + bytes.byteLength,
+  )
+}
+
+function parseSafeImageUrl(value: string): URL {
+  let url: URL
+  try {
+    url = new URL(value)
+  } catch {
+    throw new Error("Invalid image URL")
+  }
+
+  if (url.protocol !== "http:" && url.protocol !== "https:") {
+    throw new Error(`Unsupported image URL protocol "${url.protocol}"`)
+  }
+
+  if (isBlockedHost(url.hostname)) {
+    throw new Error(
+      `Refusing to fetch image from private host "${url.hostname}"`,
+    )
+  }
+
+  return url
+}
+
+function assertImageResponse(url: string, response: Response): void {
+  const contentType = response.headers.get("content-type")
+  const mediaType = contentType?.split(";")[0]?.trim().toLowerCase()
+  if (!mediaType?.startsWith("image/")) {
+    throw new Error(
+      `Expected image content-type for ${url}, received "${contentType ?? "missing"}"`,
+    )
+  }
+
+  const contentLength = response.headers.get("content-length")
+  if (!contentLength) return
+
+  const size = Number(contentLength)
+  if (!Number.isFinite(size) || size < 0) {
+    throw new Error(`Invalid image content-length "${contentLength}"`)
+  }
+  if (size > MAX_IMAGE_BYTES) {
+    throw new Error("Image response is too large")
+  }
+}
+
+function isBlockedHost(hostname: string): boolean {
+  const host = hostname.toLowerCase().replace(/^\[/, "").replace(/\]$/, "")
+  if (
+    host === "localhost" ||
+    host.endsWith(".localhost") ||
+    host === "metadata.google.internal"
+  ) {
+    return true
+  }
+
+  const ipVersion = isIP(host)
+  if (ipVersion === 4) return isBlockedIPv4(host)
+  if (ipVersion === 6) return isBlockedIPv6(host)
+
+  return false
+}
+
+function isBlockedIPv4(address: string): boolean {
+  const parts = address.split(".").map((part) => Number(part))
+  const [first, second] = parts
+  if (parts.length !== 4 || first === undefined || second === undefined) {
+    return true
+  }
+
+  return (
+    first === 0 ||
+    first === 10 ||
+    first === 127 ||
+    first >= 224 ||
+    (first === 100 && second >= 64 && second <= 127) ||
+    (first === 169 && second === 254) ||
+    (first === 172 && second >= 16 && second <= 31) ||
+    (first === 192 && second === 168)
+  )
+}
+
+function isBlockedIPv6(address: string): boolean {
+  const host = address.toLowerCase()
+  return (
+    host === "::" ||
+    host === "::1" ||
+    host.startsWith("::ffff:") ||
+    host.startsWith("fc") ||
+    host.startsWith("fd") ||
+    /^fe[89ab]/.test(host)
+  )
 }

--- a/packages/factory/export/react/assets/get-images-to-export.ts
+++ b/packages/factory/export/react/assets/get-images-to-export.ts
@@ -1,14 +1,17 @@
 import * as path from "path"
-import { Workspace } from "@seldon/core"
+
+import type { Workspace } from "@seldon/core"
 import { getNodeProperties } from "@seldon/core/workspace/helpers/nodes/get-node-properties"
+
 import { getWorkspaceNodeList } from "../../../helpers/workspace-nodes"
-import { ExportOptions, ImageToExportMap } from "../../types"
+import type { ExportOptions, ImageToExportMap } from "../../types"
 
 export async function getImagesToExport(
   workspace: Workspace,
   options: ExportOptions,
 ) {
   const images: ImageToExportMap = {}
+  const usedFilenames = new Set<string>()
 
   for (const node of getWorkspaceNodeList(workspace)) {
     const properties = getNodeProperties(node, workspace)
@@ -27,11 +30,10 @@ export async function getImagesToExport(
       return
     }
 
-    let filename = value.split("/").pop()
-
-    if (!filename || !filename.includes(".")) {
-      filename = `${filename ?? "image"}.png`
-    }
+    const filename = getUniqueFilename(
+      getSafeImageFilename(value),
+      usedFilenames,
+    )
 
     const relativePath = path.posix.join(
       options.output.assetPublicPath,
@@ -45,4 +47,60 @@ export async function getImagesToExport(
   }
 
   return images
+}
+
+function getSafeImageFilename(value: string): string {
+  const rawFilename = getImageFilename(value)
+  const withoutQuery = rawFilename.split("?")[0]?.split("#")[0] ?? ""
+
+  let decoded = withoutQuery
+  try {
+    decoded = decodeURIComponent(withoutQuery)
+  } catch {
+    decoded = withoutQuery
+  }
+
+  const sanitized = decoded
+    .replace(/\\/g, "/")
+    .split("/")
+    .pop()
+    ?.replace(/[^a-zA-Z0-9._-]/g, "-")
+    .replace(/^\.+/, "")
+    .slice(0, 120)
+
+  if (!sanitized) return "image.png"
+  if (!sanitized.includes(".")) return `${sanitized}.png`
+  return sanitized
+}
+
+function getImageFilename(value: string): string {
+  try {
+    const url = new URL(value)
+    return path.posix.basename(url.pathname)
+  } catch {
+    return value.split("/").pop() ?? "image.png"
+  }
+}
+
+function getUniqueFilename(
+  filename: string,
+  usedFilenames: Set<string>,
+): string {
+  if (!usedFilenames.has(filename)) {
+    usedFilenames.add(filename)
+    return filename
+  }
+
+  const extension = path.posix.extname(filename)
+  const basename = extension ? filename.slice(0, -extension.length) : filename
+  let index = 2
+  let uniqueFilename = `${basename}-${index}${extension}`
+
+  while (usedFilenames.has(uniqueFilename)) {
+    index += 1
+    uniqueFilename = `${basename}-${index}${extension}`
+  }
+
+  usedFilenames.add(uniqueFilename)
+  return uniqueFilename
 }


### PR DESCRIPTION
Summary: hardens factory image asset export against unsafe workspace-provided image URLs. It stops forwarding export bearer tokens to image hosts, omits credentials, disables redirects, validates status/content-type/size, rejects local/private hosts and unsupported schemes, keeps image data URL support, sanitizes exported filenames, and adds focused tests. Validation: focused Bun test passes, Prettier check passes, git diff --check passes. Full factory quality still fails on existing repo-wide TypeScript drift unrelated to this change.