### PR TITLE
Override vulnerable Next PostCSS dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12403,7 +12403,7 @@
         "@swc/helpers": "0.5.15",
         "baseline-browser-mapping": "^2.9.19",
         "caniuse-lite": "^1.0.30001579",
-        "postcss": "8.4.31",
+        "postcss": "8.5.15",
         "styled-jsx": "5.1.6"
       },
       "bin": {
@@ -12465,9 +12465,7 @@
       }
     },
     "node_modules/next/node_modules/postcss": {
-      "version": "8.4.31",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
+      "version": "8.5.15",
       "funding": [
         {
           "type": "opencollective",
@@ -12484,9 +12482,9 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.6",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
       },
       "engines": {
         "node": "^10 || ^12 || >=14"

--- a/package.json
+++ b/package.json
@@ -32,6 +32,11 @@
     "@trivago/prettier-plugin-sort-imports": "^5.2.2",
     "prettier": "^3.3.3"
   },
+  "overrides": {
+    "next": {
+      "postcss": "8.5.15"
+    }
+  },
   "volta": {
     "node": "22.18.0"
   }


### PR DESCRIPTION
## Summary
- add a root npm override for Nexts transitive PostCSS dependency
- update package-lock so Next resolves PostCSS to 8.5.15 instead of the vulnerable 8.4.31 copy
- clears the moderate GHSA-qx2v-qp2m-jg93 audit finding without downgrading Next

## Verification
- npm install --package-lock-only --ignore-scripts
- npm audit --json
- npm audit --omit=dev --json
- npm exec prettier -- --check package.json package-lock.json
- git diff --check

## Notes
- npm warned that the shell is on Node 23.10.0 while Volta pins 22.18.0; install still completed and audit is clean.