### PR TITLE
Harden folder export file paths

### DIFF
--- a/packages/editor/lib/export/write-export-to-directory.test.ts
+++ b/packages/editor/lib/export/write-export-to-directory.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, test } from "bun:test"
+import { writeExportToDirectory } from "./write-export-to-directory"
+
+class MemoryFileHandle {
+  constructor(
+    private readonly onWrite: (content: string | ArrayBuffer) => void,
+  ) {}
+
+  async createWritable() {
+    return {
+      write: async (content: string | ArrayBuffer) => {
+        this.onWrite(content)
+      },
+      close: async () => {},
+    }
+  }
+}
+
+class MemoryDirectoryHandle {
+  readonly directories = new Map<string, MemoryDirectoryHandle>()
+  readonly files = new Map<string, string | ArrayBuffer>()
+
+  constructor(readonly name = "") {}
+
+  async getDirectoryHandle(name: string, _options?: { create?: boolean }) {
+    let directory = this.directories.get(name)
+    if (!directory) {
+      directory = new MemoryDirectoryHandle(name)
+      this.directories.set(name, directory)
+    }
+    return directory
+  }
+
+  async getFileHandle(name: string, _options?: { create?: boolean }) {
+    return new MemoryFileHandle((content) => this.files.set(name, content))
+  }
+}
+
+function asDirectoryHandle(
+  directory: MemoryDirectoryHandle,
+): FileSystemDirectoryHandle {
+  return directory as unknown as FileSystemDirectoryHandle
+}
+
+describe("writeExportToDirectory", () => {
+  test("writes files into nested directories", async () => {
+    const root = new MemoryDirectoryHandle()
+
+    const count = await writeExportToDirectory(asDirectoryHandle(root), [
+      { path: "/components/Button.tsx", content: "button" },
+      { path: "styles.css", content: "styles" },
+    ])
+
+    expect(count).toBe(2)
+    expect(root.files.get("styles.css")).toBe("styles")
+    expect(root.directories.get("components")?.files.get("Button.tsx")).toBe(
+      "button",
+    )
+  })
+
+  test("normalizes backslashes before writing", async () => {
+    const root = new MemoryDirectoryHandle()
+
+    await writeExportToDirectory(asDirectoryHandle(root), [
+      { path: "components\\Button.tsx", content: "button" },
+    ])
+
+    expect(root.directories.get("components")?.files.get("Button.tsx")).toBe(
+      "button",
+    )
+  })
+
+  test("rejects traversal and reserved path segments", async () => {
+    const root = new MemoryDirectoryHandle()
+
+    await expect(
+      writeExportToDirectory(asDirectoryHandle(root), [
+        { path: "components/../secret.txt", content: "secret" },
+      ]),
+    ).rejects.toThrow('Unsafe export path "components/../secret.txt"')
+
+    expect(root.directories.size).toBe(0)
+    expect(root.files.size).toBe(0)
+  })
+
+  test("skips empty file paths", async () => {
+    const root = new MemoryDirectoryHandle()
+
+    const count = await writeExportToDirectory(asDirectoryHandle(root), [
+      { path: "/", content: "empty" },
+    ])
+
+    expect(count).toBe(0)
+    expect(root.directories.size).toBe(0)
+    expect(root.files.size).toBe(0)
+  })
+})

--- a/packages/editor/lib/export/write-export-to-directory.ts
+++ b/packages/editor/lib/export/write-export-to-directory.ts
@@ -1,10 +1,41 @@
 import type { FileToExport } from "@seldon/factory/export/types"
 
+type SafeExportPath = {
+  directories: string[]
+  fileName: string
+}
+
+function normalizeExportPath(path: string): SafeExportPath | null {
+  const normalized = path.replace(/\\/g, "/").replace(/^\/+/, "")
+  const parts = normalized.split("/").filter(Boolean)
+
+  if (parts.length === 0) {
+    return null
+  }
+
+  for (const part of parts) {
+    if (
+      part === "." ||
+      part === ".." ||
+      part.includes("\0") ||
+      part.includes(":")
+    ) {
+      throw new Error(`Unsafe export path "${path}"`)
+    }
+  }
+
+  const fileName = parts.pop()
+  if (!fileName) {
+    return null
+  }
+
+  return { directories: parts, fileName }
+}
+
 async function ensureDirectory(
   parent: FileSystemDirectoryHandle,
-  relativePath: string,
+  parts: string[],
 ): Promise<FileSystemDirectoryHandle> {
-  const parts = relativePath.split("/").filter(Boolean)
   let current = parent
   for (const part of parts) {
     current = await current.getDirectoryHandle(part, { create: true })
@@ -19,24 +50,21 @@ export async function writeExportToDirectory(
   let written = 0
 
   for (const file of files) {
-    const normalized = file.path.replace(/\\/g, "/").replace(/^\/+/, "")
-    const segments = normalized.split("/")
-    const fileName = segments.pop()
-    if (!fileName) continue
+    const safePath = normalizeExportPath(file.path)
+    if (!safePath) continue
 
     const dir =
-      segments.length > 0
-        ? await ensureDirectory(directory, segments.join("/"))
+      safePath.directories.length > 0
+        ? await ensureDirectory(directory, safePath.directories)
         : directory
 
-    const handle = await dir.getFileHandle(fileName, { create: true })
+    const handle = await dir.getFileHandle(safePath.fileName, { create: true })
     const writable = await handle.createWritable()
-    if (typeof file.content === "string") {
+    try {
       await writable.write(file.content)
-    } else {
-      await writable.write(file.content)
+    } finally {
+      await writable.close()
     }
-    await writable.close()
     written += 1
   }
 


### PR DESCRIPTION
## Summary
- validate browser folder export paths before creating directories or files
- reject traversal, dot segments, NUL bytes, and drive-style colon segments
- keep writable handles closed with a finally block
- add focused in-memory tests for normal writes, backslash normalization, traversal rejection, and empty paths

## Verification
- bun test packages/editor/lib/export/write-export-to-directory.test.ts
- npm exec prettier -- --check packages/editor/lib/export/write-export-to-directory.ts packages/editor/lib/export/write-export-to-directory.test.ts
- git diff --check

## Note
- npx tsc -p packages/editor/tsconfig.json --noEmit --incremental false still fails on existing core/factory TypeScript drift on main, starting with Link.schema.ts textDecoration and theme resolution type errors.