### PR TITLE
Repeated children (Phase 1, editor-only)

### DIFF
--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -58,3 +58,12 @@ export {
   ensureWorkspaceEditableThemeEntry,
 } from "./workspace/helpers/themes/workspace-editable-theme"
 export { createEmptyWorkspace } from "./workspace/helpers/create-empty-workspace"
+export {
+  applyNodeRepeat,
+  getNodeRepeat,
+  isMeaningfulRepeat,
+  MAX_REPEAT_COUNT,
+  MAX_REPEAT_EXPANSION,
+  REPEAT_EDITOR_KEY,
+} from "./workspace/helpers/nodes/node-repeat"
+export type { RepeatEditorData } from "./workspace/helpers/nodes/node-repeat"

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -67,3 +67,10 @@ export {
   REPEAT_EDITOR_KEY,
 } from "./workspace/helpers/nodes/node-repeat"
 export type { RepeatEditorData } from "./workspace/helpers/nodes/node-repeat"
+export {
+  collectDescendantIdsInOrder,
+  getRepeatInheritanceSourceId,
+  resolveInheritedRepeatData,
+  resolveNodeRepeat,
+} from "./workspace/helpers/nodes/resolve-node-repeat"
+export type { ResolvedRepeat } from "./workspace/helpers/nodes/resolve-node-repeat"

--- a/packages/core/workspace/helpers/nodes/node-repeat.ts
+++ b/packages/core/workspace/helpers/nodes/node-repeat.ts
@@ -20,12 +20,16 @@ export const MAX_REPEAT_EXPANSION = 200
  * keyed by a descendant node id for text/icon prototyping.
  */
 export interface RepeatEditorData {
-  /** Total rendered copies including index 0. Range 1..{@link MAX_REPEAT_COUNT}. */
-  count: number
+  /**
+   * Total rendered copies including index 0. Range 1..{@link MAX_REPEAT_COUNT}.
+   * Optional: an instance may store a data-only override that omits `count` and
+   * inherits it from the template via {@link resolveNodeRepeat}.
+   */
+  count?: number
   /**
    * Optional prototyping strings for text/icon descendants. Keyed by a stable
    * descendant node id. Each array holds values for echoes 1..count-1; index 0
-   * always renders the descendant's own value.
+   * always renders the descendant's own value. An empty slot inherits.
    */
   data?: Record<string, string[]>
 }
@@ -37,20 +41,27 @@ export function getNodeRepeat(node: EditorBearing): RepeatEditorData | undefined
   const raw = node.__editor?.[REPEAT_EDITOR_KEY]
   if (raw == null || typeof raw !== "object") return undefined
   const candidate = raw as Partial<RepeatEditorData>
-  if (typeof candidate.count !== "number") return undefined
+  const hasCount = typeof candidate.count === "number"
+  const hasData = candidate.data != null && typeof candidate.data === "object"
+  if (!hasCount && !hasData) return undefined
   return candidate as RepeatEditorData
 }
 
 /**
  * A repeat is meaningful only when it paints more than once or carries
- * prototyping data. A bare `count <= 1` with no data is equivalent to no repeat.
+ * prototyping override data. A bare `count <= 1` with no data is equivalent to
+ * no repeat. A data-only override (no `count`) is meaningful when it holds at
+ * least one non-empty slot.
  */
 export function isMeaningfulRepeat(
   repeat: RepeatEditorData | undefined,
 ): repeat is RepeatEditorData {
   if (!repeat) return false
-  if (repeat.count > 1) return true
-  return repeat.data != null && Object.keys(repeat.data).length > 0
+  if (repeat.count != null && repeat.count > 1) return true
+  if (!repeat.data) return false
+  return Object.values(repeat.data).some((values) =>
+    values.some((value) => value != null && value !== ""),
+  )
 }
 
 /**

--- a/packages/core/workspace/helpers/nodes/node-repeat.ts
+++ b/packages/core/workspace/helpers/nodes/node-repeat.ts
@@ -37,7 +37,9 @@ export interface RepeatEditorData {
 type EditorBearing = Pick<EntryNode, "__editor">
 
 /** Reads the repeat preview state from a node, or `undefined` when absent. */
