### PR TITLE
Add support for unique node reference handles

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -121,12 +121,52 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@babel/helper-environment-visitor": {
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.24.7.tgz",
+      "integrity": "sha512-DoiN84+4Gnd0ncbBOM9AZENV4a5ZiL39HYMyZJGZ/AZEykHYdJw0wW3kdcsh9/Kn+BRXHLkkklZ51ecPKmI1CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.24.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-function-name": {
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.24.7.tgz",
+      "integrity": "sha512-FyoJTsj/PEUWu1/TYRiXTIHc8lbw+TDYkZuoE43opPS5TrI7MyONBE1oNvfguEXAD9yhQRrVBnXdXzSLQl9XnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.24.7",
+        "@babel/types": "^7.24.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/helper-globals": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
       "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
       "dev": true,
       "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-hoist-variables": {
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.24.7.tgz",
+      "integrity": "sha512-MJJwhkoGy5c4ehfoRyrJ/owKeMl19U54h27YYftT0o2teQ3FJ3nQUf/I3LlJsX4l3qlw7WRXUmiyajvHXoTubQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.24.7"
+      },
       "engines": {
         "node": ">=6.9.0"
       }
@@ -161,6 +201,19 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-split-export-declaration": {
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.24.7.tgz",
+      "integrity": "sha512-oy5V7pD+UvfkEATUKvIjvIAH/xCzfsFVw7ygW2SI6NClZzquT+mwdTfgfdbUiceh6iQO0CHtCPsyze/MZ2YbAA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.24.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-string-parser": {
@@ -334,6 +387,448 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -2025,6 +2520,48 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
     "node_modules/escalade": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
@@ -3242,9 +3779,9 @@
       "license": "MIT"
     },
     "node_modules/node-releases": {
-      "version": "2.0.47",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.47.tgz",
-      "integrity": "sha512-Uzmd6LXpouKo8EUK68IjH4+E01w/hXyV3R3g/geCJo+rXLNfh1xucB+LOzYEOQPSiUK3h/xZf0cQGcSsmyL2Og==",
+      "version": "2.0.48",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.48.tgz",
+      "integrity": "sha512-1uz8041X6LoI6ZSdZacM9lVY28vuzDlSKitnpbSNK0RfKoIJkX29NBPVEFXhnuSuEOA9Ww0xnPJ+ILWbGAv8DA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3755,6 +4292,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -3842,6 +4389,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/to-fast-properties": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+      "integrity": "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/ts-api-utils": {
@@ -4651,19 +5208,71 @@
         "vite": "^8.0.0"
       }
     },
-    "packages/editor/node_modules/@esbuild/darwin-arm64": {
-      "version": "0.28.1",
-      "cpu": [
-        "arm64"
-      ],
+    "packages/editor/node_modules/@babel/generator": {
+      "version": "7.17.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.17.7.tgz",
+      "integrity": "sha512-oLcVCTeIFadUoArDTwpluncplrYBmTCCZZgXCbgNGvOBBiSDDK3eWO4b/+eOTli5tKv1lg+a5/NAXg+nTcei1w==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
+      "dependencies": {
+        "@babel/types": "^7.17.0",
+        "jsesc": "^2.5.1",
+        "source-map": "^0.5.0"
+      },
       "engines": {
-        "node": ">=18"
+        "node": ">=6.9.0"
+      }
+    },
+    "packages/editor/node_modules/@babel/traverse": {
+      "version": "7.23.2",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.2.tgz",
+      "integrity": "sha512-azpe59SQ48qG6nu2CzcMLbxUudtN+dOM9kDbUqGq3HXUJRlo7i8fvPoxQUzYgLZ4cMVmuZgm8vvBpNeRhd6XSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.22.13",
+        "@babel/generator": "^7.23.0",
+        "@babel/helper-environment-visitor": "^7.22.20",
+        "@babel/helper-function-name": "^7.23.0",
+        "@babel/helper-hoist-variables": "^7.22.5",
+        "@babel/helper-split-export-declaration": "^7.22.6",
+        "@babel/parser": "^7.23.0",
+        "@babel/types": "^7.23.0",
+        "debug": "^4.1.0",
+        "globals": "^11.1.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "packages/editor/node_modules/@babel/traverse/node_modules/@babel/generator": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "packages/editor/node_modules/@babel/traverse/node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "packages/editor/node_modules/@eslint/config-array": {
@@ -4747,6 +5356,8 @@
     },
     "packages/editor/node_modules/@trivago/prettier-plugin-sort-imports": {
       "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@trivago/prettier-plugin-sort-imports/-/prettier-plugin-sort-imports-4.3.0.tgz",
+      "integrity": "sha512-r3n0onD3BTOVUNPhR4lhVK4/pABGpbA7bW3eumZnYdKaHkf1qEC+Mag6DPbGNuuh0eG8AaYj+YqmVHSiGslaTQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -4767,107 +5378,10 @@
         }
       }
     },
-    "packages/editor/node_modules/@trivago/prettier-plugin-sort-imports/node_modules/@babel/generator": {
-      "version": "7.17.7",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/types": "^7.17.0",
-        "jsesc": "^2.5.1",
-        "source-map": "^0.5.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "packages/editor/node_modules/@trivago/prettier-plugin-sort-imports/node_modules/@babel/generator/node_modules/@babel/types": {
-      "version": "7.29.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.28.5"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "packages/editor/node_modules/@trivago/prettier-plugin-sort-imports/node_modules/@babel/generator/node_modules/jsesc": {
-      "version": "2.5.2",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "jsesc": "bin/jsesc"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "packages/editor/node_modules/@trivago/prettier-plugin-sort-imports/node_modules/@babel/generator/node_modules/source-map": {
-      "version": "0.5.7",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "packages/editor/node_modules/@trivago/prettier-plugin-sort-imports/node_modules/@babel/traverse": {
-      "version": "7.23.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.22.13",
-        "@babel/generator": "^7.23.0",
-        "@babel/helper-environment-visitor": "^7.22.20",
-        "@babel/helper-function-name": "^7.23.0",
-        "@babel/helper-hoist-variables": "^7.22.5",
-        "@babel/helper-split-export-declaration": "^7.22.6",
-        "@babel/parser": "^7.23.0",
-        "@babel/types": "^7.23.0",
-        "debug": "^4.1.0",
-        "globals": "^11.1.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "packages/editor/node_modules/@trivago/prettier-plugin-sort-imports/node_modules/@babel/traverse/node_modules/@babel/generator": {
-      "version": "7.29.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/parser": "^7.29.0",
-        "@babel/types": "^7.29.0",
-        "@jridgewell/gen-mapping": "^0.3.12",
-        "@jridgewell/trace-mapping": "^0.3.28",
-        "jsesc": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "packages/editor/node_modules/@trivago/prettier-plugin-sort-imports/node_modules/@babel/traverse/node_modules/@babel/types": {
-      "version": "7.29.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.28.5"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "packages/editor/node_modules/@trivago/prettier-plugin-sort-imports/node_modules/@babel/traverse/node_modules/globals": {
-      "version": "11.12.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "packages/editor/node_modules/@trivago/prettier-plugin-sort-imports/node_modules/@babel/types": {
       "version": "7.17.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.17.0.tgz",
+      "integrity": "sha512-TmKSNO4D5rzhL5bjWFcVHHLETzfQ/AmbKpKPOSjlP0WoHZ6L911fgoOKY4Alp/emzG4cHJdyN49zpgkbXFEHHw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4894,46 +5408,6 @@
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
-      }
-    },
-    "packages/editor/node_modules/esbuild": {
-      "version": "0.28.1",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "bin": {
-        "esbuild": "bin/esbuild"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.28.1",
-        "@esbuild/android-arm": "0.28.1",
-        "@esbuild/android-arm64": "0.28.1",
-        "@esbuild/android-x64": "0.28.1",
-        "@esbuild/darwin-arm64": "0.28.1",
-        "@esbuild/darwin-x64": "0.28.1",
-        "@esbuild/freebsd-arm64": "0.28.1",
-        "@esbuild/freebsd-x64": "0.28.1",
-        "@esbuild/linux-arm": "0.28.1",
-        "@esbuild/linux-arm64": "0.28.1",
-        "@esbuild/linux-ia32": "0.28.1",
-        "@esbuild/linux-loong64": "0.28.1",
-        "@esbuild/linux-mips64el": "0.28.1",
-        "@esbuild/linux-ppc64": "0.28.1",
-        "@esbuild/linux-riscv64": "0.28.1",
-        "@esbuild/linux-s390x": "0.28.1",
-        "@esbuild/linux-x64": "0.28.1",
-        "@esbuild/netbsd-arm64": "0.28.1",
-        "@esbuild/netbsd-x64": "0.28.1",
-        "@esbuild/openbsd-arm64": "0.28.1",
-        "@esbuild/openbsd-x64": "0.28.1",
-        "@esbuild/openharmony-arm64": "0.28.1",
-        "@esbuild/sunos-x64": "0.28.1",
-        "@esbuild/win32-arm64": "0.28.1",
-        "@esbuild/win32-ia32": "0.28.1",
-        "@esbuild/win32-x64": "0.28.1"
       }
     },
     "packages/editor/node_modules/eslint": {
@@ -5042,6 +5516,29 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "packages/editor/node_modules/globals": {
+      "version": "11.12.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "packages/editor/node_modules/jsesc": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "packages/editor/node_modules/minimatch": {

--- a/packages/core/properties/constants/index.ts
+++ b/packages/core/properties/constants/index.ts
@@ -21,9 +21,11 @@ export {
   type PropertyShorthandCatalogKey,
 } from "./shared/shorthand-properties"
 export {
+  NODE_FIELD_DISPLAY_ORDER,
   PropertyDisplayCategory,
   PROPERTY_DISPLAY_META,
   PROPERTY_DISPLAY_ORDER,
   attachPropertyDisplayMetadata,
+  type NodeFieldDisplayId,
   type PropertyDisplayMeta,
 } from "./property-display"

--- a/packages/core/properties/constants/property-display.ts
+++ b/packages/core/properties/constants/property-display.ts
@@ -203,6 +203,17 @@ export const PROPERTY_DISPLAY_ORDER: ReadonlyArray<{
   },
 ]
 
+/**
+ * Leading node-entry fields shown in the inspector before the property rows.
+ * These are node metadata (not `Properties` keys), so they live here as their
+ * own order instead of in `PROPERTY_DISPLAY_ORDER`. Theme is always pinned
+ * first; every other field follows in alphabetical order. The editor renders
+ * one row per id in this order, ahead of the Attributes block.
+ */
+export const NODE_FIELD_DISPLAY_ORDER = ["theme", "reference"] as const
+
+export type NodeFieldDisplayId = (typeof NODE_FIELD_DISPLAY_ORDER)[number]
+
 export type PropertyDisplayMeta = {
   displayCategory: PropertyDisplayCategory
   displayOrder: number

--- a/packages/core/rules/config/rules.config.ts
+++ b/packages/core/rules/config/rules.config.ts
@@ -280,6 +280,29 @@ export const rules: RulesConfig = {
     },
 
     /**
+     * Rules for setting a node's unique reference handle.
+     * A ref must stay globally unique, so it never propagates to copies.
+     */
+    setRef: {
+      board: {
+        allowed: false,
+        propagation: "none",
+      },
+      userVariant: {
+        allowed: true,
+        propagation: "none",
+      },
+      defaultVariant: {
+        allowed: false,
+        propagation: "none",
+      },
+      instance: {
+        allowed: true,
+        propagation: "none",
+      },
+    },
+
+    /**
      * Rules for reordering entities
      */
     reorder: {

--- a/packages/core/rules/types/rule-config-types.ts
+++ b/packages/core/rules/types/rule-config-types.ts
@@ -68,6 +68,7 @@ export interface MutationRules {
   reset: Config
   setTheme: Config
   rename: Config
+  setRef: Config
   reorder: Config
   move: Config
 }

--- a/packages/core/workspace/constants/index.ts
+++ b/packages/core/workspace/constants/index.ts
@@ -27,6 +27,8 @@ export const ErrorMessages = {
   variantNotFound: (id: VariantId) => `Variant ${id} not found.`,
   variantLabelNotUnique: (label: string) =>
     `A variant that is called ${label} already exists. Please choose another name.`,
+  refNotUnique: (ref: string) =>
+    `The reference "${ref}" is already in use. Please choose another reference.`,
   defaultVariantNotFound: (id: ComponentId) =>
     `Default variant not found for component ${id}.`,
   defaultVariantCannotBeRemoved: () => `Default variants cannot be removed.`,

--- a/packages/core/workspace/helpers/nodes/duplicate-entry-variant-subtree.ts
+++ b/packages/core/workspace/helpers/nodes/duplicate-entry-variant-subtree.ts
@@ -18,6 +18,15 @@ function collectTreeRefIds(ref: ComponentTreeRef): string[] {
   return ids
 }
 
+/**
+ * Drops the `ref` handle from a node. A reference must stay globally unique, so
+ * duplicates never inherit the source node's ref.
+ */
+function stripRef<T extends EntryNode>(node: T): T {
+  delete node.ref
+  return node
+}
+
 function cloneEntryNodeWithIdRemap(
   row: EntryNode,
   newId: string,
@@ -25,6 +34,7 @@ function cloneEntryNodeWithIdRemap(
 ): EntryNode {
   const clone = structuredClone(row) as EntryNode
   clone.id = newId
+  delete clone.ref
   const link = parseNodeLink(clone.template)
   if (link && idMap.has(link.nodeId)) {
     clone.template = formatNodeLink(idMap.get(link.nodeId)!)
@@ -140,14 +150,14 @@ export function buildDuplicateEntryVariantSubtreePlan(
   const newNodes: Record<string, EntryNode> = {}
 
   if (isEntryNodeDefault(sourceNode)) {
-    newNodes[newRootId] = {
+    newNodes[newRootId] = stripRef({
       ...structuredClone(sourceNode),
       id: newRootId,
       type: "variant",
       label: newVariantLabel,
       template: formatNodeLink(sourceRootId),
       overrides: structuredClone(sourceNode.overrides),
-    }
+    })
     for (const [oldId, newId] of idMap) {
       const row = nodes[oldId]
       if (!row) continue
@@ -159,7 +169,7 @@ export function buildDuplicateEntryVariantSubtreePlan(
       if (link?.kind === "node" && idMap.has(link.nodeId)) {
         template = formatNodeLink(idMap.get(link.nodeId)!)
       }
-      newNodes[newId] = {
+      newNodes[newId] = stripRef({
         ...structuredClone(row),
         id: newId,
         type: "instance",
@@ -167,7 +177,7 @@ export function buildDuplicateEntryVariantSubtreePlan(
         overrides: {},
         origin: "schema",
         __editor: { initialOverrides: {} },
-      }
+      })
     }
   } else {
     const defaultVariantId = board.variants[0]?.id
@@ -181,14 +191,14 @@ export function buildDuplicateEntryVariantSubtreePlan(
       const row = nodes[oldId]
       if (!row) continue
       if (oldId === sourceRootId) {
-        newNodes[newId] = {
+        newNodes[newId] = stripRef({
           ...structuredClone(row),
           id: newId,
           type: "variant",
           label: newVariantLabel,
           template: rootTemplate,
           overrides: structuredClone(row.overrides),
-        }
+        })
       } else {
         newNodes[newId] = cloneEntryNodeWithIdRemap(row, newId, idMap)
       }

--- a/packages/core/workspace/helpers/nodes/order-entry-node-keys.ts
+++ b/packages/core/workspace/helpers/nodes/order-entry-node-keys.ts
@@ -1,0 +1,55 @@
+import type { EntryNode } from "../../model/entry-node"
+import type { Workspace } from "../../model/workspace"
+
+/**
+ * Canonical key order for a serialized `EntryNode`. `ref` sits right after `id`
+ * so a node's stable identifiers lead the entry. Keys absent on a node are
+ * skipped, so optional fields like `ref` and `origin` only appear when set.
+ */
+const ENTRY_NODE_KEY_ORDER: readonly (keyof EntryNode)[] = [
+  "id",
+  "ref",
+  "type",
+  "level",
+  "label",
+  "theme",
+  "template",
+  "overrides",
+  "origin",
+  "__editor",
+]
+
+/** Returns a copy of a node with its keys in canonical serialization order. */
+export function orderEntryNodeKeys(node: EntryNode): EntryNode {
+  const ordered: Record<string, unknown> = {}
+
+  for (const key of ENTRY_NODE_KEY_ORDER) {
+    if (key in node && node[key] !== undefined) {
+      ordered[key] = node[key]
+    }
+  }
+
+  // Preserve any keys not covered by the canonical list, keeping output lossless.
+  for (const key of Object.keys(node)) {
+    if (!(key in ordered)) {
+      ordered[key] = (node as Record<string, unknown>)[key]
+    }
+  }
+
+  return ordered as EntryNode
+}
+
+/**
+ * Returns a copy of the workspace whose `nodes` entries use the canonical key
+ * order. Use before serializing a workspace to JSON so node fields persist in a
+ * stable, readable order. Other top-level maps are left untouched.
+ */
+export function orderWorkspaceNodeKeys(workspace: Workspace): Workspace {
+  const nodes: Workspace["nodes"] = {}
+
+  for (const [id, node] of Object.entries(workspace.nodes)) {
+    nodes[id] = orderEntryNodeKeys(node)
+  }
+
+  return { ...workspace, nodes }
+}

--- a/packages/core/workspace/middleware/validation/action-groups/node-mutations.ts
+++ b/packages/core/workspace/middleware/validation/action-groups/node-mutations.ts
@@ -263,6 +263,15 @@ export function validateNodeMutation(
       })
       break
     }
+    case "set_node_ref": {
+      const nodeId = action.payload.nodeId as InstanceId | VariantId
+      nodeValidators.exists(workspace, nodeId)
+      nodeValidators.refIsUnique(workspace, {
+        nodeId,
+        ref: action.payload.ref,
+      })
+      break
+    }
     case "set_node_editor_data":
     case "reset_node_label":
     case "reset_node_editor_data":

--- a/packages/core/workspace/middleware/validation/validate-action.ts
+++ b/packages/core/workspace/middleware/validation/validate-action.ts
@@ -160,6 +160,7 @@ export function validateAction(workspace: Workspace, action: Action): void {
       return
     case "set_node_theme":
     case "set_node_label":
+    case "set_node_ref":
     case "set_node_editor_data":
     case "reset_node_label":
     case "reset_node_editor_data":

--- a/packages/core/workspace/middleware/validation/validators/node.ts
+++ b/packages/core/workspace/middleware/validation/validators/node.ts
@@ -121,6 +121,17 @@ export const nodeValidators = {
   exists: (workspace: Workspace, id: InstanceId | VariantId) => {
     check(workspace.nodes[id], ErrorMessages.nodeNotFound(id))
   },
+  refIsUnique: (
+    workspace: Workspace,
+    { nodeId, ref }: { nodeId: InstanceId | VariantId; ref: string },
+  ) => {
+    const trimmed = ref.trim()
+    if (trimmed === "") return
+    const taken = Object.values(workspace.nodes).some(
+      (node) => node.id !== nodeId && node.ref === trimmed,
+    )
+    check(!taken, ErrorMessages.refNotUnique(trimmed))
+  },
   canHaveChildren: (workspace: Workspace, id: InstanceId | VariantId) => {
     const node = workspace.nodes[id]
     check(node, ErrorMessages.nodeNotFound(id))

--- a/packages/core/workspace/model/entry-node.ts
+++ b/packages/core/workspace/model/entry-node.ts
@@ -33,6 +33,12 @@ export interface EntryNode {
   template: string
   overrides: EntryNodePropertyOverrides
   origin?: NodeOrigin
+  /**
+   * Stable, user-assigned reference handle for this node. Unique across the
+   * whole workspace and never inherited or merged, so generated code and app
+   * logic can target a specific node regardless of position. Absent until set.
+   */
+  ref?: string
   __editor?: Record<string, unknown>
 }
 

--- a/packages/core/workspace/reducers/handlers/set/set-node-ref.ts
+++ b/packages/core/workspace/reducers/handlers/set/set-node-ref.ts
@@ -1,0 +1,33 @@
+import type { ExtractPayload, Workspace } from "../../../../index"
+import { rules } from "../../../../rules/config/rules.config"
+import {
+  nodeRetrievalService,
+  typeCheckingService,
+  workspaceMutationService,
+  workspacePropagationService,
+} from "../../../services"
+
+/**
+ * Applies a node's unique reference handle when ref rules allow.
+ * Propagation stays "none" so a ref is never copied onto other nodes.
+ */
+export function setNodeRef(
+  payload: ExtractPayload<"set_node_ref">,
+  workspace: Workspace,
+): Workspace {
+  const node = nodeRetrievalService.getNode(payload.nodeId, workspace)
+  const entityType = typeCheckingService.getEntityType(node)
+  const { allowed, propagation } = rules.mutations.setRef[entityType]
+
+  if (!allowed) {
+    return workspace
+  }
+
+  return workspacePropagationService.propagateNodeOperation({
+    nodeId: payload.nodeId,
+    propagation,
+    apply: (node, workspace) =>
+      workspaceMutationService.setNodeRef(node.id, payload.ref, workspace),
+    workspace,
+  })
+}

--- a/packages/core/workspace/reducers/reducer.ts
+++ b/packages/core/workspace/reducers/reducer.ts
@@ -136,6 +136,7 @@ import { setNodeEditorData } from "./handlers/set/set-node-editor-data"
 import { setNodeLabel } from "./handlers/set/set-node-label"
 import { setNodeLayerKind } from "./handlers/set/set-node-layer-kind"
 import { setNodeProperties } from "./handlers/set/set-node-properties"
+import { setNodeRef } from "./handlers/set/set-node-ref"
 import { setNodeTheme } from "./handlers/set/set-node-theme"
 import { setThemeCustomTokenName } from "./handlers/set/set-theme-custom-token-name"
 import { setThemeEditorData } from "./handlers/set/set-theme-editor-data"
@@ -303,6 +304,8 @@ function reducer(workspace: Workspace, action: WorkspaceAction): Workspace {
       return setNodeLayerKind(action.payload, workspace)
     case "set_node_label":
       return setNodeLabel(action.payload, workspace)
+    case "set_node_ref":
+      return setNodeRef(action.payload, workspace)
     case "set_node_theme":
       return setNodeTheme(action.payload, workspace)
     case "set_node_editor_data":

--- a/packages/core/workspace/reducers/types.ts
+++ b/packages/core/workspace/reducers/types.ts
@@ -605,6 +605,13 @@ export type WorkspaceAction =
       }
     }
   | {
+      type: "set_node_ref"
+      payload: {
+        nodeId: VariantId | InstanceId
+        ref: string
+      }
+    }
+  | {
       type: "set_node_theme"
       payload: {
         nodeId: InstanceId | VariantId

--- a/packages/core/workspace/reducers/workspace-action-schema.json
+++ b/packages/core/workspace/reducers/workspace-action-schema.json
@@ -3616,6 +3616,36 @@
                         "nodeId": {
                             "type": "string"
                         },
+                        "ref": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "nodeId",
+                        "ref"
+                    ],
+                    "type": "object"
+                },
+                "type": {
+                    "const": "set_node_ref",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "payload",
+                "type"
+            ],
+            "type": "object"
+        },
+        {
+            "additionalProperties": false,
+            "properties": {
+                "payload": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "nodeId": {
+                            "type": "string"
+                        },
                         "theme": {
                             "anyOf": [
                                 {

--- a/packages/core/workspace/services/components/duplicate-component.service.ts
+++ b/packages/core/workspace/services/components/duplicate-component.service.ts
@@ -77,6 +77,8 @@ function cloneNodeEntry(
 ): EntryNode {
   const clone = structuredClone(node) as EntryNode
   clone.id = newId
+  // A ref must stay globally unique; never carry it onto a duplicated node.
+  delete clone.ref
   const link = parseNodeLink(clone.template)
   if (link && idMap.has(link.nodeId)) {
     clone.template = formatNodeLink(idMap.get(link.nodeId)!)

--- a/packages/core/workspace/services/mutation/label-mutations.ts
+++ b/packages/core/workspace/services/mutation/label-mutations.ts
@@ -21,6 +21,18 @@ export function setNodeLabel(
   })
 }
 
+export function setNodeRef(
+  nodeId: VariantId | InstanceId,
+  ref: string,
+  workspace: Workspace,
+): Workspace {
+  return withNodeMutation(nodeId, workspace, (node) => {
+    const trimmed = ref.trim()
+    if (trimmed === "") delete node.ref
+    else node.ref = trimmed
+  })
+}
+
 export function setNodeEditorData(
   nodeId: VariantId | InstanceId,
   editorData: Record<string, unknown> | undefined,

--- a/packages/core/workspace/services/mutation/workspace-mutation.service.ts
+++ b/packages/core/workspace/services/mutation/workspace-mutation.service.ts
@@ -16,6 +16,7 @@ import {
   getInitialVariantLabel,
   setNodeEditorData,
   setNodeLabel,
+  setNodeRef,
 } from "./label-mutations"
 import {
   resetComponentProperty,
@@ -50,6 +51,14 @@ export class WorkspaceMutationService {
     workspace: Workspace,
   ): Workspace {
     return setNodeLabel(nodeId, label, workspace)
+  }
+
+  public setNodeRef(
+    nodeId: VariantId | InstanceId,
+    ref: string,
+    workspace: Workspace,
+  ): Workspace {
+    return setNodeRef(nodeId, ref, workspace)
   }
 
   public setNodeEditorData(

--- a/packages/core/workspace/services/nodes/node-operations.service.ts
+++ b/packages/core/workspace/services/nodes/node-operations.service.ts
@@ -89,6 +89,8 @@ function cloneEntryNodeAsInstance(
   clone.type = "instance"
   clone.template = formatNodeLink(templateNodeId)
   clone.origin = "user"
+  // A ref must stay globally unique; never carry it onto a copy.
+  delete clone.ref
   const link = parseNodeLink(row.template)
   if (link?.kind === "node" && idMap.has(link.nodeId)) {
     clone.template = formatNodeLink(idMap.get(link.nodeId)!)
@@ -527,6 +529,7 @@ export class NodeOperationsService {
         if (!row) continue
         const clone = structuredClone(row)
         clone.id = newId
+        delete clone.ref
         const link = parseNodeLink(clone.template)
         if (link?.kind === "node" && idMap.has(link.nodeId)) {
           clone.template = formatNodeLink(idMap.get(link.nodeId)!)
@@ -694,6 +697,7 @@ export class NodeOperationsService {
       template: formatNodeLink(nodeId),
       origin: "user",
     }
+    delete newNodes[newRootId].ref
 
     let newTreeRef: ComponentTreeRef = { id: newRootId }
 

--- a/packages/editor/app/sidebars/properties/helpers/build-property-tree-layout.ts
+++ b/packages/editor/app/sidebars/properties/helpers/build-property-tree-layout.ts
@@ -1,5 +1,15 @@
-import { Board, Instance, Theme, Variant, Workspace } from "@seldon/core"
+import {
+  Board,
+  Instance,
+  NODE_FIELD_DISPLAY_ORDER,
+  Theme,
+  Variant,
+  Workspace,
+} from "@seldon/core"
+import { rules } from "@seldon/core/rules/config/rules.config"
+import { isBoard } from "@seldon/core/workspace/helpers/components/is-board"
 import { isResourceType } from "@seldon/core/workspace/helpers/components/is-resource-type"
+import { typeCheckingService } from "@seldon/core/workspace/services"
 import {
   PropertySection,
   getPropertySections,
@@ -13,8 +23,36 @@ import {
   iconCategoryLabel,
 } from "./icon-set-properties-data"
 import { FlatProperty } from "./properties-data"
+import { buildReferenceProperty } from "./reference-display"
 import { buildThemeAssignmentProperty } from "./theme-assignment-display"
 import { ThemeEditingContext } from "./editing-contexts"
+
+/** A reference is only editable where `setRef` rules allow it (boards excluded). */
+function isReferenceFieldAllowed(node: Variant | Instance | Board): boolean {
+  if (isBoard(node)) return false
+  const entityType = typeCheckingService.getEntityType(node)
+  return rules.mutations.setRef[entityType].allowed
+}
+
+/**
+ * Builds the leading node-field rows shown before the property rows, in the
+ * core-owned `NODE_FIELD_DISPLAY_ORDER`. Theme applies to every non-resource
+ * node and board; Reference only to nodes where `setRef` is allowed.
+ */
+function buildLeadingNodeFieldRows(
+  node: Variant | Instance | Board,
+  workspace: Workspace,
+): FlatProperty[] {
+  const rows: FlatProperty[] = []
+  for (const field of NODE_FIELD_DISPLAY_ORDER) {
+    if (field === "theme") {
+      rows.push(buildThemeAssignmentProperty(node, workspace))
+    } else if (field === "reference" && isReferenceFieldAllowed(node)) {
+      rows.push(buildReferenceProperty(node))
+    }
+  }
+  return rows
+}
 
 export function buildPropertyTreeSections({
   properties,
@@ -75,17 +113,12 @@ export function buildPropertyTreeSections({
     ] as Array<PropertySection | ThemePropertySection>
   }
 
-  const leadingProperties: FlatProperty[] = []
-  const propertiesWithTheme = isResourceType(node as Board)
-    ? [...leadingProperties, ...properties]
-    : [
-        ...leadingProperties,
-        buildThemeAssignmentProperty(node, workspace),
-        ...properties,
-      ]
+  const propertiesWithLeadingFields = isResourceType(node as Board)
+    ? [...properties]
+    : [...buildLeadingNodeFieldRows(node, workspace), ...properties]
 
   const regularSections = getPropertySections(
-    propertiesWithTheme,
+    propertiesWithLeadingFields,
     node,
     workspace,
   )
@@ -142,12 +175,9 @@ export function buildPropertyTreeAllProperties({
     return properties
   }
 
-  const leadingProperties: FlatProperty[] = []
-
   if (isResourceType(node as Board)) {
-    return [...leadingProperties, ...properties]
+    return [...properties]
   }
 
-  const themeProperty = buildThemeAssignmentProperty(node, workspace)
-  return [...leadingProperties, themeProperty, ...properties]
+  return [...buildLeadingNodeFieldRows(node, workspace), ...properties]
 }

--- a/packages/editor/app/sidebars/properties/helpers/reference-display.ts
+++ b/packages/editor/app/sidebars/properties/helpers/reference-display.ts
@@ -1,0 +1,30 @@
+import { Board, Instance, ValueType, Variant } from "@seldon/core"
+import { isBoard } from "@seldon/core/workspace/helpers/components/is-board"
+import { FlatProperty } from "./properties-data"
+
+/**
+ * Synthetic Reference row for the properties sidebar. Reads the node's `ref`
+ * field as a free-text value. Boards do not carry a ref.
+ */
+export function buildReferenceProperty(
+  node: Variant | Instance | Board,
+): FlatProperty {
+  const ref = isBoard(node) ? undefined : node.ref
+
+  return {
+    key: "reference",
+    propertyType: "atomic",
+    label: "Reference",
+    icon: "seldon-component",
+    value: ref
+      ? { type: ValueType.EXACT, value: ref }
+      : { type: ValueType.EMPTY, value: null },
+    actualValue: ref ?? "",
+    valueType: ref ? ValueType.EXACT : ValueType.EMPTY,
+    controlType: "text",
+    isCompound: false,
+    isShorthand: false,
+    isSubProperty: false,
+    status: ref ? "set" : "unset",
+  }
+}

--- a/packages/editor/app/sidebars/properties/hooks/use-commit-property-value.ts
+++ b/packages/editor/app/sidebars/properties/hooks/use-commit-property-value.ts
@@ -17,6 +17,7 @@ import type {
   SubPropertyKey,
 } from "@seldon/core/properties/types/property-keys"
 import type { ThemeInstanceId } from "@seldon/core/themes/types/theme-id"
+import { isBoard } from "@seldon/core/workspace/helpers/components/is-board"
 import { useObjectProperties } from "@lib/workspace/hooks/use-object-properties"
 import { useSelection } from "@lib/workspace/hooks/use-selection"
 import { useWorkspace } from "@lib/workspace/hooks/use-workspace"
@@ -39,6 +40,7 @@ import { FlatProperty } from "../helpers/properties-data"
 import { RESET_VALUES } from "../helpers/property-control-constants"
 import { shouldUsePresetPropertyBehavior } from "../helpers/property-types"
 import { updateProperty } from "../helpers/property-update-handler"
+import { useSetObjectReference } from "./use-set-object-reference"
 import { useSetObjectTheme } from "./use-set-object-theme"
 
 interface UseCommitPropertyValueInput {
@@ -79,6 +81,7 @@ export function useCommitPropertyValue({
   const { workspace } = useWorkspace({ usePreview: false })
   const { selection } = useSelection()
   const setObjectTheme = useSetObjectTheme()
+  const setObjectReference = useSetObjectReference()
   const { show: showUploadPanel } = useImageUploadPanel()
 
   const reset = useCallback(() => {
@@ -242,6 +245,12 @@ export function useCommitPropertyValue({
         return
       }
 
+      if (property.key === "reference" && subject && !isBoard(subject)) {
+        setObjectReference(subject, newValue)
+        onDone()
+        return
+      }
+
       if (newValue === "__upload__") {
         const supportsUpload =
           property.key === "source" ||
@@ -365,6 +374,7 @@ export function useCommitPropertyValue({
       workspace,
       setProperties,
       setObjectTheme,
+      setObjectReference,
       showUploadPanel,
       themeEditingContext,
       fontCollectionEditingContext,

--- a/packages/editor/app/sidebars/properties/hooks/use-set-object-reference.ts
+++ b/packages/editor/app/sidebars/properties/hooks/use-set-object-reference.ts
@@ -1,0 +1,25 @@
+import { useCallback } from "react"
+import { Instance, Variant } from "@seldon/core"
+import { useWorkspace } from "@lib/workspace/hooks/use-workspace"
+
+/**
+ * Reference-assignment command. Sets a node's unique `ref` handle. Owns the
+ * dispatch so property controls stay binding shells. Boards have no ref, so
+ * only nodes are accepted.
+ */
+export function useSetObjectReference() {
+  const { dispatch } = useWorkspace({ usePreview: false })
+
+  return useCallback(
+    (subject: Variant | Instance, ref: string) => {
+      dispatch({
+        type: "set_node_ref",
+        payload: {
+          nodeId: subject.id,
+          ref,
+        },
+      })
+    },
+    [dispatch],
+  )
+}

--- a/packages/editor/lib/hooks/use-import-export.tsx
+++ b/packages/editor/lib/hooks/use-import-export.tsx
@@ -7,6 +7,7 @@ import {
 import { triggerDownload } from "@lib/helpers/trigger-download"
 import { kebabCase } from "change-case"
 import { useCallback } from "react"
+import { orderWorkspaceNodeKeys } from "@seldon/core/workspace/helpers/nodes/order-entry-node-keys"
 import { workspacePropagationService } from "@seldon/core/workspace/services/propagation/workspace-propagation.service"
 import type { Workspace } from "@seldon/core/workspace/types"
 import {
@@ -30,9 +31,12 @@ export function useImportExport() {
   const addToast = useAddToast()
 
   const exportWorkspaceToFile = useCallback(async () => {
-    const blob = new Blob([JSON.stringify(workspace, null, 2)], {
-      type: "application/json",
-    })
+    const blob = new Blob(
+      [JSON.stringify(orderWorkspaceNodeKeys(workspace), null, 2)],
+      {
+        type: "application/json",
+      },
+    )
     const name =
       prompt("Enter name for your exported file", workspaceName) ??
       workspaceName

--- a/packages/editor/public/THIRD-PARTY-NOTICES.txt
+++ b/packages/editor/public/THIRD-PARTY-NOTICES.txt
@@ -371,7 +371,7 @@ MIT License
 
 --------------------------------------------------------------------------------
 
-@types/node@20.19.41
+@types/node@20.19.43
 License: MIT
 
 MIT License
@@ -479,7 +479,7 @@ MIT License
 
 --------------------------------------------------------------------------------
 
-@types/react@19.2.15
+@types/react@19.2.17
 License: MIT
 
 MIT License
@@ -560,7 +560,7 @@ MIT License
 
 --------------------------------------------------------------------------------
 
-acorn@8.16.0
+acorn@8.17.0
 License: MIT
 
 MIT License
@@ -754,7 +754,7 @@ SOFTWARE.
 
 --------------------------------------------------------------------------------
 
-brace-expansion@1.1.14
+brace-expansion@1.1.15
 License: MIT
 
 MIT License
@@ -1345,9 +1345,9 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 --------------------------------------------------------------------------------
 
 format@0.2.2
-License: MIT
+License: UNKNOWN
 
-SPDX identifier: MIT
+SPDX identifier: UNKNOWN
 
 --------------------------------------------------------------------------------
 
@@ -1564,7 +1564,7 @@ SPDX identifier: CC0-1.0
 
 --------------------------------------------------------------------------------
 
-idb-keyval@6.2.4
+idb-keyval@6.2.5
 License: Apache-2.0
 
 Copyright 2016, Jake Archibald
@@ -2235,7 +2235,7 @@ THE SOFTWARE.
 
 --------------------------------------------------------------------------------
 
-property-information@7.1.0
+property-information@7.2.0
 License: MIT
 
 (The MIT License)
@@ -2290,7 +2290,7 @@ SOFTWARE.
 
 --------------------------------------------------------------------------------
 
-react@19.2.6
+react@19.2.7
 License: MIT
 
 MIT License
@@ -2317,7 +2317,7 @@ SOFTWARE.
 
 --------------------------------------------------------------------------------
 
-react-dom@19.2.6
+react-dom@19.2.7
 License: MIT
 
 MIT License
@@ -2371,7 +2371,7 @@ SOFTWARE.
 
 --------------------------------------------------------------------------------
 
-react-router@7.16.0
+react-router@7.18.0
 License: MIT
 
 MIT License

--- a/packages/factory/export/react/assets/generate-refs-registry.ts
+++ b/packages/factory/export/react/assets/generate-refs-registry.ts
@@ -1,0 +1,92 @@
+import {
+  ComponentToExport,
+  ExportOptions,
+  FileToExport,
+  JSONTreeNode,
+} from "../../types"
+
+/**
+ * One entry in the generated refs registry. `className` scopes DOM lookups to
+ * the rendered node, since the same exported component can render many times.
+ */
+type SeldonRefEntry = {
+  component: string
+  nodeId: string
+  className: string
+}
+
+/**
+ * Generates a React-only `refs/index.ts` registry. It exports a `SeldonRef`
+ * string-literal union of every node ref in the workspace and a `SELDON_REFS`
+ * map from ref to its component, node id, and class name. App code uses it for
+ * type-safe ref names alongside the emitted `data-seldon-ref` attributes.
+ *
+ * Returns `null` when no node carries a ref, so the file is only emitted when
+ * it has content.
+ */
+export function generateRefsRegistry(
+  components: ComponentToExport[],
+  nodeIdToClass: Record<string, string>,
+  options: ExportOptions,
+): FileToExport | null {
+  const refs = new Map<string, SeldonRefEntry>()
+
+  function visit(node: JSONTreeNode) {
+    if (node.ref && !refs.has(node.ref)) {
+      const className =
+        node.classNames && node.classNames.length > 0
+          ? node.classNames.filter(Boolean).join(" ")
+          : (nodeIdToClass[node.nodeId] ?? "")
+      refs.set(node.ref, {
+        component: node.name,
+        nodeId: node.nodeId,
+        className,
+      })
+    }
+    if (Array.isArray(node.children)) {
+      node.children.forEach(visit)
+    }
+  }
+
+  for (const component of components) {
+    visit(component.tree)
+  }
+
+  if (refs.size === 0) {
+    return null
+  }
+
+  const sortedRefs = Array.from(refs.entries()).sort(([a], [b]) =>
+    a.localeCompare(b),
+  )
+
+  const unionType = sortedRefs
+    .map(([ref]) => `  | ${JSON.stringify(ref)}`)
+    .join("\n")
+
+  const mapEntries = sortedRefs
+    .map(([ref, entry]) => `  ${JSON.stringify(ref)}: ${JSON.stringify(entry)},`)
+    .join("\n")
+
+  const content = `export type SeldonRef =
+${unionType}
+
+export interface SeldonRefEntry {
+  component: string
+  nodeId: string
+  className: string
+}
+
+export const SELDON_REFS: Record<SeldonRef, SeldonRefEntry> = {
+${mapEntries}
+}
+`
+
+  const indexPath =
+    `${options.output.componentsFolder}/refs/index.ts`.replaceAll("//", "/")
+
+  return {
+    path: indexPath,
+    content,
+  }
+}

--- a/packages/factory/export/react/discovery/get-json-tree-from-children.ts
+++ b/packages/factory/export/react/discovery/get-json-tree-from-children.ts
@@ -60,6 +60,7 @@ export function getJsonTreeFromChildren(
     componentId,
     schemaVariantId,
     nodeId: variant.id,
+    ref: variant.ref,
     level: componentLevel,
     dataBinding: {
       interfaceName: name + "Props",
@@ -190,6 +191,7 @@ export function getJsonTreeFromChildren(
       componentId: childComponentId,
       schemaVariantId: childSchemaVariantId,
       nodeId: node.id,
+      ref: node.ref,
       level: childSchema.level,
       dataBinding: {
         interfaceName,

--- a/packages/factory/export/react/export-react.ts
+++ b/packages/factory/export/react/export-react.ts
@@ -9,6 +9,7 @@ import { generateComponentStylesheet } from "../css/generation/generate-css-styl
 import { generateThemeStylesheetFiles } from "../css/generation/insert-theme-variables"
 import { ExportOptions, FileToExport } from "../types"
 import { generateIconIndex } from "./assets/generate-icon-index"
+import { generateRefsRegistry } from "./assets/generate-refs-registry"
 import { getFilesToExportFromImagesToExport } from "./assets/get-files-to-export-from-images-to-export"
 import { getFontsComponent } from "./assets/get-fonts-component"
 import { getIcons } from "./assets/get-icons"
@@ -129,6 +130,19 @@ export async function exportReact(
     filesToExport.push(iconIndexFile)
   } catch {
     // Failed to generate icon index
+  }
+
+  try {
+    const refsRegistryFile = generateRefsRegistry(
+      componentsToExport,
+      nodeIdToClass,
+      options,
+    )
+    if (refsRegistryFile) {
+      filesToExport.push(refsRegistryFile)
+    }
+  } catch {
+    // Failed to generate refs registry
   }
 
   try {

--- a/packages/factory/export/react/generation/preprocess/generate-jsx-structure.ts
+++ b/packages/factory/export/react/generation/preprocess/generate-jsx-structure.ts
@@ -140,6 +140,7 @@ export function generateJSXStructure(
       path: node.dataBinding.path,
       propVarName,
       propKeyName,
+      ref: node.ref,
       children: children.length > 0 ? children : undefined,
       condition,
       grandchildProps: grandchildProps.length > 0 ? grandchildProps : undefined,
@@ -156,6 +157,7 @@ export function generateJSXStructure(
     name: config.react.returns || "div",
     path: tree.dataBinding.path,
     propVarName: "props",
+    ref: tree.ref,
     children: rootChildren.length > 0 ? rootChildren : undefined,
   }
 

--- a/packages/factory/export/react/generation/preprocess/jsx-structure-to-string.ts
+++ b/packages/factory/export/react/generation/preprocess/jsx-structure-to-string.ts
@@ -1,4 +1,5 @@
 import { ComponentToExport } from "../../../types"
+import { dataSeldonRefAttr } from "../shared/data-ref-attr"
 import { JSXNode } from "./types"
 
 /**
@@ -95,8 +96,9 @@ export function jsxStructureToString(
   // catalog default tree. Without this, nested children passed by a parent
   // generated component (e.g. ItemInputRow nesting into FormControlIconic)
   // would be silently discarded by React's explicit-children precedence.
+  const rootRefAttr = dataSeldonRefAttr(jsxRoot.ref)
   let content = `
-  return (\n    <${config.react.returns} className={${classNameVarName}} {...props}>`
+  return (\n    <${config.react.returns} className={${classNameVarName}}${rootRefAttr} {...props}>`
 
   if (jsxRoot.children && jsxRoot.children.length > 0) {
     content += `\n      {children !== undefined ? (\n        children\n      ) : (\n        <>`

--- a/packages/factory/export/react/generation/preprocess/types.ts
+++ b/packages/factory/export/react/generation/preprocess/types.ts
@@ -15,6 +15,7 @@ export type JSXNode = {
   children?: JSXNode[]
   condition?: string // For conditional rendering (prop name that controls visibility)
   className?: string
+  ref?: string // Node reference handle, emitted as data-seldon-ref
   grandchildProps?: Array<{
     propKeyName: string // child component's slot name, e.g. "icon"
     propVarName: string // parent's variable name, e.g. "buttonIconicIconProps"

--- a/packages/factory/export/react/generation/shared/data-ref-attr.ts
+++ b/packages/factory/export/react/generation/shared/data-ref-attr.ts
@@ -1,0 +1,8 @@
+/**
+ * JSX attribute string that emits a node's reference as `data-seldon-ref`.
+ * Returns an empty string when the node has no ref. Placed before `{...props}`
+ * at a call site so a caller-passed instance ref overrides this default.
+ */
+export function dataSeldonRefAttr(ref: string | undefined): string {
+  return ref ? ` data-seldon-ref={${JSON.stringify(ref)}}` : ""
+}

--- a/packages/factory/export/react/generation/shared/generate-default-props.ts
+++ b/packages/factory/export/react/generation/shared/generate-default-props.ts
@@ -46,16 +46,29 @@ export function generateDefaultProps(
 
     if (conditionalPaths.has(node.dataBinding.path)) {
       const className = getClassName(node, nodeIdToClass)
+      const entry: DefaultPropsValue = {}
       if (className) {
-        defaultProps[propName] = { className }
+        entry.className = className
+      }
+      // A child instance has no literal JSX attribute site; its ref rides the
+      // sdn default props through the `{...props}` spread onto the child root.
+      if (node.ref) {
+        entry["data-seldon-ref"] = node.ref
+      }
+      if (Object.keys(entry).length > 0) {
+        defaultProps[propName] = entry
       }
     } else {
-      defaultProps[propName] = flattenProps(
+      const entry = flattenProps(
         node.dataBinding.props,
         node.nodeId,
         nodeIdToClass,
         node.classNames,
       )
+      if (node.ref) {
+        entry["data-seldon-ref"] = node.ref
+      }
+      defaultProps[propName] = entry
     }
 
     if (Array.isArray(node.children)) {

--- a/packages/factory/export/react/generation/shared/generate-react-component-return-statements.ts
+++ b/packages/factory/export/react/generation/shared/generate-react-component-return-statements.ts
@@ -3,15 +3,17 @@ import { NATIVE_REACT_PRIMITIVES } from "@seldon/core/components/constants"
 
 import { NodeIdToClass } from "../../../css/types"
 import { ComponentToExport } from "../../../types"
+import { dataSeldonRefAttr } from "./data-ref-attr"
 
 /**
  * Generate the return statement for an iconMap component
  */
 export function generateIconMapReturn(
-  _component: ComponentToExport,
+  component: ComponentToExport,
   _nodeIdToClass: NodeIdToClass,
   classNameVarName: string,
 ): string {
+  const refAttr = dataSeldonRefAttr(component.tree.ref)
   return `
     let Icon = iconMap[icon || "__default__"]
     if (!Icon) {
@@ -20,7 +22,7 @@ export function generateIconMapReturn(
   //
   // React JSX component with merged default and custom properties
   //
-    return <Icon className={${classNameVarName}} {...props} />
+    return <Icon className={${classNameVarName}}${refAttr} {...props} />
   `
 }
 
@@ -33,6 +35,7 @@ export function generateHtmlElementReturn(
   classNameVarName: string,
 ): string {
   const { tree } = component
+  const refAttr = dataSeldonRefAttr(tree.ref)
   const { options, defaultValue } = tree.dataBinding.props.htmlElement
 
   // Validate options and defaultValue
@@ -67,13 +70,13 @@ export function generateHtmlElementReturn(
   //
   // React JSX component with merged default and custom properties
   //
-  return <${Component} className={${classNameVarName}} {...props}>{children}</${Component}> \n`
+  return <${Component} className={${classNameVarName}}${refAttr} {...props}>{children}</${Component}> \n`
       } else {
         content += `case "${option}": 
   //
   // React JSX component with merged default and custom properties
   //
-  return <${Component} className={${classNameVarName}} {...props} /> \n`
+  return <${Component} className={${classNameVarName}}${refAttr} {...props} /> \n`
       }
     })
 
@@ -87,13 +90,13 @@ export function generateHtmlElementReturn(
   //
   // React JSX component with merged default and custom properties
   //
-  return <${Component} className={${classNameVarName}} {...props}>{children}</${Component}> \n`
+  return <${Component} className={${classNameVarName}}${refAttr} {...props}>{children}</${Component}> \n`
   } else {
     content += `default: 
   //
   // React JSX component with merged default and custom properties
   //
-  return <${Component} className={${classNameVarName}} {...props} /> \n`
+  return <${Component} className={${classNameVarName}}${refAttr} {...props} /> \n`
   }
   content += `}`
 
@@ -109,6 +112,7 @@ export function generateWrapperElementReturn(
   classNameVarName: string,
 ): string {
   const { tree } = component
+  const refAttr = dataSeldonRefAttr(tree.ref)
   const { options, defaultValue } = tree.dataBinding.props.wrapperElement
 
   invariant(options, "wrapperElement.options is required to create a switch")
@@ -138,13 +142,13 @@ export function generateWrapperElementReturn(
   //
   // React JSX component with merged default and custom properties
   //
-  return <${Component} className={${classNameVarName}} {...props}>{children}</${Component}> \n`
+  return <${Component} className={${classNameVarName}}${refAttr} {...props}>{children}</${Component}> \n`
       } else {
         content += `case "${option}": 
   //
   // React JSX component with merged default and custom properties
   //
-  return <${Component} className={${classNameVarName}} {...props} /> \n`
+  return <${Component} className={${classNameVarName}}${refAttr} {...props} /> \n`
       }
     })
 
@@ -158,13 +162,13 @@ export function generateWrapperElementReturn(
   //
   // React JSX component with merged default and custom properties
   //
-  return <${Component} className={${classNameVarName}} {...props}>{children}</${Component}> \n`
+  return <${Component} className={${classNameVarName}}${refAttr} {...props}>{children}</${Component}> \n`
   } else {
     content += `default: 
   //
   // React JSX component with merged default and custom properties
   //
-  return <${Component} className={${classNameVarName}} {...props} /> \n`
+  return <${Component} className={${classNameVarName}}${refAttr} {...props} /> \n`
   }
   content += `}`
 
@@ -180,6 +184,7 @@ export function generateSimpleReturn(
   classNameVarName: string,
 ): string {
   const { config, tree } = component
+  const refAttr = dataSeldonRefAttr(tree.ref)
   // Check if children prop exists in rootProps
   const hasChildrenProp = "children" in tree.dataBinding.props
 
@@ -200,12 +205,12 @@ export function generateSimpleReturn(
   //
   // React JSX component with merged default and custom properties
   //
-  return <${config.react.returns} className={${classNameVarName}}${rootPropsString} {...props}>{children}</${config.react.returns}>`
+  return <${config.react.returns} className={${classNameVarName}}${rootPropsString}${refAttr} {...props}>{children}</${config.react.returns}>`
   } else {
     return `
   //
   // React JSX component with merged default and custom properties
   //
-  return <${config.react.returns} className={${classNameVarName}}${rootPropsString} {...props} />`
+  return <${config.react.returns} className={${classNameVarName}}${rootPropsString}${refAttr} {...props} />`
   }
 }

--- a/packages/factory/export/types.ts
+++ b/packages/factory/export/types.ts
@@ -118,6 +118,8 @@ export type JSONTreeNode = {
   componentId: ComponentId
   schemaVariantId: string | null
   nodeId: InstanceId | VariantId
+  /** Unique node reference handle, emitted as `data-seldon-ref` when present. */
+  ref?: string
   children?: null | string | JSONTreeNode[]
   level: ComponentLevel
   dataBinding: DataBinding


### PR DESCRIPTION
## 📝 Description

Adds a unique, node-level **Reference** (`ref`) field that lets users assign a stable handle to a node (instance or user variant) in the inspector, and emits it as a `data-seldon-ref` attribute in the Factory React export so app code can target a specific element regardless of position.

- **Core**: new optional `ref` field on `EntryNode`; `set_node_ref` action, mutation, handler, and `setRef` rule block (allowed on instances and user variants only, `propagation: "none"`); global `refIsUnique` validation; `ref` stripped on all duplicate/paste/clone paths to preserve global uniqueness; regenerated `workspace-action-schema.json` so MCP/AI agents get the action; new `NODE_FIELD_DISPLAY_ORDER` constant.
- **Editor**: synthetic "Reference" inspector row (Theme then Reference, driven by the core order); `set_node_ref` dispatch with uniqueness error surfacing; canonical node-key ordering applied on "Export to file" so `ref` serializes directly after `id` and before `type`.
- **Factory (React-only)**: threads `ref` through `JSONTreeNode`/`JSXNode`; emits `data-seldon-ref` on a component's own root element and on child instances via their `sdn` props; generates a `refs/index.ts` registry (`SeldonRef` union + `SELDON_REFS` map). An empty/unset `ref` emits nothing.

## 🔗 Related Issues

_None_

## 🧪 Type of Change

- ✨ New feature

## 📦 Affected Packages

- `@seldon/core`
- `@seldon/factory`
- `@seldon/editor`
- Root: `package-lock.json` regenerated and `packages/editor/public/THIRD-PARTY-NOTICES.txt` updated from a dependency reinstall.

## 📸 Screenshots/Videos

_N/A_

## 🔍 Code Quality Checklist

- Code follows the project's style guidelines
- Self-review of the code has been performed
- Code is properly commented, particularly in hard-to-understand areas
- No console.log statements or debugging code left in
- TypeScript types are properly defined, no use of "as any"
- No unused imports or variables

## 📋 Breaking Changes

_None._ The `ref` field is optional and additive, so existing workspaces need no migration. Nodes without a `ref` emit no attribute and no registry entry.

## 🚀 Deployment Notes

- `workspace-action-schema.json` was regenerated; the MCP `apply_actions` tool picks up `set_node_ref` with no extra wiring.
- `package-lock.json` changed; run `npm install` after pulling.

## 📚 Documentation Updates

_None_

## ⚠️ Additional Notes

- The `data-seldon-ref` emission and `refs/index.ts` registry are React-export-specific; the core `ref` field stays framework-neutral for future Swift/Java exporters.
- Because the same exported component can render multiple times, a `data-seldon-ref` value can appear more than once in the live DOM; scope DOM lookups to a rendered subtree when targeting a single element.
- Verified end-to-end against a workspace fixture: refs appear in the parent component's `sdn` (e.g. `CalendarRange.tsx`) and in `seldon/refs/index.ts`.

---

I have read the CLA and I agree to its terms.

SeldonDigital
AndreiSeldon