-export function getNodeRepeat(node: EditorBearing): RepeatEditorData | undefined {
+export function getNodeRepeat(
+  node: EditorBearing,
+): RepeatEditorData | undefined {
   const raw = node.__editor?.[REPEAT_EDITOR_KEY]
   if (raw == null || typeof raw !== "object") return undefined
   const candidate = raw as Partial<RepeatEditorData>

--- a/packages/core/workspace/helpers/nodes/node-repeat.ts
+++ b/packages/core/workspace/helpers/nodes/node-repeat.ts
@@ -1,0 +1,73 @@
+import type { EntryNode } from "../../model/entry-node"
+
+/** Key under `EntryNode.__editor` that holds the repeat preview state. */
+export const REPEAT_EDITOR_KEY = "repeat"
+
+/** Largest total render count for a single repeat, index 0 included. */
+export const MAX_REPEAT_COUNT = 50
+
+/**
+ * Ceiling for the product of nested repeat counts along an ancestor chain.
+ * Keeps the canvas from expanding into an unmanageable number of echoes when
+ * repeats are nested inside other repeats.
+ */
+export const MAX_REPEAT_EXPANSION = 200
+
+/**
+ * Editor-only repeat preview state stored on a child node. The node paints
+ * `count` times on the canvas. Index 0 is the single real, selectable node;
+ * the rest are render-only echoes. `data` carries per-echo placeholder strings
+ * keyed by a descendant node id for text/icon prototyping.
+ */
+export interface RepeatEditorData {
+  /** Total rendered copies including index 0. Range 1..{@link MAX_REPEAT_COUNT}. */
+  count: number
+  /**
+   * Optional prototyping strings for text/icon descendants. Keyed by a stable
+   * descendant node id. Each array holds values for echoes 1..count-1; index 0
+   * always renders the descendant's own value.
+   */
+  data?: Record<string, string[]>
+}
+
+type EditorBearing = Pick<EntryNode, "__editor">
+
+/** Reads the repeat preview state from a node, or `undefined` when absent. */
+export function getNodeRepeat(node: EditorBearing): RepeatEditorData | undefined {
+  const raw = node.__editor?.[REPEAT_EDITOR_KEY]
+  if (raw == null || typeof raw !== "object") return undefined
+  const candidate = raw as Partial<RepeatEditorData>
+  if (typeof candidate.count !== "number") return undefined
+  return candidate as RepeatEditorData
+}
+
+/**
+ * A repeat is meaningful only when it paints more than once or carries
+ * prototyping data. A bare `count <= 1` with no data is equivalent to no repeat.
+ */
+export function isMeaningfulRepeat(
+  repeat: RepeatEditorData | undefined,
+): repeat is RepeatEditorData {
+  if (!repeat) return false
+  if (repeat.count > 1) return true
+  return repeat.data != null && Object.keys(repeat.data).length > 0
+}
+
+/**
+ * Writes the repeat preview state onto a node, preserving any other `__editor`
+ * keys such as `initialOverrides`. Clears the key (and an emptied `__editor`)
+ * when the repeat is not meaningful.
+ */
+export function applyNodeRepeat(
+  node: EditorBearing,
+  repeat: RepeatEditorData | undefined,
+): void {
+  if (!isMeaningfulRepeat(repeat)) {
+    if (node.__editor) {
+      delete node.__editor[REPEAT_EDITOR_KEY]
+      if (Object.keys(node.__editor).length === 0) delete node.__editor
+    }
+    return
+  }
+  node.__editor = { ...node.__editor, [REPEAT_EDITOR_KEY]: repeat }
+}

--- a/packages/core/workspace/helpers/nodes/resolve-node-repeat.ts
+++ b/packages/core/workspace/helpers/nodes/resolve-node-repeat.ts
@@ -1,0 +1,165 @@
+import { parseNodeLink } from "../../model/template-ref"
+import type { EntryNodeId, Workspace } from "../../types"
+import { getBoardByNodeId } from "../components/get-board-by-node-id"
+import { getChildrenIds } from "../components/get-children-ids"
+import { findParentNode } from "./find-parent-node"
+import { getNodeRepeat } from "./node-repeat"
+
+/**
+ * Effective repeat for a node after inheritance and override merge. `count` is
+ * always concrete and `data` is keyed by the queried node's own descendant ids,
+ * so render and inspector lookups match without translation.
+ */
+export interface ResolvedRepeat {
+  count: number
+  data: Record<string, string[]>
+}
+
+/**
+ * Finds the node a given node inherits repeat from: the positionally matching
+ * child under the parent's template. Instance children are independent clones
+ * that template from a shared catalog default, so the inheritance link runs
+ * through the parent rather than the child's own template. Returns null at an
+ * origin, where the parent templates from a catalog schema.
+ */
+export function getRepeatInheritanceSourceId(
+  nodeId: EntryNodeId,
+  workspace: Workspace,
+): EntryNodeId | null {
+  const parent = findParentNode(nodeId, workspace)
+  if (!parent) return null
+
+  const link = parseNodeLink(parent.template)
+  if (!link) return null
+
+  const parentBoard = getBoardByNodeId(workspace, parent.id)
+  if (!parentBoard) return null
+  const index = getChildrenIds(parentBoard, parent.id).indexOf(nodeId)
+  if (index < 0) return null
+
+  const sourceParentId = link.nodeId as EntryNodeId
+  const sourceBoard = getBoardByNodeId(workspace, sourceParentId)
+  if (!sourceBoard) return null
+  const sourceChildId = getChildrenIds(sourceBoard, sourceParentId)[index]
+  if (!sourceChildId || sourceChildId === nodeId) return null
+
+  return sourceChildId
+}
+
+/** Lists every descendant id under a node in deterministic tree order. */
+export function collectDescendantIdsInOrder(
+  rootId: EntryNodeId,
+  workspace: Workspace,
+): EntryNodeId[] {
+  const board = getBoardByNodeId(workspace, rootId)
+  if (!board) return []
+
+  const ordered: EntryNodeId[] = []
+  const walk = (id: EntryNodeId): void => {
+    for (const childId of getChildrenIds(board, id)) {
+      ordered.push(childId)
+      walk(childId)
+    }
+  }
+  walk(rootId)
+  return ordered
+}
+
+/**
+ * Remaps inherited data keyed by the source node's descendant ids onto the
+ * queried node's descendant ids by matching tree position. Clones share their
+ * structure, so the nth descendant corresponds across the inheritance link.
+ */
+function translateInheritedData(
+  inheritedData: Record<string, string[]>,
+  sourceId: EntryNodeId,
+  nodeId: EntryNodeId,
+  workspace: Workspace,
+): Record<string, string[]> {
+  const sourceOrder = collectDescendantIdsInOrder(sourceId, workspace)
+  const targetOrder = collectDescendantIdsInOrder(nodeId, workspace)
+  const sourceIndexById = new Map(sourceOrder.map((id, i) => [id, i]))
+
+  const translated: Record<string, string[]> = {}
+  for (const [sourceDescId, values] of Object.entries(inheritedData)) {
+    const ordinal = sourceIndexById.get(sourceDescId as EntryNodeId)
+    if (ordinal == null) continue
+    const targetDescId = targetOrder[ordinal]
+    if (targetDescId) translated[targetDescId] = values
+  }
+  return translated
+}
+
+/** Layers own data over inherited data per slot. A non-empty own slot wins. */
+function mergeRepeatData(
+  inherited: Record<string, string[]>,
+  own: Record<string, string[]>,
+): Record<string, string[]> {
+  const merged: Record<string, string[]> = {}
+  const keys = new Set([...Object.keys(inherited), ...Object.keys(own)])
+  for (const key of keys) {
+    const inheritedSlots = inherited[key] ?? []
+    const ownSlots = own[key] ?? []
+    const length = Math.max(inheritedSlots.length, ownSlots.length)
+    const slots: string[] = []
+    for (let i = 0; i < length; i++) {
+      const ownValue = ownSlots[i]
+      slots[i] =
+        ownValue != null && ownValue !== ""
+          ? ownValue
+          : (inheritedSlots[i] ?? "")
+    }
+    merged[key] = slots
+  }
+  return merged
+}
+
+/**
+ * Returns the repeat data a node inherits from its template's matching child,
+ * remapped onto the node's own descendant ids. Excludes the node's own
+ * overrides, so callers can compare own values against the inherited baseline.
+ */
+export function resolveInheritedRepeatData(
+  nodeId: EntryNodeId,
+  workspace: Workspace,
+): Record<string, string[]> {
+  const sourceId = getRepeatInheritanceSourceId(nodeId, workspace)
+  if (!sourceId) return {}
+  const inherited = resolveNodeRepeat(sourceId, workspace)
+  if (!inherited) return {}
+  return translateInheritedData(inherited.data, sourceId, nodeId, workspace)
+}
+
+/**
+ * Resolves a node's effective repeat by inheriting from its template's matching
+ * child and layering the node's own repeat on top. Count inherits unless the
+ * node sets its own; data merges per slot with the node's own value winning.
+ * Returns undefined when no count is set anywhere along the chain.
+ */
+export function resolveNodeRepeat(
+  nodeId: EntryNodeId,
+  workspace: Workspace,
+  visited: Set<EntryNodeId> = new Set(),
+): ResolvedRepeat | undefined {
+  if (visited.has(nodeId)) return undefined
+  visited.add(nodeId)
+
+  const node = workspace.nodes[nodeId]
+  const own = node ? getNodeRepeat(node) : undefined
+
+  const sourceId = getRepeatInheritanceSourceId(nodeId, workspace)
+  const inherited = sourceId
+    ? resolveNodeRepeat(sourceId, workspace, visited)
+    : undefined
+
+  const count = own?.count ?? inherited?.count
+  if (count == null) return undefined
+
+  const inheritedData =
+    inherited && sourceId
+      ? translateInheritedData(inherited.data, sourceId, nodeId, workspace)
+      : {}
+  const data = mergeRepeatData(inheritedData, own?.data ?? {})
+
+  return { count, data }
+}

--- a/packages/core/workspace/middleware/validation/action-groups/node-mutations.ts
+++ b/packages/core/workspace/middleware/validation/action-groups/node-mutations.ts
@@ -8,6 +8,11 @@ import { collectExternalVariantUsage } from "../../../helpers/general/collect-ex
 import { isUserVariant } from "../../../helpers/general/is-user-variant"
 import { findBoardContainingTreeNodeId } from "../../../helpers/nodes/duplicate-entry-variant-subtree"
 import {
+  MAX_REPEAT_COUNT,
+  MAX_REPEAT_EXPANSION,
+  getNodeRepeat,
+} from "../../../helpers/nodes/node-repeat"
+import {
   SANDBOX_MAX_MAGNITUDE,
   findPlaygroundKeyForSandbox,
   getPlaygroundSandboxIds,
@@ -278,6 +283,12 @@ export function validateNodeMutation(
     case "reset_node":
       nodeValidators.exists(workspace, action.payload.nodeId)
       break
+    case "set_node_repeat": {
+      const nodeId = action.payload.nodeId as InstanceId | VariantId
+      nodeValidators.exists(workspace, nodeId)
+      assertRepeatConstraints(workspace, action, nodeId)
+      break
+    }
     case "reset_user_variant_to_default": {
       const variantRootId = action.payload.variantRootId as VariantId
       nodeValidators.exists(workspace, variantRootId)
@@ -418,6 +429,51 @@ function getInstanceNodeOrThrow(
     )
   }
   return node
+}
+
+/**
+ * Enforces the editor-only repeat preview cap: a whole count within
+ * 1..{@link MAX_REPEAT_COUNT}, and a nested-expansion ceiling so a repeat set
+ * inside other repeats does not multiply into an unmanageable number of echoes.
+ */
+function assertRepeatConstraints(
+  workspace: Workspace,
+  action: Extract<Action, { type: "set_node_repeat" }>,
+  nodeId: InstanceId | VariantId,
+): void {
+  const repeat = action.payload.repeat
+  if (!repeat) return
+
+  const count = repeat.count
+  if (!Number.isInteger(count) || count < 1) {
+    throw new WorkspaceValidationError(
+      "Repeat count must be a whole number of at least 1.",
+      action,
+    )
+  }
+  if (count > MAX_REPEAT_COUNT) {
+    throw new WorkspaceValidationError(
+      `Repeat count cannot exceed ${MAX_REPEAT_COUNT}.`,
+      action,
+    )
+  }
+
+  let expansion = count
+  let ancestor = nodeTraversalService.findParentNode(nodeId, workspace)
+  while (ancestor) {
+    const ancestorRepeat = getNodeRepeat(ancestor)
+    if (ancestorRepeat && ancestorRepeat.count > 1) {
+      expansion *= ancestorRepeat.count
+    }
+    ancestor = nodeTraversalService.findParentNode(ancestor, workspace)
+  }
+
+  if (expansion > MAX_REPEAT_EXPANSION) {
+    throw new WorkspaceValidationError(
+      `Nested repeats would render ${expansion} copies, above the ${MAX_REPEAT_EXPANSION} limit. Lower a repeat count.`,
+      action,
+    )
+  }
 }
 
 /**

--- a/packages/core/workspace/middleware/validation/action-groups/node-mutations.ts
+++ b/packages/core/workspace/middleware/validation/action-groups/node-mutations.ts
@@ -444,7 +444,11 @@ function assertRepeatConstraints(
   const repeat = action.payload.repeat
   if (!repeat) return
 
+  // A data-only override omits count and inherits it from the template, so there
+  // is no count constraint to enforce on this write.
   const count = repeat.count
+  if (count == null) return
+
   if (!Number.isInteger(count) || count < 1) {
     throw new WorkspaceValidationError(
       "Repeat count must be a whole number of at least 1.",
@@ -462,7 +466,7 @@ function assertRepeatConstraints(
   let ancestor = nodeTraversalService.findParentNode(nodeId, workspace)
   while (ancestor) {
     const ancestorRepeat = getNodeRepeat(ancestor)
-    if (ancestorRepeat && ancestorRepeat.count > 1) {
+    if (ancestorRepeat?.count != null && ancestorRepeat.count > 1) {
       expansion *= ancestorRepeat.count
     }
     ancestor = nodeTraversalService.findParentNode(ancestor, workspace)

--- a/packages/core/workspace/middleware/validation/validate-action.ts
+++ b/packages/core/workspace/middleware/validation/validate-action.ts
@@ -166,6 +166,7 @@ export function validateAction(workspace: Workspace, action: Action): void {
     case "set_node_label":
     case "set_node_ref":
     case "set_node_editor_data":
+    case "set_node_repeat":
     case "reset_node_label":
     case "reset_node_editor_data":
     case "reset_user_variant_to_default":

--- a/packages/core/workspace/reducers/README.md
+++ b/packages/core/workspace/reducers/README.md
@@ -85,6 +85,7 @@ The `reducer` switch has no default branch. Validation rejects unknown action ty
 | `set_node_label` | `setNodeLabel` | `set-node-label.ts` |
 | `set_node_theme` | `setNodeTheme` | `set-node-theme.ts` |
 | `set_node_editor_data` | `setNodeEditorData` | `set-node-editor-data.ts` |
+| `set_node_repeat` | `setNodeRepeat` | `set-node-repeat.ts` |
 | `set_node_properties` | `setNodeProperties` | `set-node-properties.ts` |
 | `set_node_state_properties` | `setNodeStateProperties` | `set-node-state-properties.ts` |
 | `set_node_ref` | `setNodeRef` | `set-node-ref.ts` |

--- a/packages/core/workspace/reducers/handlers/remove/remove-instance.ts
+++ b/packages/core/workspace/reducers/handlers/remove/remove-instance.ts
@@ -84,19 +84,20 @@ export function removeInstance(
     return workspace
   }
 
-  const result = workspacePropagationService.propagateNodeOperation({
-    nodeId: payload.instanceId,
+  const result = workspacePropagationService.propagatePositionalChildOperation({
+    childId: payload.instanceId,
     propagation,
-    apply: (node, workspace) => {
-      if (!typeCheckingService.isInstance(node)) return workspace
+    applyToChild: (childId, workspace) => {
+      const childNode = nodeRetrievalService.getNode(childId, workspace)
+      if (!typeCheckingService.isInstance(childNode)) return workspace
 
       if (removalBehavior === "delete") {
-        return nodeOperationsService.deleteInstance(node.id, workspace)
+        return nodeOperationsService.deleteInstance(childId, workspace)
       }
 
       if (removalBehavior === "hide") {
         return workspaceMutationService.setNodeProperties(
-          node.id,
+          childId,
           {
             display: {
               type: ValueType.OPTION as const,

--- a/packages/core/workspace/reducers/handlers/set/set-node-repeat.ts
+++ b/packages/core/workspace/reducers/handlers/set/set-node-repeat.ts
@@ -1,19 +1,19 @@
 import type { ExtractPayload, Workspace } from "../../../../index"
-import {
-  workspaceMutationService,
-  workspacePropagationService,
-} from "../../../services"
+import { workspaceMutationService } from "../../../services"
 
-/** Sets or clears the editor-only repeat preview state on a node. */
+/**
+ * Sets or clears the editor-only repeat preview state on a single node. Repeat
+ * follows the override model: instances inherit their template's repeat at read
+ * time via `resolveNodeRepeat`, so this writes only the targeted node and never
+ * propagates to instances.
+ */
 export function setNodeRepeat(
   payload: ExtractPayload<"set_node_repeat">,
   workspace: Workspace,
 ): Workspace {
-  return workspacePropagationService.propagatePositionalChildOperation({
-    childId: payload.nodeId,
-    propagation: "downstream",
-    applyToChild: (childId, workspace) =>
-      workspaceMutationService.setNodeRepeat(childId, payload.repeat, workspace),
+  return workspaceMutationService.setNodeRepeat(
+    payload.nodeId,
+    payload.repeat,
     workspace,
-  })
+  )
 }

--- a/packages/core/workspace/reducers/handlers/set/set-node-repeat.ts
+++ b/packages/core/workspace/reducers/handlers/set/set-node-repeat.ts
@@ -1,0 +1,14 @@
+import type { ExtractPayload, Workspace } from "../../../../index"
+import { workspaceMutationService } from "../../../services"
+
+/** Sets or clears the editor-only repeat preview state on a node. */
+export function setNodeRepeat(
+  payload: ExtractPayload<"set_node_repeat">,
+  workspace: Workspace,
+): Workspace {
+  return workspaceMutationService.setNodeRepeat(
+    payload.nodeId,
+    payload.repeat,
+    workspace,
+  )
+}

--- a/packages/core/workspace/reducers/handlers/set/set-node-repeat.ts
+++ b/packages/core/workspace/reducers/handlers/set/set-node-repeat.ts
@@ -1,14 +1,19 @@
 import type { ExtractPayload, Workspace } from "../../../../index"
-import { workspaceMutationService } from "../../../services"
+import {
+  workspaceMutationService,
+  workspacePropagationService,
+} from "../../../services"
 
 /** Sets or clears the editor-only repeat preview state on a node. */
 export function setNodeRepeat(
   payload: ExtractPayload<"set_node_repeat">,
   workspace: Workspace,
 ): Workspace {
-  return workspaceMutationService.setNodeRepeat(
-    payload.nodeId,
-    payload.repeat,
+  return workspacePropagationService.propagatePositionalChildOperation({
+    childId: payload.nodeId,
+    propagation: "downstream",
+    applyToChild: (childId, workspace) =>
+      workspaceMutationService.setNodeRepeat(childId, payload.repeat, workspace),
     workspace,
-  )
+  })
 }

--- a/packages/core/workspace/reducers/reducer.ts
+++ b/packages/core/workspace/reducers/reducer.ts
@@ -141,6 +141,7 @@ import { setNodeLabel } from "./handlers/set/set-node-label"
 import { setNodeLayerKind } from "./handlers/set/set-node-layer-kind"
 import { setNodeProperties } from "./handlers/set/set-node-properties"
 import { setNodeRef } from "./handlers/set/set-node-ref"
+import { setNodeRepeat } from "./handlers/set/set-node-repeat"
 import { setNodeStateProperties } from "./handlers/set/set-node-state-properties"
 import { setNodeTheme } from "./handlers/set/set-node-theme"
 import { setPlaygroundLabel } from "./handlers/set/set-playground-label"
@@ -328,6 +329,8 @@ function reducer(workspace: Workspace, action: WorkspaceAction): Workspace {
       return setNodeTheme(action.payload, workspace)
     case "set_node_editor_data":
       return setNodeEditorData(action.payload, workspace)
+    case "set_node_repeat":
+      return setNodeRepeat(action.payload, workspace)
     case "reset_node_label":
       return resetNodeLabel(action.payload, workspace)
     case "reset_node_editor_data":

--- a/packages/core/workspace/reducers/types.ts
+++ b/packages/core/workspace/reducers/types.ts
@@ -15,7 +15,7 @@
  * | add_variant | components.variants + nodes |
  * | insert_variant_instance, insert_duplicate_instance, insert_default_instance, add_component_and_insert_default_instance | components tree + nodes |
  * | remove_instance, remove_variant, duplicate_node, move_instance, reorder_instance_in_parent | components tree + nodes |
- * | set_node_properties, reset_node_property, reset_node, set_node_label, set_node_theme, set_node_editor_data | nodes |
+ * | set_node_properties, reset_node_property, reset_node, set_node_label, set_node_theme, set_node_editor_data, set_node_repeat | nodes |
  * | add_node_layer, remove_node_layer, reorder_node_layer, set_node_layer_kind | nodes (background/shadow paint stacks) |
  * | reset_node_label, reset_node_editor_data | nodes |
  * | reset_user_variant_to_default, reset_default_variant_to_catalog, reset_component_to_catalog | components.variants tree + nodes |
@@ -54,6 +54,7 @@ import {
   ThemeInstanceId,
   ThemeSwatchParameters,
 } from "../../themes/types"
+import type { RepeatEditorData } from "../helpers/nodes/node-repeat"
 import type { InstanceId, VariantId } from "../helpers/rules/workspace-node-ids"
 import type { BoardKey } from "../model/components"
 import type { EntryNodeId } from "../model/entry-node"
@@ -674,6 +675,13 @@ export type WorkspaceAction =
       payload: {
         nodeId: InstanceId | VariantId
         editorData: Record<string, unknown> | undefined
+      }
+    }
+  | {
+      type: "set_node_repeat"
+      payload: {
+        nodeId: InstanceId | VariantId
+        repeat: RepeatEditorData | undefined
       }
     }
   | {

--- a/packages/core/workspace/reducers/workspace-action-schema.json
+++ b/packages/core/workspace/reducers/workspace-action-schema.json
@@ -3267,6 +3267,30 @@
           "properties": {
             "nodeId": {
               "type": "string"
+            },
+            "repeat": {
+              "$ref": "#/definitions/RepeatEditorData"
+            }
+          },
+          "required": ["nodeId", "repeat"],
+          "type": "object"
+        },
+        "type": {
+          "const": "set_node_repeat",
+          "type": "string"
+        }
+      },
+      "required": ["payload", "type"],
+      "type": "object"
+    },
+    {
+      "additionalProperties": false,
+      "properties": {
+        "payload": {
+          "additionalProperties": false,
+          "properties": {
+            "nodeId": {
+              "type": "string"
             }
           },
           "required": ["nodeId"],
@@ -15564,6 +15588,26 @@
     },
     "Record<string,unknown>": {
       "additionalProperties": false,
+      "type": "object"
+    },
+    "RepeatEditorData": {
+      "additionalProperties": false,
+      "description": "Editor-only repeat preview state stored on a child node. The node paints `count` times on the canvas. Index 0 is the single real, selectable node; the rest are render-only echoes. `data` carries per-echo placeholder strings keyed by a descendant node id for text/icon prototyping.",
+      "properties": {
+        "count": {
+          "type": "number"
+        },
+        "data": {
+          "additionalProperties": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "type": "object"
+        }
+      },
+      "required": ["count"],
       "type": "object"
     },
     "Resize": {

--- a/packages/core/workspace/services/mutation/label-mutations.ts
+++ b/packages/core/workspace/services/mutation/label-mutations.ts
@@ -6,6 +6,10 @@ import { walkBoardTreeRefs } from "../../helpers/components/walk-board-tree-refs
 import { getNextVariantLabel } from "../../helpers/general/get-next-variant-label"
 import { getSpecialBoardVariantLabel } from "../../helpers/general/get-special-board-variant-label"
 import { getWorkspaceNodes } from "../../helpers/general/get-workspace-nodes"
+import {
+  applyNodeRepeat,
+  type RepeatEditorData,
+} from "../../helpers/nodes/node-repeat"
 import { Board, InstanceId, VariantId, Workspace } from "../../types"
 import { nodeRetrievalService } from "../nodes/node-retrieval.service"
 import { withNodeMutation } from "../shared/workspace-operation-helpers"
@@ -41,6 +45,21 @@ export function setNodeEditorData(
   return withNodeMutation(nodeId, workspace, (node) => {
     if (editorData === undefined) delete node.__editor
     else node.__editor = editorData
+  })
+}
+
+/**
+ * Sets the editor-only repeat preview state on a node. Merge-safe: preserves
+ * other `__editor` keys such as `initialOverrides`. A non-meaningful repeat
+ * (count <= 1 with no data) or `undefined` clears the repeat state.
+ */
+export function setNodeRepeat(
+  nodeId: VariantId | InstanceId,
+  repeat: RepeatEditorData | undefined,
+  workspace: Workspace,
+): Workspace {
+  return withNodeMutation(nodeId, workspace, (node) => {
+    applyNodeRepeat(node, repeat)
   })
 }
 

--- a/packages/core/workspace/services/mutation/label-mutations.ts
+++ b/packages/core/workspace/services/mutation/label-mutations.ts
@@ -7,8 +7,8 @@ import { getNextVariantLabel } from "../../helpers/general/get-next-variant-labe
 import { getSpecialBoardVariantLabel } from "../../helpers/general/get-special-board-variant-label"
 import { getWorkspaceNodes } from "../../helpers/general/get-workspace-nodes"
 import {
-  applyNodeRepeat,
   type RepeatEditorData,
+  applyNodeRepeat,
 } from "../../helpers/nodes/node-repeat"
 import { Board, InstanceId, VariantId, Workspace } from "../../types"
 import { nodeRetrievalService } from "../nodes/node-retrieval.service"

--- a/packages/core/workspace/services/mutation/workspace-mutation.service.ts
+++ b/packages/core/workspace/services/mutation/workspace-mutation.service.ts
@@ -3,6 +3,7 @@ import { Properties, PropertyKey, SubPropertyKey } from "../../../properties"
 import { Theme, ThemeInstanceId, ThemeSwatchKey } from "../../../themes/types"
 import { applyResetDefaultVariantToCatalog } from "../../helpers/nodes/apply-reset-default-variant-to-catalog"
 import { applyResetUserVariantToDefaultVariant } from "../../helpers/nodes/apply-reset-user-variant-to-default-variant"
+import type { RepeatEditorData } from "../../helpers/nodes/node-repeat"
 import {
   BoardKey,
   Instance,
@@ -18,6 +19,7 @@ import {
   setNodeEditorData,
   setNodeLabel,
   setNodeRef,
+  setNodeRepeat,
 } from "./label-mutations"
 import {
   resetComponentProperty,
@@ -71,6 +73,14 @@ export class WorkspaceMutationService {
     workspace: Workspace,
   ): Workspace {
     return setNodeEditorData(nodeId, editorData, workspace)
+  }
+
+  public setNodeRepeat(
+    nodeId: VariantId | InstanceId,
+    repeat: RepeatEditorData | undefined,
+    workspace: Workspace,
+  ): Workspace {
+    return setNodeRepeat(nodeId, repeat, workspace)
   }
 
   public getInitialVariantLabel(

--- a/packages/core/workspace/services/propagation/propagate-node-operation.ts
+++ b/packages/core/workspace/services/propagation/propagate-node-operation.ts
@@ -2,6 +2,7 @@ import { invariant } from "../../../index"
 import { componentBoardDefaultNodeId } from "../../helpers/components/entry-node-ids"
 import { getBoardByNodeId } from "../../helpers/components/get-board-by-node-id"
 import { getChildrenIds } from "../../helpers/components/get-children-ids"
+import { findParentNode } from "../../helpers/nodes/find-parent-node"
 import { getChildIndex } from "../../helpers/nodes/get-child-index"
 import { isEntryNodeForRules } from "../../helpers/rules/rules-node-subject"
 import { parseNodeCatalog, parseNodeLink } from "../../model/template-ref"
@@ -13,7 +14,6 @@ import {
   VariantId,
   Workspace,
 } from "../../types"
-import { findParentNode } from "../../helpers/nodes/find-parent-node"
 import { nodeRelationshipService } from "../nodes/node-relationship.service"
 import { nodeRetrievalService } from "../nodes/node-retrieval.service"
 import { typeCheckingService } from "../type-checking/type-checking.service"

--- a/packages/core/workspace/services/propagation/propagate-node-operation.ts
+++ b/packages/core/workspace/services/propagation/propagate-node-operation.ts
@@ -1,14 +1,19 @@
 import { invariant } from "../../../index"
 import { componentBoardDefaultNodeId } from "../../helpers/components/entry-node-ids"
+import { getBoardByNodeId } from "../../helpers/components/get-board-by-node-id"
+import { getChildrenIds } from "../../helpers/components/get-children-ids"
+import { getChildIndex } from "../../helpers/nodes/get-child-index"
 import { isEntryNodeForRules } from "../../helpers/rules/rules-node-subject"
 import { parseNodeCatalog, parseNodeLink } from "../../model/template-ref"
 import {
+  EntryNodeId,
   Instance,
   InstanceId,
   Variant,
   VariantId,
   Workspace,
 } from "../../types"
+import { findParentNode } from "../../helpers/nodes/find-parent-node"
 import { nodeRelationshipService } from "../nodes/node-relationship.service"
 import { nodeRetrievalService } from "../nodes/node-retrieval.service"
 import { typeCheckingService } from "../type-checking/type-checking.service"
@@ -49,6 +54,44 @@ export function propagateNodeOperation<OpResult extends OperationResult>({
     default:
       throw new Error(`Invalid propagation: ${propagation}`)
   }
+}
+
+/**
+ * Applies an operation to a child node and to the positionally matching child
+ * inside every instance of the child's parent. Instance children are independent
+ * clones that template from a shared catalog default rather than back-linking to
+ * the source variant's child, so a child-rooted fan-out cannot reach them. This
+ * roots the fan-out at the parent (mirroring insert) and resolves the matching
+ * child by tree index in each parent instance.
+ */
+export function propagatePositionalChildOperation({
+  childId,
+  propagation,
+  applyToChild,
+  workspace,
+}: {
+  childId: VariantId | InstanceId
+  propagation: Propagation
+  applyToChild: (childId: EntryNodeId, workspace: Workspace) => Workspace
+  workspace: Workspace
+}): Workspace {
+  const parent = findParentNode(childId, workspace)
+  if (!parent) return applyToChild(childId, workspace)
+
+  const index = getChildIndex(childId, workspace)
+
+  return propagateNodeOperation({
+    nodeId: parent.id as VariantId | InstanceId,
+    propagation,
+    apply: (parentNode, currentWorkspace) => {
+      const board = getBoardByNodeId(currentWorkspace, parentNode.id)
+      if (!board) return currentWorkspace
+      const positionalChildId = getChildrenIds(board, parentNode.id)[index]
+      if (!positionalChildId) return currentWorkspace
+      return applyToChild(positionalChildId, currentWorkspace)
+    },
+    workspace,
+  })
 }
 
 function applyDownstream<OpResult extends OperationResult>(

--- a/packages/core/workspace/services/propagation/workspace-propagation.service.ts
+++ b/packages/core/workspace/services/propagation/workspace-propagation.service.ts
@@ -1,4 +1,5 @@
 import {
+  EntryNodeId,
   Instance,
   InstanceId,
   Variant,
@@ -8,6 +9,7 @@ import {
 import {
   OperationResult,
   propagateNodeOperation,
+  propagatePositionalChildOperation,
 } from "./propagate-node-operation"
 
 export type { OperationResult }
@@ -26,6 +28,19 @@ export class WorkspacePropagationService {
     workspace: Workspace
   }): Workspace {
     return propagateNodeOperation(args)
+  }
+
+  /**
+   * Applies an operation to a child node and to the positionally matching child
+   * inside every instance of that child's parent.
+   */
+  public propagatePositionalChildOperation(args: {
+    childId: VariantId | InstanceId
+    propagation: "none" | "downstream" | "bidirectional"
+    applyToChild: (childId: EntryNodeId, workspace: Workspace) => Workspace
+    workspace: Workspace
+  }): Workspace {
+    return propagatePositionalChildOperation(args)
   }
 
   /** Parses a JSON string into a workspace. */

--- a/packages/editor/app/canvas/Node.tsx
+++ b/packages/editor/app/canvas/Node.tsx
@@ -27,6 +27,7 @@ import {
   type NodeState,
 } from "@seldon/core/workspace/model/node-state"
 import { useThemeById } from "@lib/themes/hooks/use-theme-by-id"
+import { useIsNodeSelected } from "@lib/workspace/hooks/use-selection"
 import { useWorkspace } from "@lib/workspace/hooks/use-workspace"
 import { useAddNodeFontFamily } from "./hooks/use-add-node-font-family"
 import { collectDescendantNodeIds } from "@lib/workspace/component-tree"
@@ -92,6 +93,10 @@ export const CanvasNode = memo(function CanvasNode({
 }: CanvasNodeProps) {
   const { workspace } = useWorkspace()
   const node = workspace.nodes[nodeId]
+
+  // Echoes share index 0's node id, so this is true for every copy of a
+  // repeated child whenever that child (index 0) is the current selection.
+  const isSelectedNode = useIsNodeSelected(nodeId)
 
   if (!node) {
     return null
@@ -207,12 +212,18 @@ export const CanvasNode = memo(function CanvasNode({
       ? { position: "absolute" as const }
       : { position: "relative" as const }
     : undefined
+  // The dotted outline marks the echo copies only, and only while the repeat
+  // is selected. Index 0 keeps its normal selection so it does not get dashed.
+  const showRepeatOutline = isRepeatCopy && isSelectedNode
   const styleOverrides =
-    positionOverride || isRepeatCopy
+    positionOverride || showRepeatOutline
       ? {
           ...positionOverride,
-          ...(isRepeatCopy
-            ? { outline: "1px dashed #6366f1", outlineOffset: "1px" }
+          ...(showRepeatOutline
+            ? {
+                outline: "1px dashed var(--sdn-seldon-swatch-primary)",
+                outlineOffset: "1px",
+              }
             : {}),
         }
       : undefined
@@ -261,7 +272,7 @@ export const CanvasNode = memo(function CanvasNode({
               rootPath={childRootPath}
               activeState={activeState}
               repeatOverrides={childOverrides}
-              isRepeatCopy
+              isRepeatCopy={isEcho}
             />
           )
         })

--- a/packages/editor/app/canvas/Node.tsx
+++ b/packages/editor/app/canvas/Node.tsx
@@ -10,9 +10,9 @@ import {
   InstanceId,
   MAX_REPEAT_COUNT,
   Properties,
+  ValueType,
   Variant,
   VariantId,
-  ValueType,
   invariant,
   resolveNodeRepeat,
 } from "@seldon/core"
@@ -264,7 +264,10 @@ export const CanvasNode = memo(function CanvasNode({
         return Array.from({ length: total }, (_, echoIndex) => {
           const isEcho = echoIndex > 0
           const childOverrides = isEcho
-            ? { ...repeatOverrides, ...buildEchoOverrides(childRepeat.data, echoIndex) }
+            ? {
+                ...repeatOverrides,
+                ...buildEchoOverrides(childRepeat.data, echoIndex),
+              }
             : repeatOverrides
           return (
             <CanvasNode

--- a/packages/editor/app/canvas/Node.tsx
+++ b/packages/editor/app/canvas/Node.tsx
@@ -13,9 +13,8 @@ import {
   Variant,
   VariantId,
   ValueType,
-  getNodeRepeat,
   invariant,
-  isMeaningfulRepeat,
+  resolveNodeRepeat,
 } from "@seldon/core"
 import { getComponentSchema } from "@seldon/core/components/catalog"
 import { ComponentId } from "@seldon/core/components/constants"
@@ -242,10 +241,12 @@ export const CanvasNode = memo(function CanvasNode({
     >
       {childNodeIds.flatMap((childNodeId) => {
         const childNode = workspace.nodes[childNodeId]
-        const childRepeat = childNode ? getNodeRepeat(childNode) : undefined
+        const childRepeat = childNode
+          ? resolveNodeRepeat(childNodeId, workspace)
+          : undefined
         const childRootPath = `${selfPath}/${childNodeId}`
 
-        if (!isMeaningfulRepeat(childRepeat)) {
+        if (!childRepeat || childRepeat.count <= 1) {
           return [
             <CanvasNode
               key={childNodeId}

--- a/packages/editor/app/canvas/Node.tsx
+++ b/packages/editor/app/canvas/Node.tsx
@@ -8,10 +8,14 @@ import {
   Display,
   Instance,
   InstanceId,
+  MAX_REPEAT_COUNT,
   Properties,
   Variant,
   VariantId,
+  ValueType,
+  getNodeRepeat,
   invariant,
+  isMeaningfulRepeat,
 } from "@seldon/core"
 import { getComponentSchema } from "@seldon/core/components/catalog"
 import { ComponentId } from "@seldon/core/components/constants"
@@ -50,13 +54,41 @@ export type CanvasNodeProps = {
    * whole tree renders the selected state. Defaults to Normal.
    */
   activeState?: NodeState
+  /**
+   * Per-echo text/icon preview values keyed by descendant node id, threaded
+   * down a repeated subtree. A matching descendant renders this value for its
+   * `content` (text) or `symbol` (icon) instead of its own. Editor preview only.
+   */
+  repeatOverrides?: Record<string, string>
+  /**
+   * True when this copy is one of a repeated child's renders (index 0 or an
+   * echo). Drives the dotted repeat-group outline. Editor preview only.
+   */
+  isRepeatCopy?: boolean
 }
+
+/** Per-echo override values for a repeated child's text/icon descendants. */
+function buildEchoOverrides(
+  data: Record<string, string[]> | undefined,
+  echoIndex: number,
+): Record<string, string> {
+  const result: Record<string, string> = {}
+  if (!data) return result
+  for (const [descendantId, values] of Object.entries(data)) {
+    const value = values[echoIndex - 1]
+    if (value != null) result[descendantId] = value
+  }
+  return result
+}
+
 export const CanvasNode = memo(function CanvasNode({
   nodeId,
   initialThemeId,
   isRoot = false,
   rootPath,
   activeState = NORMAL_STATE,
+  repeatOverrides,
+  isRepeatCopy = false,
 }: CanvasNodeProps) {
   const { workspace } = useWorkspace()
   const node = workspace.nodes[nodeId]
@@ -143,36 +175,97 @@ export const CanvasNode = memo(function CanvasNode({
   // A shared child id renders once per variant column. Scope the style class by
   // render position so each copy's computed CSS (e.g. an icon sized from its own
   // parent's buttonSize) does not collide on a single `node-<id>` selector.
+  // Repeat echoes share index 0's render position, so they intentionally share
+  // its style scope: one node painted N times, identical styling.
   const styleScopeId = selfPath.replace(/[^a-zA-Z0-9_-]/g, "-") as
     | InstanceId
     | VariantId
 
+  // Echoes of a repeated child preview a per-index text/icon value instead of
+  // the node's own. This is a render-only override; the node's stored content
+  // and symbol are untouched.
+  const repeatValue = repeatOverrides?.[nodeId]
+  let renderContext = computeContext
+  if (repeatValue != null) {
+    const overriddenProperties: Properties = { ...computeContext.properties }
+    if (catalogComponentId === ComponentId.ICON) {
+      overriddenProperties.symbol = {
+        type: ValueType.EXACT,
+        value: repeatValue as IconId,
+      }
+    } else {
+      overriddenProperties.content = {
+        type: ValueType.EXACT,
+        value: repeatValue,
+      }
+    }
+    renderContext = { ...computeContext, properties: overriddenProperties }
+  }
+
+  const positionOverride = isRoot
+    ? catalogComponentId === ComponentId.SANDBOX
+      ? { position: "absolute" as const }
+      : { position: "relative" as const }
+    : undefined
+  const styleOverrides =
+    positionOverride || isRepeatCopy
+      ? {
+          ...positionOverride,
+          ...(isRepeatCopy
+            ? { outline: "1px dashed #6366f1", outlineOffset: "1px" }
+            : {}),
+        }
+      : undefined
+
   return (
     <ComponentRenderer
-      computeContext={computeContext}
-      styleOverrides={
-        isRoot
-          ? catalogComponentId === ComponentId.SANDBOX
-            ? { position: "absolute" }
-            : { position: "relative" }
-          : undefined
-      }
+      computeContext={renderContext}
+      styleOverrides={styleOverrides}
       componentId={component.id}
       htmlAttributes={getHTMLAttributes(node, nodeProperties)}
       nodeId={styleScopeId}
       renderAsDiv={renderAsDiv}
       iconUnavailable={iconUnavailable}
     >
-      {childNodeIds.map((childNodeId) => (
-        <CanvasNode
-          key={childNodeId}
-          parentNode={node}
-          nodeId={childNodeId as InstanceId | VariantId}
-          initialThemeId={themeId as ThemeInstanceId}
-          rootPath={`${selfPath}/${childNodeId}`}
-          activeState={activeState}
-        />
-      ))}
+      {childNodeIds.flatMap((childNodeId) => {
+        const childNode = workspace.nodes[childNodeId]
+        const childRepeat = childNode ? getNodeRepeat(childNode) : undefined
+        const childRootPath = `${selfPath}/${childNodeId}`
+
+        if (!isMeaningfulRepeat(childRepeat)) {
+          return [
+            <CanvasNode
+              key={childNodeId}
+              parentNode={node}
+              nodeId={childNodeId as InstanceId | VariantId}
+              initialThemeId={themeId as ThemeInstanceId}
+              rootPath={childRootPath}
+              activeState={activeState}
+              repeatOverrides={repeatOverrides}
+            />,
+          ]
+        }
+
+        const total = Math.min(childRepeat.count, MAX_REPEAT_COUNT)
+        return Array.from({ length: total }, (_, echoIndex) => {
+          const isEcho = echoIndex > 0
+          const childOverrides = isEcho
+            ? { ...repeatOverrides, ...buildEchoOverrides(childRepeat.data, echoIndex) }
+            : repeatOverrides
+          return (
+            <CanvasNode
+              key={isEcho ? `${childNodeId}#echo${echoIndex}` : childNodeId}
+              parentNode={node}
+              nodeId={childNodeId as InstanceId | VariantId}
+              initialThemeId={themeId as ThemeInstanceId}
+              rootPath={childRootPath}
+              activeState={activeState}
+              repeatOverrides={childOverrides}
+              isRepeatCopy
+            />
+          )
+        })
+      })}
     </ComponentRenderer>
   )
 

--- a/packages/editor/app/canvas/Node.tsx
+++ b/packages/editor/app/canvas/Node.tsx
@@ -77,7 +77,9 @@ function buildEchoOverrides(
   if (!data) return result
   for (const [descendantId, values] of Object.entries(data)) {
     const value = values[echoIndex - 1]
-    if (value != null) result[descendantId] = value
+    // An empty slot (including the "" padding written for earlier-index edits)
+    // means "use the node's own value", not "override with an empty string".
+    if (value != null && value !== "") result[descendantId] = value
   }
   return result
 }

--- a/packages/editor/app/sidebars/objects/VMNode.tsx
+++ b/packages/editor/app/sidebars/objects/VMNode.tsx
@@ -1,10 +1,6 @@
 import { memo, type CSSProperties, type ReactElement } from "react"
 import { COLORS } from "@lib/helpers/colors"
-import {
-  MAX_REPEAT_COUNT,
-  getNodeRepeat,
-  isMeaningfulRepeat,
-} from "@seldon/core"
+import { MAX_REPEAT_COUNT, resolveNodeRepeat } from "@seldon/core"
 import type { EntryNode } from "@seldon/core/workspace/types"
 import { useRowHighlightStyle } from "@lib/workspace/hooks/use-object-hover"
 import { useIsNodeSelected } from "@lib/workspace/hooks/use-selection"
@@ -216,8 +212,10 @@ const VMNodeInner = function VMNodeInner({
     )
 
     const childNode = workspace.nodes[childNodeId]
-    const repeat = childNode ? getNodeRepeat(childNode) : undefined
-    if (!isMeaningfulRepeat(repeat)) return [indexZeroRow]
+    const repeat = childNode
+      ? resolveNodeRepeat(childNodeId, workspace)
+      : undefined
+    if (!repeat || repeat.count <= 1) return [indexZeroRow]
 
     const total = Math.min(repeat.count, MAX_REPEAT_COUNT)
     const echoCount = total - 1

--- a/packages/editor/app/sidebars/objects/VMNode.tsx
+++ b/packages/editor/app/sidebars/objects/VMNode.tsx
@@ -1,5 +1,5 @@
-import { memo, type CSSProperties, type ReactElement } from "react"
 import { COLORS } from "@lib/helpers/colors"
+import { type CSSProperties, type ReactElement, memo } from "react"
 import { MAX_REPEAT_COUNT, resolveNodeRepeat } from "@seldon/core"
 import type { EntryNode } from "@seldon/core/workspace/types"
 import { useRowHighlightStyle } from "@lib/workspace/hooks/use-object-hover"
@@ -47,7 +47,9 @@ function echoSelectedBorder(
     borderTopColor: showTop ? color : "transparent",
     borderBottomColor: isLast ? color : "transparent",
     ...(showTop ? {} : { borderTopLeftRadius: 0, borderTopRightRadius: 0 }),
-    ...(isLast ? {} : { borderBottomLeftRadius: 0, borderBottomRightRadius: 0 }),
+    ...(isLast
+      ? {}
+      : { borderBottomLeftRadius: 0, borderBottomRightRadius: 0 }),
   }
 }
 

--- a/packages/editor/app/sidebars/objects/VMNode.tsx
+++ b/packages/editor/app/sidebars/objects/VMNode.tsx
@@ -1,4 +1,5 @@
-import { memo, type ReactElement } from "react"
+import { memo, type CSSProperties, type ReactElement } from "react"
+import { COLORS } from "@lib/helpers/colors"
 import {
   MAX_REPEAT_COUNT,
   getNodeRepeat,
@@ -6,6 +7,7 @@ import {
 } from "@seldon/core"
 import type { EntryNode } from "@seldon/core/workspace/types"
 import { useRowHighlightStyle } from "@lib/workspace/hooks/use-object-hover"
+import { useIsNodeSelected } from "@lib/workspace/hooks/use-selection"
 import { useWorkspace } from "@lib/workspace/hooks/use-workspace"
 import { useSidebarCanvasTracking } from "../../tracking/hooks/use-sidebar-canvas-tracking"
 import { useSidebarRowStyling } from "../../tracking/hooks/use-sidebar-row-styling"
@@ -28,6 +30,31 @@ const NODE_SELECTION_KIND = "node"
 /** Most echo rows to list before collapsing the remainder into a summary row. */
 const ECHO_ROW_LIMIT = 6
 
+/**
+ * Selected-echo border. Recolors the row's existing border without touching its
+ * width, so no pixel shift occurs. Sides take the selection color; the top is
+ * colored only on the first echo when index 0 is open, the bottom only on the
+ * last echo. Corners are squared wherever the bracket does not close, so the
+ * stacked rows read as one box.
+ */
+function echoSelectedBorder(
+  isFirst: boolean,
+  isLast: boolean,
+  isExpanded: boolean,
+): CSSProperties {
+  const color = COLORS.primary[500]
+  const showTop = isFirst && isExpanded
+  return {
+    borderStyle: "dashed",
+    borderLeftColor: color,
+    borderRightColor: color,
+    borderTopColor: showTop ? color : "transparent",
+    borderBottomColor: isLast ? color : "transparent",
+    ...(showTop ? {} : { borderTopLeftRadius: 0, borderTopRightRadius: 0 }),
+    ...(isLast ? {} : { borderBottomLeftRadius: 0, borderBottomRightRadius: 0 }),
+  }
+}
+
 interface VMNodeProps {
   nodeId: string
   /**
@@ -44,10 +71,21 @@ interface VMNodeProps {
    * routes selection to the underlying node (index 0 of the repeat).
    */
   isEcho?: boolean
+  /** First row of the echo cluster. */
+  isFirstEcho?: boolean
+  /** Last row of the echo cluster. */
+  isLastEcho?: boolean
 }
 
-/** Muted summary row standing in for echo rows beyond {@link ECHO_ROW_LIMIT}. */
-function RepeatEchoSummaryRow({ count }: { count: number }) {
+/** Summary row standing in for echo rows beyond {@link ECHO_ROW_LIMIT}. */
+function RepeatEchoSummaryRow({
+  nodeId,
+  count,
+}: {
+  nodeId: string
+  count: number
+}) {
+  const isSelected = useIsNodeSelected(nodeId)
   return (
     <div
       style={{
@@ -55,6 +93,9 @@ function RepeatEchoSummaryRow({ count }: { count: number }) {
         fontStyle: "italic",
         opacity: 0.6,
         fontSize: 12,
+        border: "var(--hairline) solid transparent",
+        borderRadius: "var(--sdn-corners-tight)",
+        ...(isSelected ? echoSelectedBorder(false, true, false) : {}),
       }}
     >
       +{count} more
@@ -69,6 +110,8 @@ const VMNodeInner = function VMNodeInner({
   parentIsSelected,
   disableReordering,
   isEcho,
+  isFirstEcho,
+  isLastEcho,
 }: {
   node: EntryNode
   rootId: string
@@ -76,6 +119,8 @@ const VMNodeInner = function VMNodeInner({
   parentIsSelected: boolean
   disableReordering: boolean
   isEcho: boolean
+  isFirstEcho: boolean
+  isLastEcho: boolean
 }) {
   const { workspace } = useWorkspace({ usePreview: false })
   const {
@@ -106,11 +151,18 @@ const VMNodeInner = function VMNodeInner({
     isEcho,
   })
 
+  // Echoes share index 0's node id, so they read as selected with it. They show
+  // the dashed bracket instead of the solid selected box.
+  const rowSelected = isEcho ? false : isSelected
   const { rowStyle, iconColor, labelColor } = useSidebarRowStyling(node, {
-    isSelected,
+    isSelected: rowSelected,
   })
-  const hoverStyle = useRowHighlightStyle(node.id, isSelected, rootId)
-  const combinedRowStyle = { ...hoverStyle, ...rowStyle }
+  const hoverStyle = useRowHighlightStyle(node.id, rowSelected, rootId)
+  const echoBorder =
+    isEcho && isSelected
+      ? echoSelectedBorder(isFirstEcho, isLastEcho, isExpanded)
+      : undefined
+  const combinedRowStyle = { ...hoverStyle, ...rowStyle, ...echoBorder }
 
   const actionsMenu = useRowActionsMenu(actions, {
     color: iconColor,
@@ -150,9 +202,7 @@ const VMNodeInner = function VMNodeInner({
       ? properties.display?.value
       : undefined
 
-  // Expand a repeated child into its index-0 row plus stripped echo rows. Echo
-  // rows reuse index 0's rootId so selecting one routes to the same node and
-  // highlights the same canvas copy.
+  // Expand a repeated child into its index-0 row plus stripped echo rows.
   function renderChildRows(childNodeId: string): ReactElement[] {
     const childRootId = `${rootId}/${childNodeId}`
     const indexZeroRow = (
@@ -173,6 +223,7 @@ const VMNodeInner = function VMNodeInner({
     const echoCount = total - 1
     const shownEchoes = Math.min(echoCount, ECHO_ROW_LIMIT)
 
+    const hasSummary = echoCount > shownEchoes
     const rows: ReactElement[] = [indexZeroRow]
     for (let echoIndex = 1; echoIndex <= shownEchoes; echoIndex++) {
       rows.push(
@@ -183,13 +234,16 @@ const VMNodeInner = function VMNodeInner({
           show={show}
           parentIsSelected={isSelected}
           isEcho
+          isFirstEcho={echoIndex === 1}
+          isLastEcho={!hasSummary && echoIndex === shownEchoes}
         />,
       )
     }
-    if (echoCount > shownEchoes) {
+    if (hasSummary) {
       rows.push(
         <RepeatEchoSummaryRow
           key={`${childNodeId}#more`}
+          nodeId={childNodeId}
           count={echoCount - shownEchoes}
         />,
       )
@@ -259,6 +313,8 @@ export const VMNode = memo(function VMNode({
   parentIsSelected = false,
   disableReordering = false,
   isEcho = false,
+  isFirstEcho = false,
+  isLastEcho = false,
 }: VMNodeProps) {
   const { workspace } = useWorkspace({ usePreview: false })
   const node = getNode(workspace, nodeId)
@@ -273,6 +329,8 @@ export const VMNode = memo(function VMNode({
       parentIsSelected={parentIsSelected}
       disableReordering={disableReordering}
       isEcho={isEcho}
+      isFirstEcho={isFirstEcho}
+      isLastEcho={isLastEcho}
     />
   )
 })

--- a/packages/editor/app/sidebars/objects/VMNode.tsx
+++ b/packages/editor/app/sidebars/objects/VMNode.tsx
@@ -1,4 +1,9 @@
-import { memo } from "react"
+import { memo, type ReactElement } from "react"
+import {
+  MAX_REPEAT_COUNT,
+  getNodeRepeat,
+  isMeaningfulRepeat,
+} from "@seldon/core"
 import type { EntryNode } from "@seldon/core/workspace/types"
 import { useRowHighlightStyle } from "@lib/workspace/hooks/use-object-hover"
 import { useWorkspace } from "@lib/workspace/hooks/use-workspace"
@@ -20,6 +25,9 @@ import { RowSelectionTarget } from "./RowSelectionTarget"
 
 const NODE_SELECTION_KIND = "node"
 
+/** Most echo rows to list before collapsing the remainder into a summary row. */
+const ECHO_ROW_LIMIT = 6
+
 interface VMNodeProps {
   nodeId: string
   /**
@@ -31,6 +39,27 @@ interface VMNodeProps {
   show?: boolean
   parentIsSelected?: boolean
   disableReordering?: boolean
+  /**
+   * Render this row as a repeat echo: a stripped leaf with an italic label that
+   * routes selection to the underlying node (index 0 of the repeat).
+   */
+  isEcho?: boolean
+}
+
+/** Muted summary row standing in for echo rows beyond {@link ECHO_ROW_LIMIT}. */
+function RepeatEchoSummaryRow({ count }: { count: number }) {
+  return (
+    <div
+      style={{
+        padding: "2px 8px",
+        fontStyle: "italic",
+        opacity: 0.6,
+        fontSize: 12,
+      }}
+    >
+      +{count} more
+    </div>
+  )
 }
 
 const VMNodeInner = function VMNodeInner({
@@ -39,13 +68,16 @@ const VMNodeInner = function VMNodeInner({
   show,
   parentIsSelected,
   disableReordering,
+  isEcho,
 }: {
   node: EntryNode
   rootId: string
   show: boolean
   parentIsSelected: boolean
   disableReordering: boolean
+  isEcho: boolean
 }) {
+  const { workspace } = useWorkspace({ usePreview: false })
   const {
     label: baseLabel,
     buttonIconic,
@@ -71,6 +103,7 @@ const VMNodeInner = function VMNodeInner({
     show,
     parentIsSelected,
     disableReordering,
+    isEcho,
   })
 
   const { rowStyle, iconColor, labelColor } = useSidebarRowStyling(node, {
@@ -117,18 +150,57 @@ const VMNodeInner = function VMNodeInner({
       ? properties.display?.value
       : undefined
 
+  // Expand a repeated child into its index-0 row plus stripped echo rows. Echo
+  // rows reuse index 0's rootId so selecting one routes to the same node and
+  // highlights the same canvas copy.
+  function renderChildRows(childNodeId: string): ReactElement[] {
+    const childRootId = `${rootId}/${childNodeId}`
+    const indexZeroRow = (
+      <VMNode
+        key={childNodeId}
+        nodeId={childNodeId}
+        rootId={childRootId}
+        show={show}
+        parentIsSelected={isSelected}
+      />
+    )
+
+    const childNode = workspace.nodes[childNodeId]
+    const repeat = childNode ? getNodeRepeat(childNode) : undefined
+    if (!isMeaningfulRepeat(repeat)) return [indexZeroRow]
+
+    const total = Math.min(repeat.count, MAX_REPEAT_COUNT)
+    const echoCount = total - 1
+    const shownEchoes = Math.min(echoCount, ECHO_ROW_LIMIT)
+
+    const rows: ReactElement[] = [indexZeroRow]
+    for (let echoIndex = 1; echoIndex <= shownEchoes; echoIndex++) {
+      rows.push(
+        <VMNode
+          key={`${childNodeId}#echo${echoIndex}`}
+          nodeId={childNodeId}
+          rootId={childRootId}
+          show={show}
+          parentIsSelected={isSelected}
+          isEcho
+        />,
+      )
+    }
+    if (echoCount > shownEchoes) {
+      rows.push(
+        <RepeatEchoSummaryRow
+          key={`${childNodeId}#more`}
+          count={echoCount - shownEchoes}
+        />,
+      )
+    }
+    return rows
+  }
+
   const childrenSection = hasChildren ? (
     <FramerExpandable isExpanded={isExpanded}>
       <IndentationLevel>
-        {children.map((childNodeId) => (
-          <VMNode
-            key={childNodeId}
-            nodeId={childNodeId}
-            rootId={`${rootId}/${childNodeId}`}
-            show={show}
-            parentIsSelected={isSelected}
-          />
-        ))}
+        {children.flatMap((childNodeId) => renderChildRows(childNodeId))}
       </IndentationLevel>
     </FramerExpandable>
   ) : null
@@ -186,6 +258,7 @@ export const VMNode = memo(function VMNode({
   show = true,
   parentIsSelected = false,
   disableReordering = false,
+  isEcho = false,
 }: VMNodeProps) {
   const { workspace } = useWorkspace({ usePreview: false })
   const node = getNode(workspace, nodeId)
@@ -199,6 +272,7 @@ export const VMNode = memo(function VMNode({
       show={show}
       parentIsSelected={parentIsSelected}
       disableReordering={disableReordering}
+      isEcho={isEcho}
     />
   )
 })

--- a/packages/editor/app/sidebars/objects/hooks/use-row-node.ts
+++ b/packages/editor/app/sidebars/objects/hooks/use-row-node.ts
@@ -69,6 +69,12 @@ export function useRowNode(
     show?: boolean
     parentIsSelected?: boolean
     disableReordering?: boolean
+    /**
+     * Render this row as a repeat echo: a stripped leaf (no chevron, no child
+     * rows, no actions) with an italic label. Selection still routes to the
+     * underlying node, which is index 0 of the repeat.
+     */
+    isEcho?: boolean
   },
 ) {
   const { workspace, dispatch } = useWorkspace({ usePreview: false })
@@ -95,6 +101,7 @@ export function useRowNode(
   const show = options?.show ?? true
   const parentIsSelected = options?.parentIsSelected ?? false
   const disableReordering = options?.disableReordering ?? false
+  const isEcho = options?.isEcho ?? false
 
   const nodeExistsInWorkspace = hasNode(workspace, node.id)
   const properties: Properties = nodeExistsInWorkspace
@@ -103,7 +110,10 @@ export function useRowNode(
   const expandedId = node.id
   const isExpandedState = useIsExpanded(expandedId)
 
-  const children = nodeExistsInWorkspace ? getNodeChildIds(node, workspace) : []
+  // Echo rows are leaves: they never disclose children, which also renders an
+  // inert, transparent chevron via useRowButton.
+  const children =
+    !isEcho && nodeExistsInWorkspace ? getNodeChildIds(node, workspace) : []
   const hasChildren = children.length > 0
 
   // A child id is shared across variant columns, so match the selected copy by
@@ -177,6 +187,7 @@ export function useRowNode(
   }
 
   function handleDoubleClick() {
+    if (isEcho) return
     const entityType = typeCheckingService.getEntityType(node)
     if (rules.mutations.rename[entityType].allowed) {
       setEditingName(true)
@@ -504,7 +515,7 @@ export function useRowNode(
     return canReset ? [buildResetAction()] : []
   }
 
-  const actions: MenuEntry[] = buildNodeActions()
+  const actions: MenuEntry[] = isEcho ? [] : buildNodeActions()
 
   function checkIfExcluded(): boolean {
     if (!nodeExistsInWorkspace) {
@@ -540,9 +551,12 @@ export function useRowNode(
     return false
   }
 
-  const labelStyle: CSSProperties | undefined = checkIfExcluded()
+  const baseLabelStyle: CSSProperties | undefined = checkIfExcluded()
     ? { textDecoration: "line-through" }
     : undefined
+  const labelStyle: CSSProperties | undefined = isEcho
+    ? { ...baseLabelStyle, fontStyle: "italic", opacity: 0.7 }
+    : baseLabelStyle
 
   const label = {
     children: getNodeLabel(),

--- a/packages/editor/app/sidebars/properties/helpers/build-property-options.ts
+++ b/packages/editor/app/sidebars/properties/helpers/build-property-options.ts
@@ -103,7 +103,10 @@ export function buildPropertyOptions({
   // A repeat echo symbol row edits the `symbol` of an icon descendant. Resolve
   // it to the real symbol property against that descendant so every symbol path
   // below (options, current value, icon glyphs) runs unchanged.
-  const repeatSymbolDescendant = getRepeatSymbolDescendant(property.key, workspace)
+  const repeatSymbolDescendant = getRepeatSymbolDescendant(
+    property.key,
+    workspace,
+  )
   const effectiveProperty = repeatSymbolDescendant
     ? { ...property, key: "symbol" }
     : property
@@ -144,7 +147,11 @@ export function buildPropertyOptions({
     effectiveSubject ?? undefined,
   )
 
-  if (includeCurrentSymbol && effectiveProperty.key === "symbol" && result.options) {
+  if (
+    includeCurrentSymbol &&
+    effectiveProperty.key === "symbol" &&
+    result.options
+  ) {
     addCurrentSymbolOption(result.options, effectiveProperty)
   }
 

--- a/packages/editor/app/sidebars/properties/helpers/build-property-options.ts
+++ b/packages/editor/app/sidebars/properties/helpers/build-property-options.ts
@@ -15,6 +15,7 @@ import { getComponentKey } from "@lib/workspace/workspace-accessors"
 import { getComboboxStoredValue } from "./combobox-stored-value"
 import { PropertyPickerResult, generatePropertyOptions } from "./options-utils"
 import { FlatProperty } from "./properties-data"
+import { getRepeatSymbolDescendant } from "./repeat-display"
 
 type PropertyOptions = PropertyPickerResult["options"]
 type MaybePropertyOptions = PropertyOptions | undefined
@@ -99,49 +100,58 @@ export function buildPropertyOptions({
     return undefined
   }
 
+  // A repeat echo symbol row edits the `symbol` of an icon descendant. Resolve
+  // it to the real symbol property against that descendant so every symbol path
+  // below (options, current value, icon glyphs) runs unchanged.
+  const repeatSymbolDescendant = getRepeatSymbolDescendant(property.key, workspace)
+  const effectiveProperty = repeatSymbolDescendant
+    ? { ...property, key: "symbol" }
+    : property
+  const effectiveSubject = repeatSymbolDescendant ?? subject
+
   // Rows that carry their own options (font collection family rows) are not
   // backed by the property schema, so use the supplied options directly.
-  if (property.options) {
-    return [property.options]
+  if (effectiveProperty.options) {
+    return [effectiveProperty.options]
   }
 
-  if (property.key === "theme") {
+  if (effectiveProperty.key === "theme") {
     return [
       getThemePickerOptions({
         workspace,
-        allowInherit: !(subject && isBoard(subject)),
+        allowInherit: !(effectiveSubject && isBoard(effectiveSubject)),
       }),
     ]
   }
 
   const componentId: ComponentId | undefined =
-    subject && isBoard(subject)
-      ? (getComponentKey(subject) as ComponentId)
-      : subject
-        ? (getNodeCatalogComponentId(subject, workspace) ?? undefined)
+    effectiveSubject && isBoard(effectiveSubject)
+      ? (getComponentKey(effectiveSubject) as ComponentId)
+      : effectiveSubject
+        ? (getNodeCatalogComponentId(effectiveSubject, workspace) ?? undefined)
         : undefined
   const componentLevel: ComponentLevel | undefined =
-    subject && isBoard(subject)
+    effectiveSubject && isBoard(effectiveSubject)
       ? undefined
-      : (subject?.level as ComponentLevel | undefined)
+      : (effectiveSubject?.level as ComponentLevel | undefined)
 
   const result = generatePropertyOptions(
-    property,
+    effectiveProperty,
     theme,
     componentId,
     componentLevel,
     workspace,
-    subject ?? undefined,
+    effectiveSubject ?? undefined,
   )
 
-  if (includeCurrentSymbol && property.key === "symbol" && result.options) {
-    addCurrentSymbolOption(result.options, property)
+  if (includeCurrentSymbol && effectiveProperty.key === "symbol" && result.options) {
+    addCurrentSymbolOption(result.options, effectiveProperty)
   }
 
-  if (property.key === "listStyleType" && result.options) {
+  if (effectiveProperty.key === "listStyleType" && result.options) {
     const htmlElementValue =
-      subject && !isBoard(subject)
-        ? (getNodeProperties(subject, workspace).htmlElement?.value as
+      effectiveSubject && !isBoard(effectiveSubject)
+        ? (getNodeProperties(effectiveSubject, workspace).htmlElement?.value as
             | HtmlElement
             | undefined)
         : undefined

--- a/packages/editor/app/sidebars/properties/helpers/build-property-tree-layout.ts
+++ b/packages/editor/app/sidebars/properties/helpers/build-property-tree-layout.ts
@@ -22,6 +22,7 @@ import {
 } from "./icon-set-properties-data"
 import { FlatProperty } from "./properties-data"
 import { buildReferenceProperty } from "./reference-display"
+import { injectRepeatRows } from "./repeat-display"
 import { buildThemeAssignmentProperty } from "./theme-assignment-display"
 
 /** A reference is only editable where `setRef` rules allow it (boards excluded). */
@@ -112,7 +113,10 @@ export function buildPropertyTreeSections({
 
   const propertiesWithLeadingFields = isResourceType(node as Board)
     ? [...properties]
-    : [...buildLeadingNodeFieldRows(node, workspace), ...properties]
+    : [
+        ...buildLeadingNodeFieldRows(node, workspace),
+        ...injectRepeatRows(properties, node, workspace),
+      ]
 
   const regularSections = getPropertySections(
     propertiesWithLeadingFields,
@@ -176,5 +180,8 @@ export function buildPropertyTreeAllProperties({
     return [...properties]
   }
 
-  return [...buildLeadingNodeFieldRows(node, workspace), ...properties]
+  return [
+    ...buildLeadingNodeFieldRows(node, workspace),
+    ...injectRepeatRows(properties, node, workspace),
+  ]
 }

--- a/packages/editor/app/sidebars/properties/helpers/render-property-option-icon.tsx
+++ b/packages/editor/app/sidebars/properties/helpers/render-property-option-icon.tsx
@@ -15,6 +15,7 @@ import { IconSeldonToken } from "@seldon/components/icons"
 import { LoadEditorIcons, asSymbolIconId } from "@app/LoadEditorIcons"
 import { getBoardPresetIconId } from "./board-preset-icon"
 import { FlatProperty } from "./properties-data"
+import { getRepeatSymbolDescendant } from "./repeat-display"
 import { resolveThemeSwatchColors } from "./resolve-theme-swatch-colors"
 import { getThemeTokenIconColor } from "./theme-token-icon-color"
 
@@ -66,13 +67,12 @@ export function createPropertyOptionIconRenderer({
     }
 
     // The "Default" ("") and "Inherit" rows are not icon ids; let them fall
-    // through to the property's default icon.
-    if (
-      property.key === "symbol" &&
-      option &&
-      option.value &&
-      option.value !== "inherit"
-    ) {
+    // through to the property's default icon. Repeat echo symbol rows edit an
+    // icon descendant's `symbol`, so they render icon glyphs like the real one.
+    const isSymbolRow =
+      property.key === "symbol" ||
+      !!getRepeatSymbolDescendant(property.key, workspace)
+    if (isSymbolRow && option && option.value && option.value !== "inherit") {
       // Icon turned off in its workspace set renders as a red Missing icon.
       if (isWorkspaceIconUnavailable(option.value as IconId, workspace)) {
         return (

--- a/packages/editor/app/sidebars/properties/helpers/repeat-display.ts
+++ b/packages/editor/app/sidebars/properties/helpers/repeat-display.ts
@@ -1,0 +1,163 @@
+import {
+  Board,
+  Instance,
+  ValueType,
+  Variant,
+  Workspace,
+  getNodeRepeat,
+} from "@seldon/core"
+import { ComponentId } from "@seldon/core/components/constants"
+import { isBoard } from "@seldon/core/workspace/helpers/components/is-board"
+import { typeCheckingService } from "@seldon/core/workspace/services"
+import { collectDescendantNodeIds } from "@lib/workspace/component-tree"
+import {
+  findComponentForNode,
+  getNodeCatalogComponentId,
+} from "@lib/workspace/node-tree"
+import { getNode } from "@lib/workspace/workspace-accessors"
+import { FlatProperty } from "./properties-data"
+
+/** Synthetic compound key for the editor-only Repeat row. */
+export const REPEAT_ROW_KEY = "repeat"
+
+const EMPTY_VALUE = { type: ValueType.EMPTY, value: null }
+
+/** A text/icon descendant that can carry per-echo prototyping values. */
+interface RepeatDataDescendant {
+  id: string
+  label: string
+  /** Which property the echo value overrides on the canvas. */
+  slot: "content" | "symbol"
+}
+
+/**
+ * Repeat is an instance-only (child) capability. Default and user variant roots
+ * are the component itself and never repeat.
+ */
+export function isRepeatEligible(
+  node: Variant | Instance | Board,
+): node is Instance {
+  if (isBoard(node)) return false
+  return typeCheckingService.isInstance(node)
+}
+
+/** Text/icon descendants of a node, in tree order, as repeat data slots. */
+export function getRepeatDataDescendants(
+  node: Variant | Instance,
+  workspace: Workspace,
+): RepeatDataDescendant[] {
+  const board = findComponentForNode(node, workspace)
+  if (!board) return []
+  const descendants: RepeatDataDescendant[] = []
+  for (const descendantId of collectDescendantNodeIds(board, node.id)) {
+    const descendant = getNode(workspace, descendantId)
+    if (!descendant) continue
+    const componentId = getNodeCatalogComponentId(descendant, workspace)
+    if (componentId === ComponentId.ICON) {
+      descendants.push({ id: descendantId, label: descendant.label, slot: "symbol" })
+    } else if (componentId === ComponentId.TEXT) {
+      descendants.push({ id: descendantId, label: descendant.label, slot: "content" })
+    }
+  }
+  return descendants
+}
+
+/** Key for a per-echo data row. Uses "#" so the key stays a single child segment. */
+export function repeatDataRowKey(descendantId: string, echoIndex: number): string {
+  return `${REPEAT_ROW_KEY}.${descendantId}#${echoIndex}`
+}
+
+/** Parses a data-row key back into its descendant id and echo index. */
+export function parseRepeatDataRowKey(
+  key: string,
+): { descendantId: string; echoIndex: number } | null {
+  const prefix = `${REPEAT_ROW_KEY}.`
+  if (!key.startsWith(prefix)) return null
+  const rest = key.slice(prefix.length)
+  const hashIndex = rest.lastIndexOf("#")
+  if (hashIndex <= 0) return null
+  const descendantId = rest.slice(0, hashIndex)
+  const echoIndex = Number.parseInt(rest.slice(hashIndex + 1), 10)
+  if (!descendantId || !Number.isInteger(echoIndex) || echoIndex < 1) return null
+  return { descendantId, echoIndex }
+}
+
+/**
+ * Builds the synthetic Repeat rows for a node: a compound count row plus, when
+ * the count is above 1, one text row per echo for every text/icon descendant.
+ * Returns an empty list for nodes that cannot repeat.
+ */
+export function buildRepeatRows(
+  node: Variant | Instance | Board,
+  workspace: Workspace,
+): FlatProperty[] {
+  if (!isRepeatEligible(node)) return []
+
+  const repeat = getNodeRepeat(node)
+  const count = repeat?.count ?? 1
+
+  const parent: FlatProperty = {
+    key: REPEAT_ROW_KEY,
+    propertyType: "compound",
+    label: "Repeat",
+    icon: "seldon-component",
+    value: { type: ValueType.EXACT, value: count },
+    actualValue: String(count),
+    valueType: ValueType.EXACT,
+    controlType: "number",
+    isCompound: true,
+    isShorthand: false,
+    isSubProperty: false,
+    status: count > 1 ? "set" : "unset",
+  }
+
+  const rows: FlatProperty[] = [parent]
+
+  if (count > 1) {
+    const descendants = getRepeatDataDescendants(node, workspace)
+    for (const descendant of descendants) {
+      const values = repeat?.data?.[descendant.id] ?? []
+      for (let echoIndex = 1; echoIndex <= count - 1; echoIndex++) {
+        const current = values[echoIndex - 1]
+        rows.push({
+          key: repeatDataRowKey(descendant.id, echoIndex),
+          propertyType: "atomic",
+          label: `${descendant.label} ${echoIndex + 1}`,
+          icon: "seldon-token",
+          value: current ? { type: ValueType.EXACT, value: current } : EMPTY_VALUE,
+          actualValue: current ?? "",
+          valueType: current ? ValueType.EXACT : ValueType.EMPTY,
+          controlType: "text",
+          isCompound: false,
+          isShorthand: false,
+          isSubProperty: true,
+          status: current ? "set" : "unset",
+        })
+      }
+    }
+  }
+
+  return rows
+}
+
+/**
+ * Inserts the Repeat rows into a flat property list, just above the `cursor`
+ * row when present, otherwise at the front. Returns the input unchanged for
+ * nodes that cannot repeat.
+ */
+export function injectRepeatRows(
+  properties: FlatProperty[],
+  node: Variant | Instance | Board,
+  workspace: Workspace,
+): FlatProperty[] {
+  const repeatRows = buildRepeatRows(node, workspace)
+  if (repeatRows.length === 0) return properties
+
+  const cursorIndex = properties.findIndex((property) => property.key === "cursor")
+  const insertAt = cursorIndex >= 0 ? cursorIndex : 0
+  return [
+    ...properties.slice(0, insertAt),
+    ...repeatRows,
+    ...properties.slice(insertAt),
+  ]
+}

--- a/packages/editor/app/sidebars/properties/helpers/repeat-display.ts
+++ b/packages/editor/app/sidebars/properties/helpers/repeat-display.ts
@@ -5,6 +5,8 @@ import {
   Variant,
   Workspace,
   getNodeRepeat,
+  resolveInheritedRepeatData,
+  resolveNodeRepeat,
 } from "@seldon/core"
 import { ComponentId } from "@seldon/core/components/constants"
 import { isBoard } from "@seldon/core/workspace/helpers/components/is-board"
@@ -115,7 +117,9 @@ export function buildRepeatRows(
 ): FlatProperty[] {
   if (!isRepeatEligible(node)) return []
 
-  const repeat = getNodeRepeat(node)
+  const repeat = resolveNodeRepeat(node.id, workspace)
+  const ownRepeat = getNodeRepeat(node)
+  const inheritedData = resolveInheritedRepeatData(node.id, workspace)
   const count = repeat?.count ?? 1
 
   const parent: FlatProperty = {
@@ -146,6 +150,16 @@ export function buildRepeatRows(
       for (const descendant of descendants) {
         const values = repeat?.data?.[descendant.id] ?? []
         const current = values[echoIndex - 1]
+
+        // A slot is an override when this node sets its own value for the echo and
+        // it diverges from the inherited slot (empty when this node owns the
+        // repeat). An explicit per-echo value is a deviation from the index[0]
+        // base, so it shows blue.
+        const ownValue = ownRepeat?.data?.[descendant.id]?.[echoIndex - 1]
+        const inheritedValue = inheritedData[descendant.id]?.[echoIndex - 1] ?? ""
+        const hasOwn = ownValue != null && ownValue !== ""
+        const isOverride = hasOwn && ownValue !== inheritedValue
+
         rows.push({
           key: repeatDataRowKey(descendant.id, echoIndex),
           propertyType: "atomic",
@@ -158,7 +172,7 @@ export function buildRepeatRows(
           isCompound: false,
           isShorthand: false,
           isSubProperty: true,
-          status: current ? "set" : "unset",
+          status: isOverride ? "override" : current ? "set" : "unset",
         })
       }
     }

--- a/packages/editor/app/sidebars/properties/helpers/repeat-display.ts
+++ b/packages/editor/app/sidebars/properties/helpers/repeat-display.ts
@@ -83,6 +83,28 @@ export function parseRepeatDataRowKey(
 }
 
 /**
+ * Returns the icon descendant a repeat echo symbol row edits, or null when the
+ * key is not a repeat symbol row. Lets the symbol-picker UI treat the echo row
+ * exactly like the real `symbol` property.
+ */
+export function getRepeatSymbolDescendant(
+  key: string,
+  workspace: Workspace,
+): Variant | Instance | null {
+  const repeatRow = parseRepeatDataRowKey(key)
+  if (!repeatRow) return null
+  const descendant = getNode(workspace, repeatRow.descendantId)
+  if (
+    !descendant ||
+    isBoard(descendant) ||
+    getNodeCatalogComponentId(descendant, workspace) !== ComponentId.ICON
+  ) {
+    return null
+  }
+  return descendant
+}
+
+/**
  * Builds the synthetic Repeat rows for a node: a compound count row plus, when
  * the count is above 1, one text row per echo for every text/icon descendant.
  * Returns an empty list for nodes that cannot repeat.
@@ -115,9 +137,14 @@ export function buildRepeatRows(
 
   if (count > 1) {
     const descendants = getRepeatDataDescendants(node, workspace)
-    for (const descendant of descendants) {
-      const values = repeat?.data?.[descendant.id] ?? []
-      for (let echoIndex = 1; echoIndex <= count - 1; echoIndex++) {
+
+    // Cluster by echo (the repeated copy), then by descendant in tree order:
+    // "Icon 2, Label 2, Icon 3, Label 3" rather than grouping all icons first.
+    // Symbol rows render a combo whose options are generated against the icon
+    // descendant in build-property-options, matching the real symbol picker.
+    for (let echoIndex = 1; echoIndex <= count - 1; echoIndex++) {
+      for (const descendant of descendants) {
+        const values = repeat?.data?.[descendant.id] ?? []
         const current = values[echoIndex - 1]
         rows.push({
           key: repeatDataRowKey(descendant.id, echoIndex),
@@ -127,7 +154,7 @@ export function buildRepeatRows(
           value: current ? { type: ValueType.EXACT, value: current } : EMPTY_VALUE,
           actualValue: current ?? "",
           valueType: current ? ValueType.EXACT : ValueType.EMPTY,
-          controlType: "text",
+          controlType: descendant.slot === "symbol" ? "combo" : "text",
           isCompound: false,
           isShorthand: false,
           isSubProperty: true,

--- a/packages/editor/app/sidebars/properties/helpers/repeat-display.ts
+++ b/packages/editor/app/sidebars/properties/helpers/repeat-display.ts
@@ -56,16 +56,27 @@ export function getRepeatDataDescendants(
     if (!descendant) continue
     const componentId = getNodeCatalogComponentId(descendant, workspace)
     if (componentId === ComponentId.ICON) {
-      descendants.push({ id: descendantId, label: descendant.label, slot: "symbol" })
+      descendants.push({
+        id: descendantId,
+        label: descendant.label,
+        slot: "symbol",
+      })
     } else if (componentId === ComponentId.TEXT) {
-      descendants.push({ id: descendantId, label: descendant.label, slot: "content" })
+      descendants.push({
+        id: descendantId,
+        label: descendant.label,
+        slot: "content",
+      })
     }
   }
   return descendants
 }
 
 /** Key for a per-echo data row. Uses "#" so the key stays a single child segment. */
-export function repeatDataRowKey(descendantId: string, echoIndex: number): string {
+export function repeatDataRowKey(
+  descendantId: string,
+  echoIndex: number,
+): string {
   return `${REPEAT_ROW_KEY}.${descendantId}#${echoIndex}`
 }
 
@@ -80,7 +91,8 @@ export function parseRepeatDataRowKey(
   if (hashIndex <= 0) return null
   const descendantId = rest.slice(0, hashIndex)
   const echoIndex = Number.parseInt(rest.slice(hashIndex + 1), 10)
-  if (!descendantId || !Number.isInteger(echoIndex) || echoIndex < 1) return null
+  if (!descendantId || !Number.isInteger(echoIndex) || echoIndex < 1)
+    return null
   return { descendantId, echoIndex }
 }
 
@@ -156,7 +168,8 @@ export function buildRepeatRows(
         // repeat). An explicit per-echo value is a deviation from the index[0]
         // base, so it shows blue.
         const ownValue = ownRepeat?.data?.[descendant.id]?.[echoIndex - 1]
-        const inheritedValue = inheritedData[descendant.id]?.[echoIndex - 1] ?? ""
+        const inheritedValue =
+          inheritedData[descendant.id]?.[echoIndex - 1] ?? ""
         const hasOwn = ownValue != null && ownValue !== ""
         const isOverride = hasOwn && ownValue !== inheritedValue
 
@@ -165,7 +178,9 @@ export function buildRepeatRows(
           propertyType: "atomic",
           label: `${descendant.label} ${echoIndex + 1}`,
           icon: "seldon-token",
-          value: current ? { type: ValueType.EXACT, value: current } : EMPTY_VALUE,
+          value: current
+            ? { type: ValueType.EXACT, value: current }
+            : EMPTY_VALUE,
           actualValue: current ?? "",
           valueType: current ? ValueType.EXACT : ValueType.EMPTY,
           controlType: descendant.slot === "symbol" ? "combo" : "text",
@@ -194,7 +209,9 @@ export function injectRepeatRows(
   const repeatRows = buildRepeatRows(node, workspace)
   if (repeatRows.length === 0) return properties
 
-  const cursorIndex = properties.findIndex((property) => property.key === "cursor")
+  const cursorIndex = properties.findIndex(
+    (property) => property.key === "cursor",
+  )
   const insertAt = cursorIndex >= 0 ? cursorIndex : 0
   return [
     ...properties.slice(0, insertAt),

--- a/packages/editor/app/sidebars/properties/hooks/use-commit-property-value.ts
+++ b/packages/editor/app/sidebars/properties/hooks/use-commit-property-value.ts
@@ -37,6 +37,11 @@ import {
 import type { PropertyPickerResult } from "../helpers/options-utils"
 import { getPropertiesSubjectId } from "../helpers/properties-data"
 import { FlatProperty } from "../helpers/properties-data"
+import {
+  REPEAT_ROW_KEY,
+  parseRepeatDataRowKey,
+} from "../helpers/repeat-display"
+import { useSetNodeRepeat } from "./use-set-node-repeat"
 import { RESET_VALUES } from "../helpers/property-control-constants"
 import { shouldUsePresetPropertyBehavior } from "../helpers/property-types"
 import { updateProperty } from "../helpers/property-update-handler"
@@ -82,6 +87,8 @@ export function useCommitPropertyValue({
   const { selection } = useSelection()
   const setObjectTheme = useSetObjectTheme()
   const setObjectReference = useSetObjectReference()
+  const { setCount: setNodeRepeatCount, setDataValue: setNodeRepeatDataValue } =
+    useSetNodeRepeat()
   const { show: showUploadPanel } = useImageUploadPanel()
 
   const reset = useCallback(() => {
@@ -251,6 +258,28 @@ export function useCommitPropertyValue({
         return
       }
 
+      // The editor-only Repeat row and its per-echo data rows write through the
+      // repeat command, which preserves other `__editor` keys. The count row is
+      // the compound parent; data rows key the descendant id and echo index.
+      if (subject && !isBoard(subject)) {
+        if (property.key === REPEAT_ROW_KEY) {
+          setNodeRepeatCount(subject.id, Number.parseInt(newValue, 10))
+          onDone()
+          return
+        }
+        const dataSlot = parseRepeatDataRowKey(property.key)
+        if (dataSlot) {
+          setNodeRepeatDataValue(
+            subject.id,
+            dataSlot.descendantId,
+            dataSlot.echoIndex,
+            newValue,
+          )
+          onDone()
+          return
+        }
+      }
+
       if (newValue === "__upload__") {
         const supportsUpload =
           property.key === "source" ||
@@ -375,6 +404,8 @@ export function useCommitPropertyValue({
       setProperties,
       setObjectTheme,
       setObjectReference,
+      setNodeRepeatCount,
+      setNodeRepeatDataValue,
       showUploadPanel,
       themeEditingContext,
       fontCollectionEditingContext,

--- a/packages/editor/app/sidebars/properties/hooks/use-commit-property-value.ts
+++ b/packages/editor/app/sidebars/properties/hooks/use-commit-property-value.ts
@@ -37,14 +37,14 @@ import {
 import type { PropertyPickerResult } from "../helpers/options-utils"
 import { getPropertiesSubjectId } from "../helpers/properties-data"
 import { FlatProperty } from "../helpers/properties-data"
+import { RESET_VALUES } from "../helpers/property-control-constants"
+import { shouldUsePresetPropertyBehavior } from "../helpers/property-types"
+import { updateProperty } from "../helpers/property-update-handler"
 import {
   REPEAT_ROW_KEY,
   parseRepeatDataRowKey,
 } from "../helpers/repeat-display"
 import { useSetNodeRepeat } from "./use-set-node-repeat"
-import { RESET_VALUES } from "../helpers/property-control-constants"
-import { shouldUsePresetPropertyBehavior } from "../helpers/property-types"
-import { updateProperty } from "../helpers/property-update-handler"
 import { useSetObjectReference } from "./use-set-object-reference"
 import { useSetObjectTheme } from "./use-set-object-theme"
 

--- a/packages/editor/app/sidebars/properties/hooks/use-property-control-data.ts
+++ b/packages/editor/app/sidebars/properties/hooks/use-property-control-data.ts
@@ -2,6 +2,7 @@ import { Theme, Value, ValueType } from "@seldon/core"
 import { getUnitsForProperty } from "@seldon/core/properties"
 import { FlatProperty } from "../helpers/properties-data"
 import { shouldUsePresetPropertyBehavior } from "../helpers/property-types"
+import { REPEAT_ROW_KEY } from "../helpers/repeat-display"
 import { getPropertyPlaceholder } from "../helpers/shared-utils"
 
 interface UsePropertyControlDataOptions {
@@ -177,7 +178,9 @@ export function usePropertyControlData({
       property.key === "core.ratio" ||
       property.key === "core.size" ||
       property.key.startsWith("fontWeight.") ||
-      property.key.endsWith(".step")
+      property.key.endsWith(".step") ||
+      property.key === REPEAT_ROW_KEY ||
+      property.key.startsWith(`${REPEAT_ROW_KEY}.`)
     ) {
       return undefined
     }

--- a/packages/editor/app/sidebars/properties/hooks/use-set-node-repeat.ts
+++ b/packages/editor/app/sidebars/properties/hooks/use-set-node-repeat.ts
@@ -49,7 +49,12 @@ export function useSetNodeRepeat() {
   )
 
   const setDataValue = useCallback(
-    (nodeId: NodeId, descendantId: string, echoIndex: number, value: string) => {
+    (
+      nodeId: NodeId,
+      descendantId: string,
+      echoIndex: number,
+      value: string,
+    ) => {
       // Echo count is the effective (possibly inherited) value, but the edit is
       // stored as an override on this node only.
       const resolved = resolveNodeRepeat(nodeId, workspace)

--- a/packages/editor/app/sidebars/properties/hooks/use-set-node-repeat.ts
+++ b/packages/editor/app/sidebars/properties/hooks/use-set-node-repeat.ts
@@ -1,0 +1,75 @@
+import { useCallback } from "react"
+import {
+  type InstanceId,
+  type RepeatEditorData,
+  type VariantId,
+  getNodeRepeat,
+} from "@seldon/core"
+import { useWorkspace } from "@lib/workspace/hooks/use-workspace"
+
+type NodeId = VariantId | InstanceId
+
+/**
+ * Repeat-assignment commands for the editor-only repeat preview. Owns the
+ * `set_node_repeat` dispatch so property controls stay binding shells. Reads the
+ * node's current repeat so a count change trims stale echo data and a data edit
+ * preserves the rest.
+ */
+export function useSetNodeRepeat() {
+  const { workspace, dispatch } = useWorkspace({ usePreview: false })
+
+  const setCount = useCallback(
+    (nodeId: NodeId, count: number) => {
+      if (!Number.isFinite(count) || count <= 1) {
+        dispatch({
+          type: "set_node_repeat",
+          payload: { nodeId, repeat: undefined },
+        })
+        return
+      }
+
+      const current = getNodeRepeat(workspace.nodes[nodeId] ?? {})
+      const echoSlots = count - 1
+      let data: RepeatEditorData["data"]
+      if (current?.data) {
+        const trimmed: Record<string, string[]> = {}
+        for (const [key, values] of Object.entries(current.data)) {
+          trimmed[key] = values.slice(0, echoSlots)
+        }
+        data = trimmed
+      }
+
+      dispatch({
+        type: "set_node_repeat",
+        payload: { nodeId, repeat: { count, ...(data ? { data } : {}) } },
+      })
+    },
+    [workspace, dispatch],
+  )
+
+  const setDataValue = useCallback(
+    (nodeId: NodeId, descendantId: string, echoIndex: number, value: string) => {
+      const current = getNodeRepeat(workspace.nodes[nodeId] ?? {})
+      if (!current || current.count <= 1) return
+
+      const echoSlots = current.count - 1
+      const data: Record<string, string[]> = {}
+      for (const [key, values] of Object.entries(current.data ?? {})) {
+        data[key] = [...values]
+      }
+
+      const slotValues = data[descendantId] ? [...data[descendantId]] : []
+      while (slotValues.length < echoSlots) slotValues.push("")
+      slotValues[echoIndex - 1] = value
+      data[descendantId] = slotValues.slice(0, echoSlots)
+
+      dispatch({
+        type: "set_node_repeat",
+        payload: { nodeId, repeat: { count: current.count, data } },
+      })
+    },
+    [workspace, dispatch],
+  )
+
+  return { setCount, setDataValue }
+}

--- a/packages/editor/app/sidebars/properties/hooks/use-set-node-repeat.ts
+++ b/packages/editor/app/sidebars/properties/hooks/use-set-node-repeat.ts
@@ -4,6 +4,7 @@ import {
   type RepeatEditorData,
   type VariantId,
   getNodeRepeat,
+  resolveNodeRepeat,
 } from "@seldon/core"
 import { useWorkspace } from "@lib/workspace/hooks/use-workspace"
 
@@ -49,12 +50,15 @@ export function useSetNodeRepeat() {
 
   const setDataValue = useCallback(
     (nodeId: NodeId, descendantId: string, echoIndex: number, value: string) => {
-      const current = getNodeRepeat(workspace.nodes[nodeId] ?? {})
-      if (!current || current.count <= 1) return
+      // Echo count is the effective (possibly inherited) value, but the edit is
+      // stored as an override on this node only.
+      const resolved = resolveNodeRepeat(nodeId, workspace)
+      if (!resolved || resolved.count <= 1) return
 
-      const echoSlots = current.count - 1
+      const echoSlots = resolved.count - 1
+      const own = getNodeRepeat(workspace.nodes[nodeId] ?? {})
       const data: Record<string, string[]> = {}
-      for (const [key, values] of Object.entries(current.data ?? {})) {
+      for (const [key, values] of Object.entries(own?.data ?? {})) {
         data[key] = [...values]
       }
 
@@ -63,9 +67,15 @@ export function useSetNodeRepeat() {
       slotValues[echoIndex - 1] = value
       data[descendantId] = slotValues.slice(0, echoSlots)
 
+      // Keep an explicit own count only when this node already set one. A node
+      // that inherits its count stores a data-only override so the count keeps
+      // tracking the template.
+      const repeat: RepeatEditorData =
+        own?.count != null ? { count: own.count, data } : { data }
+
       dispatch({
         type: "set_node_repeat",
-        payload: { nodeId, repeat: { count: current.count, data } },
+        payload: { nodeId, repeat },
       })
     },
     [workspace, dispatch],


### PR DESCRIPTION
## 📝 Description

Adds an editor-only **Repeat** capability that paints a single child node N times on the canvas for visualization and prototyping. Index 0 is the only real, selectable node; the remaining copies are render-only echoes that can preview per-index text/icon prototyping values. All state lives in node `__editor.repeat`, so the factory keeps ignoring it and export is unchanged.

**Core**
- New `set_node_repeat` action with a merge-safe service mutation that preserves other `__editor` keys (e.g. `initialOverrides`).
- `node-repeat` helper with `RepeatEditorData` (optional `count` to support data-only overrides), accessors, and the `MAX_REPEAT_COUNT` (50) ceiling plus a nested-expansion guard.
- New `resolve-node-repeat` read-time resolver: a repeated child inherits its template's matching child repeat and layers its own overrides on top, remapping descendant ids by tree position. An explicit per-echo value wins over the inherited slot.
- Validation for the repeat structure, including the count cap and nested-expansion guard over ancestor repeat counts.
- `propagatePositionalChildOperation` for parent-rooted, positional propagation; `remove_instance` now propagates deletions positionally to instance children.

**Editor**
- Canvas expands a repeated child into N copies; echoes share index 0's render position and selection identity, thread content/symbol overrides recursively, and show a dashed repeat-group outline only on the echo copies (not index 0).
- Objects tree renders index 0 plus stripped italic echo rows with consistent borders (transparent reserved in every state to avoid pixel shift) and a bracket-style dashed selection border; echo selection routes to index 0.
- Properties sidebar shows a **Repeat** compound row above `cursor` with a count control and per-echo text/icon data rows, clustered by echo. Symbol echo rows reuse the real symbol picker (grouping and glyph previews). The count value renders without a `PX` unit. Echo slots that diverge from the inherited value show the blue override indicator.

## 🔗 Related Issues

_None_

## 🧪 Type of Change

- ✨ New feature

## 📦 Affected Packages

- `@seldon/core`
- `@seldon/editor`

## 📸 Screenshots/Videos

_N/A_

## 🔍 Code Quality Checklist

- Code follows the project's style guidelines
- Self-review of the code has been performed
- Code is properly commented, particularly in hard-to-understand areas
- No console.log statements or debugging code left in
- TypeScript types are properly defined, no use of "as any"
- No unused imports or variables

## 📋 Breaking Changes

_None._ Repeat data lives in `__editor.repeat`; the factory ignores it and export is unchanged.

## 🚀 Deployment Notes

_None._ No migration is required; `metadata.version` is unchanged and nodes without `__editor.repeat` behave as before.

## 📚 Documentation Updates

`packages/core/workspace/reducers/README.md` updated to list the new `set_node_repeat` action.

## ⚠️ Additional Notes

Phase 1 is editor-only. The repeat `count` and prototyping data are not promoted to core properties yet, so there is no `.map()` export lowering. Repeats are capped at 50, with a nested-expansion guard across ancestor repeats.

---

I have read the CLA and I agree to its terms.

SeldonDigital
AndreiSeldon