### PR TITLE
Feature/ordinal component

### DIFF
--- a/.cursor/rules/components.mdc
+++ b/.cursor/rules/components.mdc
@@ -116,6 +116,8 @@ variants: [
 
 Use `overrides` in component schemas. Overrides must use full typed property values and are matched against the target child schema. Unknown override keys are dropped by merge logic. Do not invent child properties that the referenced schema does not expose.
 
+Inline every `overrides` object literal at its child. Do not hoist an `overrides` block into a module `const` and reference it from children. Repeat the literal for each child even when several children share the same values. Schema files read as flat, self-contained data, and a shared const both hides the per-child values and makes every child point at the same object reference. This applies to child `overrides`, variant root `overrides`, and any nested property object inside them. The only module-level values a schema file declares are the `schema` export and its `exportConfig`.
+
 When a child uses a family variant, set `variant: "<variantId>"` to point at it. After consolidating or removing a schema, update every reference to the new family id and variant, and remove the old `ComponentId` entries. Renaming a schema does not rename its `ComponentId`. Change the id only when you intend to update all references.
 
 Use `@token.id` for theme references, e.g. `@swatch.primary`, `@size.medium`, `@font.body`. 

--- a/.cursor/rules/engineering.mdc
+++ b/.cursor/rules/engineering.mdc
@@ -17,6 +17,7 @@ Use the local code first. Follow nearby patterns, public APIs, and domain rules 
 - All comments should be about current behavior, not legacy, deprecated, past behavior, or anything that is not relevant going forward. 
 - Do not add comments that are obvious or referential to markdown files. 
 - Add JSDocs as needed.
+- In `*.schema.ts` files, inline every property and `overrides` object literal at its child. Do not hoist shared schema values into a module `const` and reuse it. The only module-level values are the `schema` export and its `exportConfig`. See `.cursor/rules/components.mdc`.
 
 ### Naming
 

--- a/packages/core/components/catalog/elements/Button.schema.ts
+++ b/packages/core/components/catalog/elements/Button.schema.ts
@@ -208,6 +208,10 @@ export const schema = {
             type: Sdn.ValueType.EXACT,
             value: "Button",
           },
+          cursor: {
+            type: Sdn.ValueType.OPTION,
+            value: Sdn.Cursor.POINTER,
+          },
           color: {
             type: Sdn.ValueType.COMPUTED,
             value: Sdn.ComputedFunction.HIGH_CONTRAST_COLOR,

--- a/packages/core/components/catalog/elements/Button.schema.ts
+++ b/packages/core/components/catalog/elements/Button.schema.ts
@@ -279,6 +279,167 @@ export const schema = {
       ],
     },
     {
+      id: "menu",
+      label: "Menu",
+      intent:
+        "Dropdown menu button pairing a label with a chevron that reveals more options.",
+      overrides: {
+        buttonSize: {
+          type: Sdn.ValueType.THEME_ORDINAL,
+          value: "@fontSize.small",
+        },
+        padding: {
+          top: {
+            type: Sdn.ValueType.THEME_ORDINAL,
+            value: "@padding.tight",
+          },
+          right: {
+            type: Sdn.ValueType.THEME_ORDINAL,
+            value: "@padding.compact",
+          },
+          bottom: {
+            type: Sdn.ValueType.THEME_ORDINAL,
+            value: "@padding.tight",
+          },
+          left: {
+            type: Sdn.ValueType.THEME_ORDINAL,
+            value: "@padding.compact",
+          },
+        },
+        background: [
+          {
+            kind: {
+              type: Sdn.ValueType.OPTION,
+              value: Sdn.BackgroundKind.COLOR,
+            },
+            color: {
+              type: Sdn.ValueType.THEME_CATEGORICAL,
+              value: "@swatch.offWhite",
+            },
+            brightness: { type: Sdn.ValueType.EMPTY, value: null },
+            opacity: { type: Sdn.ValueType.EMPTY, value: null },
+          },
+        ],
+        border: {
+          width: {
+            type: Sdn.ValueType.OPTION,
+            value: Sdn.BorderWidth.HAIRLINE,
+          },
+          color: {
+            type: Sdn.ValueType.THEME_CATEGORICAL,
+            value: "@swatch.offBlack",
+          },
+          opacity: {
+            type: Sdn.ValueType.EXACT,
+            value: { unit: Sdn.Unit.PERCENT, value: 40 },
+          },
+        },
+        corners: {
+          topLeft: {
+            type: Sdn.ValueType.THEME_ORDINAL,
+            value: "@corners.tight",
+          },
+          topRight: {
+            type: Sdn.ValueType.THEME_ORDINAL,
+            value: "@corners.tight",
+          },
+          bottomLeft: {
+            type: Sdn.ValueType.THEME_ORDINAL,
+            value: "@corners.tight",
+          },
+          bottomRight: {
+            type: Sdn.ValueType.THEME_ORDINAL,
+            value: "@corners.tight",
+          },
+        },
+        shadow: [
+          {
+            preset: {
+              type: Sdn.ValueType.THEME_CATEGORICAL,
+              value: "@shadow.light",
+            },
+            style: { type: Sdn.ValueType.EMPTY, value: null },
+            offsetX: {
+              type: Sdn.ValueType.EXACT,
+              value: { unit: Sdn.Unit.PX, value: 0 },
+            },
+            offsetY: {
+              type: Sdn.ValueType.EXACT,
+              value: { unit: Sdn.Unit.PX, value: 1 },
+            },
+            blur: {
+              type: Sdn.ValueType.THEME_ORDINAL,
+              value: "@blur.tiny",
+            },
+            color: {
+              type: Sdn.ValueType.EXACT,
+              value: { hue: 0, saturation: 0, lightness: 0 },
+            },
+            brightness: { type: Sdn.ValueType.EMPTY, value: null },
+            opacity: {
+              type: Sdn.ValueType.EXACT,
+              value: { unit: Sdn.Unit.PERCENT, value: 10 },
+            },
+            spread: {
+              type: Sdn.ValueType.THEME_ORDINAL,
+              value: "@spread.xxsmall",
+            },
+          },
+        ],
+      },
+      children: [
+        {
+          component: Seldon.ComponentId.TEXT,
+          variant: "label",
+          overrides: {
+            content: {
+              type: Sdn.ValueType.EXACT,
+              value: "Button Menu",
+            },
+            cursor: {
+              type: Sdn.ValueType.OPTION,
+              value: Sdn.Cursor.POINTER,
+            },
+            color: {
+              type: Sdn.ValueType.COMPUTED,
+              value: Sdn.ComputedFunction.HIGH_CONTRAST_COLOR,
+            },
+            font: {
+              preset: {
+                type: Sdn.ValueType.THEME_CATEGORICAL,
+                value: "@font.label",
+              },
+              size: {
+                type: Sdn.ValueType.COMPUTED,
+                value: Sdn.ComputedFunction.AUTO_FIT,
+              },
+            },
+          },
+        },
+        {
+          component: Seldon.ComponentId.ICON,
+          overrides: {
+            symbol: {
+              type: Sdn.ValueType.OPTION,
+              value: "material-chevronDown",
+            },
+            size: {
+              type: Sdn.ValueType.COMPUTED,
+              value: Sdn.ComputedFunction.AUTO_FIT,
+            },
+            color: {
+              type: Sdn.ValueType.COMPUTED,
+              value: Sdn.ComputedFunction.HIGH_CONTRAST_COLOR,
+            },
+            cursor: {
+              type: Sdn.ValueType.OPTION,
+              value: Sdn.Cursor.POINTER,
+            },
+          },
+        },
+      ],
+    },
+    {
       id: "iconic",
       label: "Iconic",
       intent: "Iconic button with a single icon and no label.",

--- a/packages/core/components/catalog/elements/OrdinalChip.schema.ts
+++ b/packages/core/components/catalog/elements/OrdinalChip.schema.ts
@@ -61,7 +61,7 @@ export const schema = {
     brightness: { type: Sdn.ValueType.EMPTY, value: null },
     opacity: { 
       type: Sdn.ValueType.EXACT,
-      value: { unit: Sdn.Unit.PERCENT, value: 35 },
+      value: { unit: Sdn.Unit.PERCENT, value: 40 },
      },
     background: [
       {
@@ -203,7 +203,7 @@ export const schema = {
           {
             component: Seldon.ComponentId.TEXT,
             overrides: {
-              content: { type: Sdn.ValueType.EXACT, value: "3.12 | 0.25rem" },
+              content: { type: Sdn.ValueType.EXACT, value: "3.12 · 0.25rem" },
               width: { type: Sdn.ValueType.OPTION, value: Sdn.Resize.FIT },
               font: {
                 preset: {
@@ -262,7 +262,7 @@ export const schema = {
           {
             component: Seldon.ComponentId.TEXT,
             overrides: {
-              content: { type: Sdn.ValueType.EXACT, value: "3.12 | 0.25rem" },
+              content: { type: Sdn.ValueType.EXACT, value: "3.12 · 0.25rem" },
               width: { type: Sdn.ValueType.OPTION, value: Sdn.Resize.FIT },
               font: {
                 preset: {
@@ -321,7 +321,7 @@ export const schema = {
           {
             component: Seldon.ComponentId.TEXT,
             overrides: {
-              content: { type: Sdn.ValueType.EXACT, value: "3.12 | 0.25rem" },
+              content: { type: Sdn.ValueType.EXACT, value: "3.12 · 0.25rem" },
               width: { type: Sdn.ValueType.OPTION, value: Sdn.Resize.FIT },
               font: {
                 preset: {
@@ -383,7 +383,7 @@ export const schema = {
           {
             component: Seldon.ComponentId.TEXT,
             overrides: {
-              content: { type: Sdn.ValueType.EXACT, value: "3.12 | 0.25rem" },
+              content: { type: Sdn.ValueType.EXACT, value: "3.12 · 0.25rem" },
               width: { type: Sdn.ValueType.OPTION, value: Sdn.Resize.FIT },
               font: {
                 preset: {
@@ -445,7 +445,7 @@ export const schema = {
           {
             component: Seldon.ComponentId.TEXT,
             overrides: {
-              content: { type: Sdn.ValueType.EXACT, value: "3.12 | 0.25rem" },
+              content: { type: Sdn.ValueType.EXACT, value: "3.12 · 0.25rem" },
               width: { type: Sdn.ValueType.OPTION, value: Sdn.Resize.FIT },
               font: {
                 preset: {

--- a/packages/core/components/catalog/elements/OrdinalChip.schema.ts
+++ b/packages/core/components/catalog/elements/OrdinalChip.schema.ts
@@ -2,53 +2,6 @@ import * as Sdn from "../../../properties"
 import * as Seldon from "../../constants"
 import { ComponentExport, ComponentSchema } from "../../types"
 
-const ordinalRowFrame = {
-  orientation: {
-    type: Sdn.ValueType.OPTION,
-    value: Sdn.Orientation.HORIZONTAL,
-  },
-  gap: {
-    type: Sdn.ValueType.THEME_ORDINAL,
-    value: "@gap.compact",
-  },
-  margin: {
-    top: { type: Sdn.ValueType.OPTION, value: Sdn.Margin.NONE },
-    right: { type: Sdn.ValueType.OPTION, value: Sdn.Margin.NONE },
-    bottom: { type: Sdn.ValueType.OPTION, value: Sdn.Margin.NONE },
-    left: { type: Sdn.ValueType.OPTION, value: Sdn.Margin.NONE },
-  },
-  padding: {
-    top: { type: Sdn.ValueType.OPTION, value: Sdn.Padding.NONE },
-    right: { type: Sdn.ValueType.OPTION, value: Sdn.Padding.NONE },
-    bottom: { type: Sdn.ValueType.OPTION, value: Sdn.Padding.NONE },
-    left: { type: Sdn.ValueType.OPTION, value: Sdn.Padding.NONE },
-  },
-} as const
-
-const ordinalRowText = {
-  content: { type: Sdn.ValueType.EXACT, value: "3.12 | 0.25rem" },
-  width: { type: Sdn.ValueType.OPTION, value: Sdn.Resize.FIT },
-  font: {
-    preset: {
-      type: Sdn.ValueType.THEME_CATEGORICAL,
-      value: "@font.callout",
-    },
-    weight: {
-      type: Sdn.ValueType.THEME_ORDINAL,
-      value: "@fontWeight.light",
-    },
-    size: {
-      type: Sdn.ValueType.THEME_ORDINAL,
-      value: "@fontSize.xsmall",
-    },
-    lineHeight: {
-      type: Sdn.ValueType.THEME_ORDINAL,
-      value: "@lineHeight.compact",
-    },
-  },
-  wrapText: { type: Sdn.ValueType.EXACT, value: false },
-} as const
-
 export const schema = {
   name: "Ordinal Chip",
   id: Seldon.ComponentId.ORDINAL_CHIP,
@@ -106,7 +59,10 @@ export const schema = {
     rowSpan: { type: Sdn.ValueType.EMPTY, value: null },
     color: { type: Sdn.ValueType.EMPTY, value: null },
     brightness: { type: Sdn.ValueType.EMPTY, value: null },
-    opacity: { type: Sdn.ValueType.EMPTY, value: null },
+    opacity: { 
+      type: Sdn.ValueType.EXACT,
+      value: { unit: Sdn.Unit.PERCENT, value: 35 },
+     },
     background: [
       {
         kind: { type: Sdn.ValueType.OPTION, value: Sdn.BackgroundKind.COLOR },
@@ -215,7 +171,28 @@ export const schema = {
     children: [
       {
         component: Seldon.ComponentId.FRAME,
-        overrides: ordinalRowFrame,
+        overrides: {
+          orientation: {
+            type: Sdn.ValueType.OPTION,
+            value: Sdn.Orientation.HORIZONTAL,
+          },
+          gap: {
+            type: Sdn.ValueType.THEME_ORDINAL,
+            value: "@gap.compact",
+          },
+          margin: {
+            top: { type: Sdn.ValueType.OPTION, value: Sdn.Margin.NONE },
+            right: { type: Sdn.ValueType.OPTION, value: Sdn.Margin.NONE },
+            bottom: { type: Sdn.ValueType.OPTION, value: Sdn.Margin.NONE },
+            left: { type: Sdn.ValueType.OPTION, value: Sdn.Margin.NONE },
+          },
+          padding: {
+            top: { type: Sdn.ValueType.OPTION, value: Sdn.Padding.NONE },
+            right: { type: Sdn.ValueType.OPTION, value: Sdn.Padding.NONE },
+            bottom: { type: Sdn.ValueType.OPTION, value: Sdn.Padding.NONE },
+            left: { type: Sdn.ValueType.OPTION, value: Sdn.Padding.NONE },
+          },
+        },
         children: [
           {
             component: Seldon.ComponentId.ICON,
@@ -225,13 +202,56 @@ export const schema = {
           },
           {
             component: Seldon.ComponentId.TEXT,
-            overrides: ordinalRowText,
+            overrides: {
+              content: { type: Sdn.ValueType.EXACT, value: "3.12 | 0.25rem" },
+              width: { type: Sdn.ValueType.OPTION, value: Sdn.Resize.FIT },
+              font: {
+                preset: {
+                  type: Sdn.ValueType.THEME_CATEGORICAL,
+                  value: "@font.callout",
+                },
+                weight: {
+                  type: Sdn.ValueType.THEME_ORDINAL,
+                  value: "@fontWeight.light",
+                },
+                size: {
+                  type: Sdn.ValueType.THEME_ORDINAL,
+                  value: "@fontSize.xsmall",
+                },
+                lineHeight: {
+                  type: Sdn.ValueType.THEME_ORDINAL,
+                  value: "@lineHeight.compact",
+                },
+              },
+              wrapText: { type: Sdn.ValueType.EXACT, value: false },
+            },
           },
         ],
       },
       {
         component: Seldon.ComponentId.FRAME,
-        overrides: ordinalRowFrame,
+        overrides: {
+          orientation: {
+            type: Sdn.ValueType.OPTION,
+            value: Sdn.Orientation.HORIZONTAL,
+          },
+          gap: {
+            type: Sdn.ValueType.THEME_ORDINAL,
+            value: "@gap.compact",
+          },
+          margin: {
+            top: { type: Sdn.ValueType.OPTION, value: Sdn.Margin.NONE },
+            right: { type: Sdn.ValueType.OPTION, value: Sdn.Margin.NONE },
+            bottom: { type: Sdn.ValueType.OPTION, value: Sdn.Margin.NONE },
+            left: { type: Sdn.ValueType.OPTION, value: Sdn.Margin.NONE },
+          },
+          padding: {
+            top: { type: Sdn.ValueType.OPTION, value: Sdn.Padding.NONE },
+            right: { type: Sdn.ValueType.OPTION, value: Sdn.Padding.NONE },
+            bottom: { type: Sdn.ValueType.OPTION, value: Sdn.Padding.NONE },
+            left: { type: Sdn.ValueType.OPTION, value: Sdn.Padding.NONE },
+          },
+        },
         children: [
           {
             component: Seldon.ComponentId.ICON,
@@ -241,13 +261,56 @@ export const schema = {
           },
           {
             component: Seldon.ComponentId.TEXT,
-            overrides: ordinalRowText,
+            overrides: {
+              content: { type: Sdn.ValueType.EXACT, value: "3.12 | 0.25rem" },
+              width: { type: Sdn.ValueType.OPTION, value: Sdn.Resize.FIT },
+              font: {
+                preset: {
+                  type: Sdn.ValueType.THEME_CATEGORICAL,
+                  value: "@font.callout",
+                },
+                weight: {
+                  type: Sdn.ValueType.THEME_ORDINAL,
+                  value: "@fontWeight.light",
+                },
+                size: {
+                  type: Sdn.ValueType.THEME_ORDINAL,
+                  value: "@fontSize.xsmall",
+                },
+                lineHeight: {
+                  type: Sdn.ValueType.THEME_ORDINAL,
+                  value: "@lineHeight.compact",
+                },
+              },
+              wrapText: { type: Sdn.ValueType.EXACT, value: false },
+            },
           },
         ],
       },
       {
         component: Seldon.ComponentId.FRAME,
-        overrides: ordinalRowFrame,
+        overrides: {
+          orientation: {
+            type: Sdn.ValueType.OPTION,
+            value: Sdn.Orientation.HORIZONTAL,
+          },
+          gap: {
+            type: Sdn.ValueType.THEME_ORDINAL,
+            value: "@gap.compact",
+          },
+          margin: {
+            top: { type: Sdn.ValueType.OPTION, value: Sdn.Margin.NONE },
+            right: { type: Sdn.ValueType.OPTION, value: Sdn.Margin.NONE },
+            bottom: { type: Sdn.ValueType.OPTION, value: Sdn.Margin.NONE },
+            left: { type: Sdn.ValueType.OPTION, value: Sdn.Margin.NONE },
+          },
+          padding: {
+            top: { type: Sdn.ValueType.OPTION, value: Sdn.Padding.NONE },
+            right: { type: Sdn.ValueType.OPTION, value: Sdn.Padding.NONE },
+            bottom: { type: Sdn.ValueType.OPTION, value: Sdn.Padding.NONE },
+            left: { type: Sdn.ValueType.OPTION, value: Sdn.Padding.NONE },
+          },
+        },
         children: [
           {
             component: Seldon.ComponentId.ICON,
@@ -257,13 +320,56 @@ export const schema = {
           },
           {
             component: Seldon.ComponentId.TEXT,
-            overrides: ordinalRowText,
+            overrides: {
+              content: { type: Sdn.ValueType.EXACT, value: "3.12 | 0.25rem" },
+              width: { type: Sdn.ValueType.OPTION, value: Sdn.Resize.FIT },
+              font: {
+                preset: {
+                  type: Sdn.ValueType.THEME_CATEGORICAL,
+                  value: "@font.callout",
+                },
+                weight: {
+                  type: Sdn.ValueType.THEME_ORDINAL,
+                  value: "@fontWeight.light",
+                },
+                size: {
+                  type: Sdn.ValueType.THEME_ORDINAL,
+                  value: "@fontSize.xsmall",
+                },
+                lineHeight: {
+                  type: Sdn.ValueType.THEME_ORDINAL,
+                  value: "@lineHeight.compact",
+                },
+              },
+              wrapText: { type: Sdn.ValueType.EXACT, value: false },
+            },
           },
         ],
       },
       {
         component: Seldon.ComponentId.FRAME,
-        overrides: ordinalRowFrame,
+        overrides: {
+          orientation: {
+            type: Sdn.ValueType.OPTION,
+            value: Sdn.Orientation.HORIZONTAL,
+          },
+          gap: {
+            type: Sdn.ValueType.THEME_ORDINAL,
+            value: "@gap.compact",
+          },
+          margin: {
+            top: { type: Sdn.ValueType.OPTION, value: Sdn.Margin.NONE },
+            right: { type: Sdn.ValueType.OPTION, value: Sdn.Margin.NONE },
+            bottom: { type: Sdn.ValueType.OPTION, value: Sdn.Margin.NONE },
+            left: { type: Sdn.ValueType.OPTION, value: Sdn.Margin.NONE },
+          },
+          padding: {
+            top: { type: Sdn.ValueType.OPTION, value: Sdn.Padding.NONE },
+            right: { type: Sdn.ValueType.OPTION, value: Sdn.Padding.NONE },
+            bottom: { type: Sdn.ValueType.OPTION, value: Sdn.Padding.NONE },
+            left: { type: Sdn.ValueType.OPTION, value: Sdn.Padding.NONE },
+          },
+        },
         children: [
           {
             component: Seldon.ComponentId.ICON,
@@ -276,13 +382,56 @@ export const schema = {
           },
           {
             component: Seldon.ComponentId.TEXT,
-            overrides: ordinalRowText,
+            overrides: {
+              content: { type: Sdn.ValueType.EXACT, value: "3.12 | 0.25rem" },
+              width: { type: Sdn.ValueType.OPTION, value: Sdn.Resize.FIT },
+              font: {
+                preset: {
+                  type: Sdn.ValueType.THEME_CATEGORICAL,
+                  value: "@font.callout",
+                },
+                weight: {
+                  type: Sdn.ValueType.THEME_ORDINAL,
+                  value: "@fontWeight.light",
+                },
+                size: {
+                  type: Sdn.ValueType.THEME_ORDINAL,
+                  value: "@fontSize.xsmall",
+                },
+                lineHeight: {
+                  type: Sdn.ValueType.THEME_ORDINAL,
+                  value: "@lineHeight.compact",
+                },
+              },
+              wrapText: { type: Sdn.ValueType.EXACT, value: false },
+            },
           },
         ],
       },
       {
         component: Seldon.ComponentId.FRAME,
-        overrides: ordinalRowFrame,
+        overrides: {
+          orientation: {
+            type: Sdn.ValueType.OPTION,
+            value: Sdn.Orientation.HORIZONTAL,
+          },
+          gap: {
+            type: Sdn.ValueType.THEME_ORDINAL,
+            value: "@gap.compact",
+          },
+          margin: {
+            top: { type: Sdn.ValueType.OPTION, value: Sdn.Margin.NONE },
+            right: { type: Sdn.ValueType.OPTION, value: Sdn.Margin.NONE },
+            bottom: { type: Sdn.ValueType.OPTION, value: Sdn.Margin.NONE },
+            left: { type: Sdn.ValueType.OPTION, value: Sdn.Margin.NONE },
+          },
+          padding: {
+            top: { type: Sdn.ValueType.OPTION, value: Sdn.Padding.NONE },
+            right: { type: Sdn.ValueType.OPTION, value: Sdn.Padding.NONE },
+            bottom: { type: Sdn.ValueType.OPTION, value: Sdn.Padding.NONE },
+            left: { type: Sdn.ValueType.OPTION, value: Sdn.Padding.NONE },
+          },
+        },
         children: [
           {
             component: Seldon.ComponentId.ICON,
@@ -295,7 +444,29 @@ export const schema = {
           },
           {
             component: Seldon.ComponentId.TEXT,
-            overrides: ordinalRowText,
+            overrides: {
+              content: { type: Sdn.ValueType.EXACT, value: "3.12 | 0.25rem" },
+              width: { type: Sdn.ValueType.OPTION, value: Sdn.Resize.FIT },
+              font: {
+                preset: {
+                  type: Sdn.ValueType.THEME_CATEGORICAL,
+                  value: "@font.callout",
+                },
+                weight: {
+                  type: Sdn.ValueType.THEME_ORDINAL,
+                  value: "@fontWeight.light",
+                },
+                size: {
+                  type: Sdn.ValueType.THEME_ORDINAL,
+                  value: "@fontSize.xsmall",
+                },
+                lineHeight: {
+                  type: Sdn.ValueType.THEME_ORDINAL,
+                  value: "@lineHeight.compact",
+                },
+              },
+              wrapText: { type: Sdn.ValueType.EXACT, value: false },
+            },
           },
         ],
       },

--- a/packages/core/components/catalog/elements/OrdinalChip.schema.ts
+++ b/packages/core/components/catalog/elements/OrdinalChip.schema.ts
@@ -59,10 +59,10 @@ export const schema = {
     rowSpan: { type: Sdn.ValueType.EMPTY, value: null },
     color: { type: Sdn.ValueType.EMPTY, value: null },
     brightness: { type: Sdn.ValueType.EMPTY, value: null },
-    opacity: { 
+    opacity: {
       type: Sdn.ValueType.EXACT,
       value: { unit: Sdn.Unit.PERCENT, value: 40 },
-     },
+    },
     background: [
       {
         kind: { type: Sdn.ValueType.OPTION, value: Sdn.BackgroundKind.COLOR },

--- a/packages/core/components/catalog/elements/OrdinalChip.schema.ts
+++ b/packages/core/components/catalog/elements/OrdinalChip.schema.ts
@@ -1,0 +1,308 @@
+import * as Sdn from "../../../properties"
+import * as Seldon from "../../constants"
+import { ComponentExport, ComponentSchema } from "../../types"
+
+const ordinalRowFrame = {
+  orientation: {
+    type: Sdn.ValueType.OPTION,
+    value: Sdn.Orientation.HORIZONTAL,
+  },
+  gap: {
+    type: Sdn.ValueType.THEME_ORDINAL,
+    value: "@gap.compact",
+  },
+  margin: {
+    top: { type: Sdn.ValueType.OPTION, value: Sdn.Margin.NONE },
+    right: { type: Sdn.ValueType.OPTION, value: Sdn.Margin.NONE },
+    bottom: { type: Sdn.ValueType.OPTION, value: Sdn.Margin.NONE },
+    left: { type: Sdn.ValueType.OPTION, value: Sdn.Margin.NONE },
+  },
+  padding: {
+    top: { type: Sdn.ValueType.OPTION, value: Sdn.Padding.NONE },
+    right: { type: Sdn.ValueType.OPTION, value: Sdn.Padding.NONE },
+    bottom: { type: Sdn.ValueType.OPTION, value: Sdn.Padding.NONE },
+    left: { type: Sdn.ValueType.OPTION, value: Sdn.Padding.NONE },
+  },
+} as const
+
+const ordinalRowText = {
+  content: { type: Sdn.ValueType.EXACT, value: "3.12 | 0.25rem" },
+  width: { type: Sdn.ValueType.OPTION, value: Sdn.Resize.FIT },
+  font: {
+    preset: {
+      type: Sdn.ValueType.THEME_CATEGORICAL,
+      value: "@font.callout",
+    },
+    weight: {
+      type: Sdn.ValueType.THEME_ORDINAL,
+      value: "@fontWeight.light",
+    },
+    size: {
+      type: Sdn.ValueType.THEME_ORDINAL,
+      value: "@fontSize.xsmall",
+    },
+    lineHeight: {
+      type: Sdn.ValueType.THEME_ORDINAL,
+      value: "@lineHeight.compact",
+    },
+  },
+  wrapText: { type: Sdn.ValueType.EXACT, value: false },
+} as const
+
+export const schema = {
+  name: "Ordinal Chip",
+  id: Seldon.ComponentId.ORDINAL_CHIP,
+  intent:
+    "Schema for an ordinal chip that lists the ordinal theme scales for margin, padding, gap, border, and corners as labeled icon rows.",
+  tags: ["ordinal", "chip", "scale", "specimen", "spacing", "theme", "ui"],
+  level: Seldon.ComponentLevel.ELEMENT,
+  icon: Seldon.ComponentIcon.COMPONENT,
+  properties: {
+    display: { type: Sdn.ValueType.EMPTY, value: null },
+    direction: { type: Sdn.ValueType.EMPTY, value: null },
+    orientation: {
+      type: Sdn.ValueType.OPTION,
+      value: Sdn.Orientation.VERTICAL,
+    },
+    align: {
+      type: Sdn.ValueType.OPTION,
+      value: Sdn.Align.TOP_LEFT,
+    },
+    width: {
+      type: Sdn.ValueType.OPTION,
+      value: Sdn.Resize.FILL,
+    },
+    height: {
+      type: Sdn.ValueType.OPTION,
+      value: Sdn.Resize.FIT,
+    },
+    margin: {
+      top: { type: Sdn.ValueType.THEME_ORDINAL, value: "@margin.cozy" },
+      right: { type: Sdn.ValueType.THEME_ORDINAL, value: "@margin.cozy" },
+      bottom: { type: Sdn.ValueType.THEME_ORDINAL, value: "@margin.cozy" },
+      left: { type: Sdn.ValueType.THEME_ORDINAL, value: "@margin.cozy" },
+    },
+    padding: {
+      top: { type: Sdn.ValueType.THEME_ORDINAL, value: "@padding.cozy" },
+      right: { type: Sdn.ValueType.THEME_ORDINAL, value: "@padding.cozy" },
+      bottom: { type: Sdn.ValueType.THEME_ORDINAL, value: "@padding.cozy" },
+      left: { type: Sdn.ValueType.THEME_ORDINAL, value: "@padding.cozy" },
+    },
+    gap: {
+      type: Sdn.ValueType.THEME_ORDINAL,
+      value: "@gap.cozy",
+    },
+    wrapChildren: {
+      type: Sdn.ValueType.EXACT,
+      value: false,
+    },
+    clip: {
+      type: Sdn.ValueType.EXACT,
+      value: true,
+    },
+    columnStart: { type: Sdn.ValueType.EMPTY, value: null },
+    columnSpan: { type: Sdn.ValueType.EXACT, value: 2 },
+    rowStart: { type: Sdn.ValueType.EMPTY, value: null },
+    rowSpan: { type: Sdn.ValueType.EMPTY, value: null },
+    color: { type: Sdn.ValueType.EMPTY, value: null },
+    brightness: { type: Sdn.ValueType.EMPTY, value: null },
+    opacity: { type: Sdn.ValueType.EMPTY, value: null },
+    background: [
+      {
+        kind: { type: Sdn.ValueType.OPTION, value: Sdn.BackgroundKind.COLOR },
+        color: {
+          type: Sdn.ValueType.THEME_CATEGORICAL,
+          value: "@swatch.offWhite",
+        },
+        brightness: { type: Sdn.ValueType.EMPTY, value: null },
+        opacity: { type: Sdn.ValueType.EMPTY, value: null },
+      },
+    ],
+    border: {
+      preset: {
+        type: Sdn.ValueType.THEME_CATEGORICAL,
+        value: "@border.hairline",
+      },
+      style: { type: Sdn.ValueType.EMPTY, value: null },
+      color: {
+        type: Sdn.ValueType.COMPUTED,
+        value: Sdn.ComputedFunction.HIGH_CONTRAST_COLOR,
+      },
+      width: {
+        type: Sdn.ValueType.THEME_ORDINAL,
+        value: "@borderWidth.medium",
+      },
+      brightness: { type: Sdn.ValueType.EMPTY, value: null },
+      opacity: {
+        type: Sdn.ValueType.EXACT,
+        value: { unit: Sdn.Unit.PERCENT, value: 50 },
+      },
+    },
+    borderTop: {
+      preset: { type: Sdn.ValueType.EMPTY, value: null },
+      style: { type: Sdn.ValueType.EMPTY, value: null },
+      color: { type: Sdn.ValueType.EMPTY, value: null },
+      width: { type: Sdn.ValueType.EMPTY, value: null },
+      brightness: { type: Sdn.ValueType.EMPTY, value: null },
+      opacity: { type: Sdn.ValueType.EMPTY, value: null },
+    },
+    borderRight: {
+      preset: { type: Sdn.ValueType.EMPTY, value: null },
+      style: { type: Sdn.ValueType.EMPTY, value: null },
+      color: { type: Sdn.ValueType.EMPTY, value: null },
+      width: { type: Sdn.ValueType.EMPTY, value: null },
+      brightness: { type: Sdn.ValueType.EMPTY, value: null },
+      opacity: { type: Sdn.ValueType.EMPTY, value: null },
+    },
+    borderBottom: {
+      preset: { type: Sdn.ValueType.EMPTY, value: null },
+      style: { type: Sdn.ValueType.EMPTY, value: null },
+      color: { type: Sdn.ValueType.EMPTY, value: null },
+      width: { type: Sdn.ValueType.EMPTY, value: null },
+      brightness: { type: Sdn.ValueType.EMPTY, value: null },
+      opacity: { type: Sdn.ValueType.EMPTY, value: null },
+    },
+    borderLeft: {
+      preset: { type: Sdn.ValueType.EMPTY, value: null },
+      style: { type: Sdn.ValueType.EMPTY, value: null },
+      color: { type: Sdn.ValueType.EMPTY, value: null },
+      width: { type: Sdn.ValueType.EMPTY, value: null },
+      brightness: { type: Sdn.ValueType.EMPTY, value: null },
+      opacity: { type: Sdn.ValueType.EMPTY, value: null },
+    },
+    corners: {
+      topLeft: {
+        type: Sdn.ValueType.THEME_ORDINAL,
+        value: "@corners.cozy",
+      },
+      topRight: {
+        type: Sdn.ValueType.THEME_ORDINAL,
+        value: "@corners.cozy",
+      },
+      bottomLeft: {
+        type: Sdn.ValueType.THEME_ORDINAL,
+        value: "@corners.cozy",
+      },
+      bottomRight: {
+        type: Sdn.ValueType.THEME_ORDINAL,
+        value: "@corners.cozy",
+      },
+    },
+    shadow: [
+      {
+        preset: {
+          type: Sdn.ValueType.THEME_CATEGORICAL,
+          value: "@shadow.none",
+        },
+        style: { type: Sdn.ValueType.EMPTY, value: null },
+        offsetX: { type: Sdn.ValueType.EMPTY, value: null },
+        offsetY: { type: Sdn.ValueType.EMPTY, value: null },
+        blur: { type: Sdn.ValueType.EMPTY, value: null },
+        color: { type: Sdn.ValueType.EMPTY, value: null },
+        brightness: { type: Sdn.ValueType.EMPTY, value: null },
+        opacity: { type: Sdn.ValueType.EMPTY, value: null },
+        spread: { type: Sdn.ValueType.EMPTY, value: null },
+      },
+    ],
+    role: { type: Sdn.ValueType.EMPTY, value: null },
+    ariaLabel: { type: Sdn.ValueType.EMPTY, value: null },
+    ariaHidden: {
+      type: Sdn.ValueType.EXACT,
+      value: false,
+    },
+  },
+  default: {
+    children: [
+      {
+        component: Seldon.ComponentId.FRAME,
+        overrides: ordinalRowFrame,
+        children: [
+          {
+            component: Seldon.ComponentId.ICON,
+            overrides: {
+              symbol: { type: Sdn.ValueType.OPTION, value: "material-margin" },
+            },
+          },
+          {
+            component: Seldon.ComponentId.TEXT,
+            overrides: ordinalRowText,
+          },
+        ],
+      },
+      {
+        component: Seldon.ComponentId.FRAME,
+        overrides: ordinalRowFrame,
+        children: [
+          {
+            component: Seldon.ComponentId.ICON,
+            overrides: {
+              symbol: { type: Sdn.ValueType.OPTION, value: "material-padding" },
+            },
+          },
+          {
+            component: Seldon.ComponentId.TEXT,
+            overrides: ordinalRowText,
+          },
+        ],
+      },
+      {
+        component: Seldon.ComponentId.FRAME,
+        overrides: ordinalRowFrame,
+        children: [
+          {
+            component: Seldon.ComponentId.ICON,
+            overrides: {
+              symbol: { type: Sdn.ValueType.OPTION, value: "seldon-gap" },
+            },
+          },
+          {
+            component: Seldon.ComponentId.TEXT,
+            overrides: ordinalRowText,
+          },
+        ],
+      },
+      {
+        component: Seldon.ComponentId.FRAME,
+        overrides: ordinalRowFrame,
+        children: [
+          {
+            component: Seldon.ComponentId.ICON,
+            overrides: {
+              symbol: {
+                type: Sdn.ValueType.OPTION,
+                value: "material-borderStyle",
+              },
+            },
+          },
+          {
+            component: Seldon.ComponentId.TEXT,
+            overrides: ordinalRowText,
+          },
+        ],
+      },
+      {
+        component: Seldon.ComponentId.FRAME,
+        overrides: ordinalRowFrame,
+        children: [
+          {
+            component: Seldon.ComponentId.ICON,
+            overrides: {
+              symbol: {
+                type: Sdn.ValueType.OPTION,
+                value: "material-roundedCorner",
+              },
+            },
+          },
+          {
+            component: Seldon.ComponentId.TEXT,
+            overrides: ordinalRowText,
+          },
+        ],
+      },
+    ],
+  },
+} as const satisfies ComponentSchema
+
+export const exportConfig: ComponentExport = {
+  react: { returns: "HTMLDiv" },
+}

--- a/packages/core/components/catalog/index.ts
+++ b/packages/core/components/catalog/index.ts
@@ -40,6 +40,10 @@ import {
   schema as comboboxFieldSchema,
 } from "./elements/ComboboxField.schema"
 import {
+  exportConfig as ordinalChipExportConfig,
+  schema as ordinalChipSchema,
+} from "./elements/OrdinalChip.schema"
+import {
   exportConfig as descriptionListExportConfig,
   schema as descriptionListSchema,
 } from "./elements/DescriptionList.schema"
@@ -235,6 +239,10 @@ import {
   schema as colorSpecimenSchema,
 } from "./parts/specimens/ColorSpecimen.schema"
 import {
+  exportConfig as ordinalSpecimenExportConfig,
+  schema as ordinalSpecimenSchema,
+} from "./parts/specimens/OrdinalSpecimen.schema"
+import {
   exportConfig as typeSpecimenExportConfig,
   schema as typeSpecimenSchema,
 } from "./parts/specimens/TypeSpecimen.schema"
@@ -311,6 +319,7 @@ const elements: ComponentSchema[] = [
   calendarDaySchema,
   chipSchema,
   colorChipSchema,
+  ordinalChipSchema,
   formControlSchema,
   optionGroupSchema,
   headerSchema,
@@ -371,6 +380,7 @@ const parts: ComponentSchema[] = [
   socialProofCtaSchema,
   typeSpecimenSchema,
   colorSpecimenSchema,
+  ordinalSpecimenSchema,
 ]
 
 const modules: ComponentSchema[] = [
@@ -442,6 +452,7 @@ const exportConfigById: Partial<Record<ComponentId, ComponentExport>> = {
   [ComponentId.CALENDAR_DAY]: calendarDayExportConfig,
   [ComponentId.CHIP]: chipExportConfig,
   [ComponentId.COLOR_CHIP]: colorChipExportConfig,
+  [ComponentId.ORDINAL_CHIP]: ordinalChipExportConfig,
   [ComponentId.FORM_CONTROL]: formControlExportConfig,
   [ComponentId.OPTION_GROUP]: optionGroupExportConfig,
   [ComponentId.HEADER]: headerExportConfig,
@@ -497,6 +508,7 @@ const exportConfigById: Partial<Record<ComponentId, ComponentExport>> = {
   [ComponentId.SOCIAL_PROOF_CTA]: socialProofCtaExportConfig,
   [ComponentId.TYPE_SPECIMEN]: typeSpecimenExportConfig,
   [ComponentId.COLOR_SPECIMEN]: colorSpecimenExportConfig,
+  [ComponentId.ORDINAL_SPECIMEN]: ordinalSpecimenExportConfig,
 
   // Primitives
   [ComponentId.HR]: hrExportConfig,

--- a/packages/core/components/catalog/index.ts
+++ b/packages/core/components/catalog/index.ts
@@ -40,10 +40,6 @@ import {
   schema as comboboxFieldSchema,
 } from "./elements/ComboboxField.schema"
 import {
-  exportConfig as ordinalChipExportConfig,
-  schema as ordinalChipSchema,
-} from "./elements/OrdinalChip.schema"
-import {
   exportConfig as descriptionListExportConfig,
   schema as descriptionListSchema,
 } from "./elements/DescriptionList.schema"
@@ -79,6 +75,10 @@ import {
   exportConfig as optionGroupExportConfig,
   schema as optionGroupSchema,
 } from "./elements/OptionGroup.schema"
+import {
+  exportConfig as ordinalChipExportConfig,
+  schema as ordinalChipSchema,
+} from "./elements/OrdinalChip.schema"
 import {
   exportConfig as sectionExportConfig,
   schema as sectionSchema,

--- a/packages/core/components/catalog/modules/footers/Footer.schema.ts
+++ b/packages/core/components/catalog/modules/footers/Footer.schema.ts
@@ -1,6 +1,10 @@
-import * as Sdn from "../../../../properties"
-import * as Seldon from "../../../constants"
-import { ComponentExport, ComponentSchema } from "../../../types"
+import * as Sdn from "../../../../properties";
+import * as Seldon from "../../../constants";
+import { ComponentExport, ComponentSchema } from "../../../types";
+
+
+
+
 
 export const schema = {
   name: "Footer",
@@ -331,7 +335,7 @@ export const schema = {
               align: { type: Sdn.ValueType.OPTION, value: Sdn.Align.TOP_LEFT },
               width: { type: Sdn.ValueType.OPTION, value: Sdn.Resize.FIT },
               height: { type: Sdn.ValueType.OPTION, value: Sdn.Resize.FIT },
-              gap: { type: Sdn.ValueType.THEME_ORDINAL, value: "@gap.compact" },
+              gap: { type: Sdn.ValueType.OPTION, value: Sdn.Gap.EVENLY_SPACED },
             },
             children: [
               {
@@ -751,7 +755,10 @@ export const schema = {
                 },
                 width: { type: Sdn.ValueType.OPTION, value: Sdn.Resize.FILL },
                 height: { type: Sdn.ValueType.OPTION, value: Sdn.Resize.FIT },
-                gap: { type: Sdn.ValueType.THEME_ORDINAL, value: "@gap.open" },
+                gap: {
+                  type: Sdn.ValueType.OPTION,
+                  value: Sdn.Gap.EVENLY_SPACED,
+                },
               },
               children: [
                 {

--- a/packages/core/components/catalog/modules/footers/Footer.schema.ts
+++ b/packages/core/components/catalog/modules/footers/Footer.schema.ts
@@ -1162,7 +1162,7 @@ export const schema = {
                               },
                               size: {
                                 type: Sdn.ValueType.THEME_ORDINAL,
-                                value: "@fontSize.small",
+                                value: "@fontSize.xsmall",
                               },
                             },
                           },

--- a/packages/core/components/catalog/modules/footers/Footer.schema.ts
+++ b/packages/core/components/catalog/modules/footers/Footer.schema.ts
@@ -2,10 +2,6 @@ import * as Sdn from "../../../../properties";
 import * as Seldon from "../../../constants";
 import { ComponentExport, ComponentSchema } from "../../../types";
 
-
-
-
-
 export const schema = {
   name: "Footer",
   id: Seldon.ComponentId.FOOTER,

--- a/packages/core/components/catalog/modules/footers/Footer.schema.ts
+++ b/packages/core/components/catalog/modules/footers/Footer.schema.ts
@@ -1,6 +1,6 @@
-import * as Sdn from "../../../../properties";
-import * as Seldon from "../../../constants";
-import { ComponentExport, ComponentSchema } from "../../../types";
+import * as Sdn from "../../../../properties"
+import * as Seldon from "../../../constants"
+import { ComponentExport, ComponentSchema } from "../../../types"
 
 export const schema = {
   name: "Footer",

--- a/packages/core/components/catalog/parts/Topbar.schema.ts
+++ b/packages/core/components/catalog/parts/Topbar.schema.ts
@@ -381,20 +381,6 @@ export const schema = {
                 type: Sdn.ValueType.THEME_ORDINAL,
                 value: "@fontSize.small",
               },
-              background: [
-                {
-                  kind: {
-                    type: Sdn.ValueType.OPTION,
-                    value: Sdn.BackgroundKind.NONE,
-                  },
-                },
-              ],
-              border: {
-                preset: {
-                  type: Sdn.ValueType.THEME_CATEGORICAL,
-                  value: "@border.none",
-                },
-              },
             },
             children: [
               {
@@ -403,14 +389,6 @@ export const schema = {
                   symbol: {
                     type: Sdn.ValueType.OPTION,
                     value: "material-email",
-                  },
-                  size: {
-                    type: Sdn.ValueType.THEME_ORDINAL,
-                    value: "@size.small",
-                  },
-                  color: {
-                    type: Sdn.ValueType.THEME_CATEGORICAL,
-                    value: "@swatch.primary",
                   },
                 },
               },
@@ -421,16 +399,6 @@ export const schema = {
                   content: {
                     type: Sdn.ValueType.EXACT,
                     value: "Contact",
-                  },
-                  color: {
-                    type: Sdn.ValueType.THEME_CATEGORICAL,
-                    value: "@swatch.primary",
-                  },
-                  font: {
-                    size: {
-                      type: Sdn.ValueType.THEME_ORDINAL,
-                      value: "@fontSize.xsmall",
-                    },
                   },
                 },
               },

--- a/packages/core/components/catalog/parts/ctas/JoinCTA.schema.ts
+++ b/packages/core/components/catalog/parts/ctas/JoinCTA.schema.ts
@@ -33,7 +33,7 @@ export const schema = {
     },
     align: {
       type: Sdn.ValueType.OPTION,
-      value: Sdn.Align.CENTER,
+      value: Sdn.Align.TOP_LEFT,
     },
     width: {
       type: Sdn.ValueType.OPTION,
@@ -230,6 +230,7 @@ export const schema = {
                 type: Sdn.ValueType.EXACT,
                 value: "Explore the codebase",
               },
+              width: { type: Sdn.ValueType.OPTION, value: Sdn.Resize.FIT },
               font: {
                 preset: {
                   type: Sdn.ValueType.THEME_CATEGORICAL,
@@ -240,7 +241,7 @@ export const schema = {
                 type: Sdn.ValueType.OPTION,
                 value: Sdn.TextAlign.LEFT,
               },
-              lines: { type: Sdn.ValueType.EXACT, value: 3 },
+              lines: { type: Sdn.ValueType.EXACT, value: 8 },
             },
           },
           {
@@ -304,19 +305,19 @@ export const schema = {
               corners: {
                 topLeft: {
                   type: Sdn.ValueType.THEME_ORDINAL,
-                  value: "@corners.comfortable",
+                  value: "@corners.compact",
                 },
                 topRight: {
                   type: Sdn.ValueType.THEME_ORDINAL,
-                  value: "@corners.comfortable",
+                  value: "@corners.compact",
                 },
                 bottomLeft: {
                   type: Sdn.ValueType.THEME_ORDINAL,
-                  value: "@corners.comfortable",
+                  value: "@corners.compact",
                 },
                 bottomRight: {
                   type: Sdn.ValueType.THEME_ORDINAL,
-                  value: "@corners.comfortable",
+                  value: "@corners.compact",
                 },
               },
             },

--- a/packages/core/components/catalog/parts/ctas/JoinCTA.schema.ts
+++ b/packages/core/components/catalog/parts/ctas/JoinCTA.schema.ts
@@ -1,6 +1,10 @@
-import * as Sdn from "../../../../properties"
-import * as Seldon from "../../../constants"
-import { ComponentExport, ComponentSchema } from "../../../types"
+import * as Sdn from "../../../../properties";
+import * as Seldon from "../../../constants";
+import { ComponentExport, ComponentSchema } from "../../../types";
+
+
+
+
 
 export const schema = {
   name: "Join CTA",
@@ -46,12 +50,15 @@ export const schema = {
       left: { type: Sdn.ValueType.EMPTY, value: null },
     },
     padding: {
-      top: { type: Sdn.ValueType.EMPTY, value: null },
+      top: { type: Sdn.ValueType.THEME_ORDINAL, value: "@padding.cozy" },
       right: {
         type: Sdn.ValueType.THEME_ORDINAL,
         value: "@padding.comfortable",
       },
-      bottom: { type: Sdn.ValueType.EMPTY, value: null },
+      bottom: {
+        type: Sdn.ValueType.THEME_ORDINAL,
+        value: "@padding.cozy",
+      },
       left: {
         type: Sdn.ValueType.THEME_ORDINAL,
         value: "@padding.comfortable",
@@ -130,19 +137,19 @@ export const schema = {
     corners: {
       topLeft: {
         type: Sdn.ValueType.THEME_ORDINAL,
-        value: "@corners.comfortable",
+        value: "@corners.cozy",
       },
       topRight: {
         type: Sdn.ValueType.THEME_ORDINAL,
-        value: "@corners.comfortable",
+        value: "@corners.cozy",
       },
       bottomLeft: {
         type: Sdn.ValueType.THEME_ORDINAL,
-        value: "@corners.comfortable",
+        value: "@corners.cozy",
       },
       bottomRight: {
         type: Sdn.ValueType.THEME_ORDINAL,
-        value: "@corners.comfortable",
+        value: "@corners.cozy",
       },
     },
     shadow: [

--- a/packages/core/components/catalog/parts/ctas/JoinCTA.schema.ts
+++ b/packages/core/components/catalog/parts/ctas/JoinCTA.schema.ts
@@ -193,7 +193,7 @@ export const schema = {
             overrides: {
               content: {
                 type: Sdn.ValueType.EXACT,
-                value: "Become an Affiliate",
+                value: "Become a Contributor",
               },
               color: {
                 type: Sdn.ValueType.THEME_CATEGORICAL,
@@ -221,7 +221,7 @@ export const schema = {
             overrides: {
               content: {
                 type: Sdn.ValueType.EXACT,
-                value: "Join our Affiliate Program",
+                value: "Explore the codebase",
               },
               font: {
                 preset: {
@@ -233,6 +233,7 @@ export const schema = {
                 type: Sdn.ValueType.OPTION,
                 value: Sdn.TextAlign.LEFT,
               },
+              lines: { type: Sdn.ValueType.EXACT, value: 3 },
             },
           },
           {
@@ -242,7 +243,7 @@ export const schema = {
               content: {
                 type: Sdn.ValueType.EXACT,
                 value:
-                  "Earn money with our generous 30% commission for every sale you drive with your referral link.",
+                  "Experiment with Seldon's open source codebase and see how it can be used to create a consistent and user-friendly experience.",
               },
               font: {
                 preset: {
@@ -281,7 +282,7 @@ export const schema = {
                   },
                   color: {
                     type: Sdn.ValueType.THEME_CATEGORICAL,
-                    value: "@swatch.offBlack",
+                    value: "@swatch.primary",
                   },
                   brightness: { type: Sdn.ValueType.EMPTY, value: null },
                   opacity: { type: Sdn.ValueType.EMPTY, value: null },
@@ -332,7 +333,7 @@ export const schema = {
                 overrides: {
                   content: {
                     type: Sdn.ValueType.EXACT,
-                    value: "Become an affiliate",
+                    value: "View the repo",
                   },
                   color: {
                     type: Sdn.ValueType.COMPUTED,

--- a/packages/core/components/catalog/parts/ctas/JoinCTA.schema.ts
+++ b/packages/core/components/catalog/parts/ctas/JoinCTA.schema.ts
@@ -1,10 +1,6 @@
-import * as Sdn from "../../../../properties";
-import * as Seldon from "../../../constants";
-import { ComponentExport, ComponentSchema } from "../../../types";
-
-
-
-
+import * as Sdn from "../../../../properties"
+import * as Seldon from "../../../constants"
+import { ComponentExport, ComponentSchema } from "../../../types"
 
 export const schema = {
   name: "Join CTA",

--- a/packages/core/components/catalog/parts/specimens/ColorSpecimen.schema.ts
+++ b/packages/core/components/catalog/parts/specimens/ColorSpecimen.schema.ts
@@ -1,6 +1,10 @@
-import * as Sdn from "../../../../properties"
-import * as Seldon from "../../../constants"
-import { ComponentExport, ComponentSchema } from "../../../types"
+import * as Sdn from "../../../../properties";
+import * as Seldon from "../../../constants";
+import { ComponentExport, ComponentSchema } from "../../../types";
+
+
+
+
 
 export const schema = {
   name: "Color Specimen",
@@ -136,6 +140,201 @@ export const schema = {
   },
   default: {
     children: [
+      {
+        component: Seldon.ComponentId.CONTAINER,
+        overrides: {
+          gap: { type: Sdn.ValueType.THEME_ORDINAL, value: "@gap.tight" },
+          columns: { type: Sdn.ValueType.EXACT, value: 6 },
+        },
+        children: [
+          {
+            component: Seldon.ComponentId.COLOR_CHIP,
+            overrides: {
+              columnSpan: { type: Sdn.ValueType.EXACT, value: 2 },
+              background: [
+                {
+                  color: {
+                    type: Sdn.ValueType.THEME_CATEGORICAL,
+                    value: "@swatch.white",
+                  },
+                },
+              ],
+            },
+            children: [
+              {
+                component: Seldon.ComponentId.TEXT,
+                overrides: {
+                  content: { type: Sdn.ValueType.EXACT, value: "White" },
+                },
+              },
+              { component: Seldon.ComponentId.TEXT },
+              { component: Seldon.ComponentId.TEXT },
+            ],
+          },
+          {
+            component: Seldon.ComponentId.COLOR_CHIP,
+            overrides: {
+              columnSpan: { type: Sdn.ValueType.EXACT, value: 2 },
+              background: [
+                {
+                  color: {
+                    type: Sdn.ValueType.THEME_CATEGORICAL,
+                    value: "@swatch.gray",
+                  },
+                },
+              ],
+            },
+            children: [
+              {
+                component: Seldon.ComponentId.TEXT,
+                overrides: {
+                  content: { type: Sdn.ValueType.EXACT, value: "Gray" },
+                },
+              },
+              { component: Seldon.ComponentId.TEXT },
+              { component: Seldon.ComponentId.TEXT },
+            ],
+          },
+          {
+            component: Seldon.ComponentId.COLOR_CHIP,
+            overrides: {
+              columnSpan: { type: Sdn.ValueType.EXACT, value: 2 },
+              background: [
+                {
+                  color: {
+                    type: Sdn.ValueType.THEME_CATEGORICAL,
+                    value: "@swatch.black",
+                  },
+                },
+              ],
+            },
+            children: [
+              {
+                component: Seldon.ComponentId.TEXT,
+                overrides: {
+                  content: { type: Sdn.ValueType.EXACT, value: "Black" },
+                },
+              },
+              { component: Seldon.ComponentId.TEXT },
+              { component: Seldon.ComponentId.TEXT },
+            ],
+          },
+        ],
+      },
+      {
+        component: Seldon.ComponentId.CONTAINER,
+        overrides: {
+          gap: { type: Sdn.ValueType.THEME_ORDINAL, value: "@gap.tight" },
+          columns: { type: Sdn.ValueType.EXACT, value: 6 },
+        },
+        children: [
+          {
+            component: Seldon.ComponentId.COLOR_CHIP,
+            overrides: {
+              columnSpan: { type: Sdn.ValueType.EXACT, value: 3 },
+              background: [
+                {
+                  color: {
+                    type: Sdn.ValueType.THEME_CATEGORICAL,
+                    value: "@swatch.foreground",
+                  },
+                },
+              ],
+            },
+            children: [
+              {
+                component: Seldon.ComponentId.TEXT,
+                overrides: {
+                  content: { type: Sdn.ValueType.EXACT, value: "Foreground" },
+                },
+              },
+              { component: Seldon.ComponentId.TEXT },
+              { component: Seldon.ComponentId.TEXT },
+            ],
+          },
+          {
+            component: Seldon.ComponentId.COLOR_CHIP,
+            overrides: {
+              columnSpan: { type: Sdn.ValueType.EXACT, value: 3 },
+              background: [
+                {
+                  color: {
+                    type: Sdn.ValueType.THEME_CATEGORICAL,
+                    value: "@swatch.background",
+                  },
+                },
+              ],
+            },
+            children: [
+              {
+                component: Seldon.ComponentId.TEXT,
+                overrides: {
+                  content: { type: Sdn.ValueType.EXACT, value: "Background" },
+                },
+              },
+              { component: Seldon.ComponentId.TEXT },
+              { component: Seldon.ComponentId.TEXT },
+            ],
+          },
+        ],
+      },
+      {
+        component: Seldon.ComponentId.CONTAINER,
+        overrides: {
+          gap: { type: Sdn.ValueType.THEME_ORDINAL, value: "@gap.tight" },
+          columns: { type: Sdn.ValueType.EXACT, value: 6 },
+        },
+        children: [
+          {
+            component: Seldon.ComponentId.COLOR_CHIP,
+            overrides: {
+              columnSpan: { type: Sdn.ValueType.EXACT, value: 3 },
+              background: [
+                {
+                  color: {
+                    type: Sdn.ValueType.THEME_CATEGORICAL,
+                    value: "@swatch.offWhite",
+                  },
+                },
+              ],
+            },
+            children: [
+              {
+                component: Seldon.ComponentId.TEXT,
+                overrides: {
+                  content: { type: Sdn.ValueType.EXACT, value: "Off White" },
+                },
+              },
+              { component: Seldon.ComponentId.TEXT },
+              { component: Seldon.ComponentId.TEXT },
+            ],
+          },
+          {
+            component: Seldon.ComponentId.COLOR_CHIP,
+            overrides: {
+              columnSpan: { type: Sdn.ValueType.EXACT, value: 3 },
+              background: [
+                {
+                  color: {
+                    type: Sdn.ValueType.THEME_CATEGORICAL,
+                    value: "@swatch.offBlack",
+                  },
+                },
+              ],
+            },
+            children: [
+              {
+                component: Seldon.ComponentId.TEXT,
+                overrides: {
+                  content: { type: Sdn.ValueType.EXACT, value: "Off Black" },
+                },
+              },
+              { component: Seldon.ComponentId.TEXT },
+              { component: Seldon.ComponentId.TEXT },
+            ],
+          },
+        ],
+      },
       {
         component: Seldon.ComponentId.CONTAINER,
         overrides: {
@@ -382,201 +581,6 @@ export const schema = {
                 component: Seldon.ComponentId.TEXT,
                 overrides: {
                   content: { type: Sdn.ValueType.EXACT, value: "Accent" },
-                },
-              },
-              { component: Seldon.ComponentId.TEXT },
-              { component: Seldon.ComponentId.TEXT },
-            ],
-          },
-        ],
-      },
-      {
-        component: Seldon.ComponentId.CONTAINER,
-        overrides: {
-          gap: { type: Sdn.ValueType.THEME_ORDINAL, value: "@gap.tight" },
-          columns: { type: Sdn.ValueType.EXACT, value: 6 },
-        },
-        children: [
-          {
-            component: Seldon.ComponentId.COLOR_CHIP,
-            overrides: {
-              columnSpan: { type: Sdn.ValueType.EXACT, value: 2 },
-              background: [
-                {
-                  color: {
-                    type: Sdn.ValueType.THEME_CATEGORICAL,
-                    value: "@swatch.white",
-                  },
-                },
-              ],
-            },
-            children: [
-              {
-                component: Seldon.ComponentId.TEXT,
-                overrides: {
-                  content: { type: Sdn.ValueType.EXACT, value: "White" },
-                },
-              },
-              { component: Seldon.ComponentId.TEXT },
-              { component: Seldon.ComponentId.TEXT },
-            ],
-          },
-          {
-            component: Seldon.ComponentId.COLOR_CHIP,
-            overrides: {
-              columnSpan: { type: Sdn.ValueType.EXACT, value: 2 },
-              background: [
-                {
-                  color: {
-                    type: Sdn.ValueType.THEME_CATEGORICAL,
-                    value: "@swatch.gray",
-                  },
-                },
-              ],
-            },
-            children: [
-              {
-                component: Seldon.ComponentId.TEXT,
-                overrides: {
-                  content: { type: Sdn.ValueType.EXACT, value: "Gray" },
-                },
-              },
-              { component: Seldon.ComponentId.TEXT },
-              { component: Seldon.ComponentId.TEXT },
-            ],
-          },
-          {
-            component: Seldon.ComponentId.COLOR_CHIP,
-            overrides: {
-              columnSpan: { type: Sdn.ValueType.EXACT, value: 2 },
-              background: [
-                {
-                  color: {
-                    type: Sdn.ValueType.THEME_CATEGORICAL,
-                    value: "@swatch.black",
-                  },
-                },
-              ],
-            },
-            children: [
-              {
-                component: Seldon.ComponentId.TEXT,
-                overrides: {
-                  content: { type: Sdn.ValueType.EXACT, value: "Black" },
-                },
-              },
-              { component: Seldon.ComponentId.TEXT },
-              { component: Seldon.ComponentId.TEXT },
-            ],
-          },
-        ],
-      },
-      {
-        component: Seldon.ComponentId.CONTAINER,
-        overrides: {
-          gap: { type: Sdn.ValueType.THEME_ORDINAL, value: "@gap.tight" },
-          columns: { type: Sdn.ValueType.EXACT, value: 6 },
-        },
-        children: [
-          {
-            component: Seldon.ComponentId.COLOR_CHIP,
-            overrides: {
-              columnSpan: { type: Sdn.ValueType.EXACT, value: 3 },
-              background: [
-                {
-                  color: {
-                    type: Sdn.ValueType.THEME_CATEGORICAL,
-                    value: "@swatch.foreground",
-                  },
-                },
-              ],
-            },
-            children: [
-              {
-                component: Seldon.ComponentId.TEXT,
-                overrides: {
-                  content: { type: Sdn.ValueType.EXACT, value: "Foreground" },
-                },
-              },
-              { component: Seldon.ComponentId.TEXT },
-              { component: Seldon.ComponentId.TEXT },
-            ],
-          },
-          {
-            component: Seldon.ComponentId.COLOR_CHIP,
-            overrides: {
-              columnSpan: { type: Sdn.ValueType.EXACT, value: 3 },
-              background: [
-                {
-                  color: {
-                    type: Sdn.ValueType.THEME_CATEGORICAL,
-                    value: "@swatch.background",
-                  },
-                },
-              ],
-            },
-            children: [
-              {
-                component: Seldon.ComponentId.TEXT,
-                overrides: {
-                  content: { type: Sdn.ValueType.EXACT, value: "Background" },
-                },
-              },
-              { component: Seldon.ComponentId.TEXT },
-              { component: Seldon.ComponentId.TEXT },
-            ],
-          },
-        ],
-      },
-      {
-        component: Seldon.ComponentId.CONTAINER,
-        overrides: {
-          gap: { type: Sdn.ValueType.THEME_ORDINAL, value: "@gap.tight" },
-          columns: { type: Sdn.ValueType.EXACT, value: 6 },
-        },
-        children: [
-          {
-            component: Seldon.ComponentId.COLOR_CHIP,
-            overrides: {
-              columnSpan: { type: Sdn.ValueType.EXACT, value: 3 },
-              background: [
-                {
-                  color: {
-                    type: Sdn.ValueType.THEME_CATEGORICAL,
-                    value: "@swatch.offWhite",
-                  },
-                },
-              ],
-            },
-            children: [
-              {
-                component: Seldon.ComponentId.TEXT,
-                overrides: {
-                  content: { type: Sdn.ValueType.EXACT, value: "Off White" },
-                },
-              },
-              { component: Seldon.ComponentId.TEXT },
-              { component: Seldon.ComponentId.TEXT },
-            ],
-          },
-          {
-            component: Seldon.ComponentId.COLOR_CHIP,
-            overrides: {
-              columnSpan: { type: Sdn.ValueType.EXACT, value: 3 },
-              background: [
-                {
-                  color: {
-                    type: Sdn.ValueType.THEME_CATEGORICAL,
-                    value: "@swatch.offBlack",
-                  },
-                },
-              ],
-            },
-            children: [
-              {
-                component: Seldon.ComponentId.TEXT,
-                overrides: {
-                  content: { type: Sdn.ValueType.EXACT, value: "Off Black" },
                 },
               },
               { component: Seldon.ComponentId.TEXT },

--- a/packages/core/components/catalog/parts/specimens/ColorSpecimen.schema.ts
+++ b/packages/core/components/catalog/parts/specimens/ColorSpecimen.schema.ts
@@ -1,10 +1,6 @@
-import * as Sdn from "../../../../properties";
-import * as Seldon from "../../../constants";
-import { ComponentExport, ComponentSchema } from "../../../types";
-
-
-
-
+import * as Sdn from "../../../../properties"
+import * as Seldon from "../../../constants"
+import { ComponentExport, ComponentSchema } from "../../../types"
 
 export const schema = {
   name: "Color Specimen",

--- a/packages/core/components/catalog/parts/specimens/OrdinalSpecimen.schema.ts
+++ b/packages/core/components/catalog/parts/specimens/OrdinalSpecimen.schema.ts
@@ -1,6 +1,10 @@
-import * as Sdn from "../../../../properties"
-import * as Seldon from "../../../constants"
-import { ComponentExport, ComponentSchema } from "../../../types"
+import * as Sdn from "../../../../properties";
+import * as Seldon from "../../../constants";
+import { ComponentExport, ComponentSchema } from "../../../types";
+
+
+
+
 
 export const schema = {
   name: "Ordinal Specimen",
@@ -156,23 +160,26 @@ export const schema = {
         overrides: {
           orientation: {
             type: Sdn.ValueType.OPTION,
-            value: Sdn.Orientation.HORIZONTAL,
+            value: Sdn.Orientation.VERTICAL,
           },
           gap: { type: Sdn.ValueType.OPTION, value: Sdn.Gap.EVENLY_SPACED },
           margin: {
-            top: { type: Sdn.ValueType.THEME_ORDINAL, value: "@margin.cozy" },
-            right: { type: Sdn.ValueType.THEME_ORDINAL, value: "@margin.cozy" },
+            top: { type: Sdn.ValueType.OPTION, value: Sdn.Margin.NONE },
+            right: { type: Sdn.ValueType.OPTION, value: Sdn.Margin.NONE },
             bottom: {
-              type: Sdn.ValueType.THEME_ORDINAL,
-              value: "@margin.cozy",
+              type: Sdn.ValueType.OPTION,
+              value: Sdn.Margin.NONE,
             },
-            left: { type: Sdn.ValueType.THEME_ORDINAL, value: "@margin.cozy" },
+            left: { type: Sdn.ValueType.OPTION, value: Sdn.Margin.NONE },
           },
           padding: {
-            top: { type: Sdn.ValueType.EMPTY, value: null },
+            top: {
+              type: Sdn.ValueType.THEME_ORDINAL,
+              value: "@padding.cozy",
+            },
             right: {
               type: Sdn.ValueType.THEME_ORDINAL,
-              value: "@padding.tight",
+              value: "@padding.cozy",
             },
             bottom: {
               type: Sdn.ValueType.THEME_ORDINAL,
@@ -180,7 +187,7 @@ export const schema = {
             },
             left: {
               type: Sdn.ValueType.THEME_ORDINAL,
-              value: "@padding.tight",
+              value: "@padding.cozy",
             },
           },
           borderBottom: {
@@ -197,212 +204,269 @@ export const schema = {
         },
         children: [
           {
-            component: Seldon.ComponentId.BUTTON,
-            variant: "menu",
+            component: Seldon.ComponentId.FRAME,
             children: [
-              {
-                component: Seldon.ComponentId.ICON,
-                overrides: {
-                  symbol: {
-                    type: Sdn.ValueType.OPTION,
-                    value: "material-margin",
-                  },
-                },
-              },
               {
                 component: Seldon.ComponentId.TEXT,
                 overrides: {
-                  content: { type: Sdn.ValueType.EXACT, value: "Margin" },
-                },
-              },
-              {
-                component: Seldon.ComponentId.ICON,
-                overrides: {
-                  symbol: {
-                    type: Sdn.ValueType.OPTION,
-                    value: "material-chevronDown",
+                  content: {
+                    type: Sdn.ValueType.EXACT,
+                    value: "Use the controls below to see how various combinations of this theme's tokens work in practice.",
                   },
-                  size: {
-                    type: Sdn.ValueType.COMPUTED,
-                    value: Sdn.ComputedFunction.AUTO_FIT,
-                  },
-                  color: {
-                    type: Sdn.ValueType.COMPUTED,
-                    value: Sdn.ComputedFunction.HIGH_CONTRAST_COLOR,
-                  },
-                  cursor: {
-                    type: Sdn.ValueType.OPTION,
-                    value: Sdn.Cursor.POINTER,
+                  font: {
+                    preset: {
+                      type: Sdn.ValueType.THEME_CATEGORICAL,
+                      value: "@font.normal",
+                    },
+                    size: {
+                      type: Sdn.ValueType.THEME_ORDINAL,
+                      value: "@fontSize.xsmall",
+                    },
                   },
                 },
               },
             ],
           },
           {
-            component: Seldon.ComponentId.BUTTON,
-            variant: "menu",
+            component: Seldon.ComponentId.FRAME,
+            overrides: {
+              orientation: {
+                type: Sdn.ValueType.OPTION,
+                value: Sdn.Orientation.HORIZONTAL,
+              },
+              margin: {
+                top: {
+                  type: Sdn.ValueType.THEME_ORDINAL,
+                  value: "@margin.cozy",
+                },
+                right: { type: Sdn.ValueType.OPTION, value: Sdn.Margin.NONE },
+                bottom: {
+                  type: Sdn.ValueType.OPTION,
+                  value: Sdn.Margin.NONE,
+                },
+                left: { type: Sdn.ValueType.OPTION, value: Sdn.Margin.NONE },
+              },
+              padding: {
+                top: {
+                  type: Sdn.ValueType.OPTION,
+                  value: Sdn.Padding.NONE,
+                },
+                right: { type: Sdn.ValueType.OPTION, value: Sdn.Padding.NONE },
+                bottom: { type: Sdn.ValueType.OPTION, value: Sdn.Padding.NONE },
+                left: { type: Sdn.ValueType.OPTION, value: Sdn.Padding.NONE },
+              },
+              gap: { type: Sdn.ValueType.OPTION, value: Sdn.Gap.EVENLY_SPACED },
+            },
             children: [
               {
-                component: Seldon.ComponentId.ICON,
-                overrides: {
-                  symbol: {
-                    type: Sdn.ValueType.OPTION,
-                    value: "material-padding",
+                component: Seldon.ComponentId.BUTTON,
+                variant: "menu",
+                children: [
+                  {
+                    component: Seldon.ComponentId.ICON,
+                    overrides: {
+                      symbol: {
+                        type: Sdn.ValueType.OPTION,
+                        value: "material-margin",
+                      },
+                    },
                   },
-                },
+                  {
+                    component: Seldon.ComponentId.TEXT,
+                    overrides: {
+                      content: { type: Sdn.ValueType.EXACT, value: "Margin" },
+                    },
+                  },
+                  {
+                    component: Seldon.ComponentId.ICON,
+                    overrides: {
+                      symbol: {
+                        type: Sdn.ValueType.OPTION,
+                        value: "material-chevronDown",
+                      },
+                      size: {
+                        type: Sdn.ValueType.COMPUTED,
+                        value: Sdn.ComputedFunction.AUTO_FIT,
+                      },
+                      color: {
+                        type: Sdn.ValueType.COMPUTED,
+                        value: Sdn.ComputedFunction.HIGH_CONTRAST_COLOR,
+                      },
+                      cursor: {
+                        type: Sdn.ValueType.OPTION,
+                        value: Sdn.Cursor.POINTER,
+                      },
+                    },
+                  },
+                ],
               },
               {
-                component: Seldon.ComponentId.TEXT,
-                overrides: {
-                  content: { type: Sdn.ValueType.EXACT, value: "Padding" },
-                },
+                component: Seldon.ComponentId.BUTTON,
+                variant: "menu",
+                children: [
+                  {
+                    component: Seldon.ComponentId.ICON,
+                    overrides: {
+                      symbol: {
+                        type: Sdn.ValueType.OPTION,
+                        value: "material-padding",
+                      },
+                    },
+                  },
+                  {
+                    component: Seldon.ComponentId.TEXT,
+                    overrides: {
+                      content: { type: Sdn.ValueType.EXACT, value: "Padding" },
+                    },
+                  },
+                  {
+                    component: Seldon.ComponentId.ICON,
+                    overrides: {
+                      symbol: {
+                        type: Sdn.ValueType.OPTION,
+                        value: "material-chevronDown",
+                      },
+                      size: {
+                        type: Sdn.ValueType.COMPUTED,
+                        value: Sdn.ComputedFunction.AUTO_FIT,
+                      },
+                      color: {
+                        type: Sdn.ValueType.COMPUTED,
+                        value: Sdn.ComputedFunction.HIGH_CONTRAST_COLOR,
+                      },
+                      cursor: {
+                        type: Sdn.ValueType.OPTION,
+                        value: Sdn.Cursor.POINTER,
+                      },
+                    },
+                  },
+                ],
               },
               {
-                component: Seldon.ComponentId.ICON,
-                overrides: {
-                  symbol: {
-                    type: Sdn.ValueType.OPTION,
-                    value: "material-chevronDown",
+                component: Seldon.ComponentId.BUTTON,
+                variant: "menu",
+                children: [
+                  {
+                    component: Seldon.ComponentId.ICON,
+                    overrides: {
+                      symbol: {
+                        type: Sdn.ValueType.OPTION,
+                        value: "seldon-gap",
+                      },
+                    },
                   },
-                  size: {
-                    type: Sdn.ValueType.COMPUTED,
-                    value: Sdn.ComputedFunction.AUTO_FIT,
+                  {
+                    component: Seldon.ComponentId.TEXT,
+                    overrides: {
+                      content: { type: Sdn.ValueType.EXACT, value: "Gap" },
+                    },
                   },
-                  color: {
-                    type: Sdn.ValueType.COMPUTED,
-                    value: Sdn.ComputedFunction.HIGH_CONTRAST_COLOR,
+                  {
+                    component: Seldon.ComponentId.ICON,
+                    overrides: {
+                      symbol: {
+                        type: Sdn.ValueType.OPTION,
+                        value: "material-chevronDown",
+                      },
+                      size: {
+                        type: Sdn.ValueType.COMPUTED,
+                        value: Sdn.ComputedFunction.AUTO_FIT,
+                      },
+                      color: {
+                        type: Sdn.ValueType.COMPUTED,
+                        value: Sdn.ComputedFunction.HIGH_CONTRAST_COLOR,
+                      },
+                      cursor: {
+                        type: Sdn.ValueType.OPTION,
+                        value: Sdn.Cursor.POINTER,
+                      },
+                    },
                   },
-                  cursor: {
-                    type: Sdn.ValueType.OPTION,
-                    value: Sdn.Cursor.POINTER,
-                  },
-                },
-              },
-            ],
-          },
-          {
-            component: Seldon.ComponentId.BUTTON,
-            variant: "menu",
-            children: [
-              {
-                component: Seldon.ComponentId.ICON,
-                overrides: {
-                  symbol: {
-                    type: Sdn.ValueType.OPTION,
-                    value: "seldon-gap",
-                  },
-                },
-              },
-              {
-                component: Seldon.ComponentId.TEXT,
-                overrides: {
-                  content: { type: Sdn.ValueType.EXACT, value: "Gap" },
-                },
-              },
-              {
-                component: Seldon.ComponentId.ICON,
-                overrides: {
-                  symbol: {
-                    type: Sdn.ValueType.OPTION,
-                    value: "material-chevronDown",
-                  },
-                  size: {
-                    type: Sdn.ValueType.COMPUTED,
-                    value: Sdn.ComputedFunction.AUTO_FIT,
-                  },
-                  color: {
-                    type: Sdn.ValueType.COMPUTED,
-                    value: Sdn.ComputedFunction.HIGH_CONTRAST_COLOR,
-                  },
-                  cursor: {
-                    type: Sdn.ValueType.OPTION,
-                    value: Sdn.Cursor.POINTER,
-                  },
-                },
-              },
-            ],
-          },
-          {
-            component: Seldon.ComponentId.BUTTON,
-            variant: "menu",
-            children: [
-              {
-                component: Seldon.ComponentId.ICON,
-                overrides: {
-                  symbol: {
-                    type: Sdn.ValueType.OPTION,
-                    value: "material-borderStyle",
-                  },
-                },
+                ],
               },
               {
-                component: Seldon.ComponentId.TEXT,
-                overrides: {
-                  content: { type: Sdn.ValueType.EXACT, value: "Border" },
-                },
+                component: Seldon.ComponentId.BUTTON,
+                variant: "menu",
+                children: [
+                  {
+                    component: Seldon.ComponentId.ICON,
+                    overrides: {
+                      symbol: {
+                        type: Sdn.ValueType.OPTION,
+                        value: "material-borderStyle",
+                      },
+                    },
+                  },
+                  {
+                    component: Seldon.ComponentId.TEXT,
+                    overrides: {
+                      content: { type: Sdn.ValueType.EXACT, value: "Border" },
+                    },
+                  },
+                  {
+                    component: Seldon.ComponentId.ICON,
+                    overrides: {
+                      symbol: {
+                        type: Sdn.ValueType.OPTION,
+                        value: "material-chevronDown",
+                      },
+                      size: {
+                        type: Sdn.ValueType.COMPUTED,
+                        value: Sdn.ComputedFunction.AUTO_FIT,
+                      },
+                      color: {
+                        type: Sdn.ValueType.COMPUTED,
+                        value: Sdn.ComputedFunction.HIGH_CONTRAST_COLOR,
+                      },
+                      cursor: {
+                        type: Sdn.ValueType.OPTION,
+                        value: Sdn.Cursor.POINTER,
+                      },
+                    },
+                  },
+                ],
               },
               {
-                component: Seldon.ComponentId.ICON,
-                overrides: {
-                  symbol: {
-                    type: Sdn.ValueType.OPTION,
-                    value: "material-chevronDown",
+                component: Seldon.ComponentId.BUTTON,
+                variant: "menu",
+                children: [
+                  {
+                    component: Seldon.ComponentId.ICON,
+                    overrides: {
+                      symbol: {
+                        type: Sdn.ValueType.OPTION,
+                        value: "material-roundedCorner",
+                      },
+                    },
                   },
-                  size: {
-                    type: Sdn.ValueType.COMPUTED,
-                    value: Sdn.ComputedFunction.AUTO_FIT,
+                  {
+                    component: Seldon.ComponentId.TEXT,
+                    overrides: {
+                      content: { type: Sdn.ValueType.EXACT, value: "Corners" },
+                    },
                   },
-                  color: {
-                    type: Sdn.ValueType.COMPUTED,
-                    value: Sdn.ComputedFunction.HIGH_CONTRAST_COLOR,
+                  {
+                    component: Seldon.ComponentId.ICON,
+                    overrides: {
+                      symbol: {
+                        type: Sdn.ValueType.OPTION,
+                        value: "material-chevronDown",
+                      },
+                      size: {
+                        type: Sdn.ValueType.COMPUTED,
+                        value: Sdn.ComputedFunction.AUTO_FIT,
+                      },
+                      color: {
+                        type: Sdn.ValueType.COMPUTED,
+                        value: Sdn.ComputedFunction.HIGH_CONTRAST_COLOR,
+                      },
+                      cursor: {
+                        type: Sdn.ValueType.OPTION,
+                        value: Sdn.Cursor.POINTER,
+                      },
+                    },
                   },
-                  cursor: {
-                    type: Sdn.ValueType.OPTION,
-                    value: Sdn.Cursor.POINTER,
-                  },
-                },
-              },
-            ],
-          },
-          {
-            component: Seldon.ComponentId.BUTTON,
-            variant: "menu",
-            children: [
-              {
-                component: Seldon.ComponentId.ICON,
-                overrides: {
-                  symbol: {
-                    type: Sdn.ValueType.OPTION,
-                    value: "material-roundedCorner",
-                  },
-                },
-              },
-              {
-                component: Seldon.ComponentId.TEXT,
-                overrides: {
-                  content: { type: Sdn.ValueType.EXACT, value: "Corners" },
-                },
-              },
-              {
-                component: Seldon.ComponentId.ICON,
-                overrides: {
-                  symbol: {
-                    type: Sdn.ValueType.OPTION,
-                    value: "material-chevronDown",
-                  },
-                  size: {
-                    type: Sdn.ValueType.COMPUTED,
-                    value: Sdn.ComputedFunction.AUTO_FIT,
-                  },
-                  color: {
-                    type: Sdn.ValueType.COMPUTED,
-                    value: Sdn.ComputedFunction.HIGH_CONTRAST_COLOR,
-                  },
-                  cursor: {
-                    type: Sdn.ValueType.OPTION,
-                    value: Sdn.Cursor.POINTER,
-                  },
-                },
+                ],
               },
             ],
           },
@@ -428,7 +492,7 @@ export const schema = {
         },
         children: [
           { component: Seldon.ComponentId.ORDINAL_CHIP },
-          { 
+          {
             component: Seldon.ComponentId.ORDINAL_CHIP,
             overrides: {
               opacity: {
@@ -436,7 +500,7 @@ export const schema = {
                 value: { unit: Sdn.Unit.PERCENT, value: 100 },
               },
             },
-           },
+          },
           { component: Seldon.ComponentId.ORDINAL_CHIP },
         ],
       },

--- a/packages/core/components/catalog/parts/specimens/OrdinalSpecimen.schema.ts
+++ b/packages/core/components/catalog/parts/specimens/OrdinalSpecimen.schema.ts
@@ -1,0 +1,389 @@
+import * as Sdn from "../../../../properties"
+import * as Seldon from "../../../constants"
+import { ComponentExport, ComponentSchema } from "../../../types"
+
+const legendLabel = {
+  width: { type: Sdn.ValueType.OPTION, value: Sdn.Resize.FILL },
+  color: {
+    type: Sdn.ValueType.COMPUTED,
+    value: Sdn.ComputedFunction.HIGH_CONTRAST_COLOR,
+  },
+  font: {
+    preset: {
+      type: Sdn.ValueType.THEME_CATEGORICAL,
+      value: "@font.label",
+    },
+    size: {
+      type: Sdn.ValueType.THEME_ORDINAL,
+      value: "@fontSize.xsmall",
+    },
+  },
+} as const
+
+const legendIcon = {
+  size: { type: Sdn.ValueType.THEME_ORDINAL, value: "@size.small" },
+  color: {
+    type: Sdn.ValueType.COMPUTED,
+    value: Sdn.ComputedFunction.HIGH_CONTRAST_COLOR,
+  },
+} as const
+
+const container = {
+  gap: { type: Sdn.ValueType.OPTION, value: Sdn.Gap.NONE },
+  columns: { type: Sdn.ValueType.EXACT, value: 6 },
+} as const
+
+export const schema = {
+  name: "Ordinal Specimen",
+  id: Seldon.ComponentId.ORDINAL_SPECIMEN,
+  intent:
+    "Schema for an ordinal specimen that lays out theme ordinal scales as labeled chips in grouped grids beneath a legend.",
+  tags: ["ordinal", "specimen", "scale", "spacing", "theme", "grid", "ui"],
+  level: Seldon.ComponentLevel.PART,
+  icon: Seldon.ComponentIcon.COMPONENT,
+  properties: {
+    display: { type: Sdn.ValueType.EMPTY, value: null },
+    direction: { type: Sdn.ValueType.EMPTY, value: null },
+    orientation: {
+      type: Sdn.ValueType.OPTION,
+      value: Sdn.Orientation.VERTICAL,
+    },
+    align: { type: Sdn.ValueType.EMPTY, value: null },
+    width: {
+      type: Sdn.ValueType.OPTION,
+      value: Sdn.Resize.FILL,
+    },
+    height: {
+      type: Sdn.ValueType.OPTION,
+      value: Sdn.Resize.FIT,
+    },
+    margin: {
+      top: { type: Sdn.ValueType.THEME_ORDINAL, value: "@margin.tight" },
+      right: { type: Sdn.ValueType.THEME_ORDINAL, value: "@margin.tight" },
+      bottom: { type: Sdn.ValueType.THEME_ORDINAL, value: "@margin.tight" },
+      left: { type: Sdn.ValueType.THEME_ORDINAL, value: "@margin.tight" },
+    },
+    padding: {
+      top: { type: Sdn.ValueType.OPTION, value: Sdn.Padding.NONE },
+      right: { type: Sdn.ValueType.OPTION, value: Sdn.Padding.NONE },
+      bottom: { type: Sdn.ValueType.OPTION, value: Sdn.Padding.NONE },
+      left: { type: Sdn.ValueType.OPTION, value: Sdn.Padding.NONE },
+    },
+    gap: {
+      type: Sdn.ValueType.OPTION,
+      value: Sdn.Gap.NONE,
+    },
+    wrapChildren: {
+      type: Sdn.ValueType.EXACT,
+      value: false,
+    },
+    clip: { type: Sdn.ValueType.EMPTY, value: null },
+    columnStart: { type: Sdn.ValueType.EMPTY, value: null },
+    columnSpan: { type: Sdn.ValueType.EMPTY, value: null },
+    rowStart: { type: Sdn.ValueType.EMPTY, value: null },
+    rowSpan: { type: Sdn.ValueType.EMPTY, value: null },
+    color: { type: Sdn.ValueType.EMPTY, value: null },
+    brightness: { type: Sdn.ValueType.EMPTY, value: null },
+    opacity: { type: Sdn.ValueType.EMPTY, value: null },
+    background: [
+      {
+        kind: { type: Sdn.ValueType.OPTION, value: Sdn.BackgroundKind.COLOR },
+        color: {
+          type: Sdn.ValueType.OPTION,
+          value: Sdn.Color.TRANSPARENT,
+        },
+        brightness: { type: Sdn.ValueType.EMPTY, value: null },
+        opacity: { type: Sdn.ValueType.EMPTY, value: null },
+      },
+    ],
+    border: {
+      preset: {
+        type: Sdn.ValueType.THEME_CATEGORICAL,
+        value: "@border.hairline",
+      },
+      style: { type: Sdn.ValueType.EMPTY, value: null },
+      color: {
+        type: Sdn.ValueType.THEME_CATEGORICAL,
+        value: "@swatch.offBlack",
+      },
+      width: { type: Sdn.ValueType.EMPTY, value: null },
+      brightness: { type: Sdn.ValueType.EMPTY, value: null },
+      opacity: {
+        type: Sdn.ValueType.EXACT,
+        value: { unit: Sdn.Unit.PERCENT, value: 50 },
+      },
+    },
+    borderTop: {
+      preset: { type: Sdn.ValueType.EMPTY, value: null },
+      style: { type: Sdn.ValueType.EMPTY, value: null },
+      color: { type: Sdn.ValueType.EMPTY, value: null },
+      width: { type: Sdn.ValueType.EMPTY, value: null },
+      brightness: { type: Sdn.ValueType.EMPTY, value: null },
+      opacity: { type: Sdn.ValueType.EMPTY, value: null },
+    },
+    borderRight: {
+      preset: { type: Sdn.ValueType.EMPTY, value: null },
+      style: { type: Sdn.ValueType.EMPTY, value: null },
+      color: { type: Sdn.ValueType.EMPTY, value: null },
+      width: { type: Sdn.ValueType.EMPTY, value: null },
+      brightness: { type: Sdn.ValueType.EMPTY, value: null },
+      opacity: { type: Sdn.ValueType.EMPTY, value: null },
+    },
+    borderBottom: {
+      preset: { type: Sdn.ValueType.EMPTY, value: null },
+      style: { type: Sdn.ValueType.EMPTY, value: null },
+      color: { type: Sdn.ValueType.EMPTY, value: null },
+      width: { type: Sdn.ValueType.EMPTY, value: null },
+      brightness: { type: Sdn.ValueType.EMPTY, value: null },
+      opacity: { type: Sdn.ValueType.EMPTY, value: null },
+    },
+    borderLeft: {
+      preset: { type: Sdn.ValueType.EMPTY, value: null },
+      style: { type: Sdn.ValueType.EMPTY, value: null },
+      color: { type: Sdn.ValueType.EMPTY, value: null },
+      width: { type: Sdn.ValueType.EMPTY, value: null },
+      brightness: { type: Sdn.ValueType.EMPTY, value: null },
+      opacity: { type: Sdn.ValueType.EMPTY, value: null },
+    },
+    corners: {
+      topLeft: { type: Sdn.ValueType.THEME_ORDINAL, value: "@corners.tight" },
+      topRight: { type: Sdn.ValueType.THEME_ORDINAL, value: "@corners.tight" },
+      bottomLeft: {
+        type: Sdn.ValueType.THEME_ORDINAL,
+        value: "@corners.tight",
+      },
+      bottomRight: {
+        type: Sdn.ValueType.THEME_ORDINAL,
+        value: "@corners.tight",
+      },
+    },
+    shadow: [
+      {
+        preset: {
+          type: Sdn.ValueType.THEME_CATEGORICAL,
+          value: "@shadow.none",
+        },
+        style: { type: Sdn.ValueType.EMPTY, value: null },
+        offsetX: { type: Sdn.ValueType.EMPTY, value: null },
+        offsetY: { type: Sdn.ValueType.EMPTY, value: null },
+        blur: { type: Sdn.ValueType.EMPTY, value: null },
+        color: { type: Sdn.ValueType.EMPTY, value: null },
+        brightness: { type: Sdn.ValueType.EMPTY, value: null },
+        opacity: { type: Sdn.ValueType.EMPTY, value: null },
+        spread: { type: Sdn.ValueType.EMPTY, value: null },
+      },
+    ],
+    role: { type: Sdn.ValueType.EMPTY, value: null },
+    ariaLabel: { type: Sdn.ValueType.EMPTY, value: null },
+    ariaHidden: {
+      type: Sdn.ValueType.EXACT,
+      value: false,
+    },
+  },
+  default: {
+    children: [
+      {
+        component: Seldon.ComponentId.FRAME,
+        overrides: {
+          orientation: {
+            type: Sdn.ValueType.OPTION,
+            value: Sdn.Orientation.HORIZONTAL,
+          },
+          gap: { type: Sdn.ValueType.THEME_ORDINAL, value: "@gap.cozy" },
+          margin: {
+            top: { type: Sdn.ValueType.THEME_ORDINAL, value: "@margin.cozy" },
+            right: { type: Sdn.ValueType.THEME_ORDINAL, value: "@margin.cozy" },
+            bottom: {
+              type: Sdn.ValueType.THEME_ORDINAL,
+              value: "@margin.cozy",
+            },
+            left: { type: Sdn.ValueType.THEME_ORDINAL, value: "@margin.cozy" },
+          },
+          padding: {
+            top: { type: Sdn.ValueType.EMPTY, value: null },
+            right: { type: Sdn.ValueType.EMPTY, value: null },
+            bottom: {
+              type: Sdn.ValueType.THEME_ORDINAL,
+              value: "@padding.cozy",
+            },
+            left: { type: Sdn.ValueType.EMPTY, value: null },
+          },
+          borderBottom: {
+            preset: {
+              type: Sdn.ValueType.THEME_CATEGORICAL,
+              value: "@border.hairline",
+            },
+            brightness: { type: Sdn.ValueType.EMPTY, value: null },
+            opacity: {
+              type: Sdn.ValueType.EXACT,
+              value: { unit: Sdn.Unit.PERCENT, value: 50 },
+            },
+          },
+        },
+        children: [
+          {
+            component: Seldon.ComponentId.MENU_ITEM,
+            overrides: {
+              width: { type: Sdn.ValueType.OPTION, value: Sdn.Resize.FIT },
+            },
+            children: [
+              {
+                component: Seldon.ComponentId.ICON,
+                overrides: {
+                  symbol: {
+                    type: Sdn.ValueType.OPTION,
+                    value: "material-margin",
+                  },
+                  ...legendIcon,
+                },
+              },
+              {
+                component: Seldon.ComponentId.TEXT,
+                variant: "label",
+                overrides: {
+                  content: { type: Sdn.ValueType.EXACT, value: "Margin" },
+                  ...legendLabel,
+                },
+              },
+            ],
+          },
+          {
+            component: Seldon.ComponentId.MENU_ITEM,
+            overrides: {
+              width: { type: Sdn.ValueType.OPTION, value: Sdn.Resize.FIT },
+            },
+            children: [
+              {
+                component: Seldon.ComponentId.ICON,
+                overrides: {
+                  symbol: {
+                    type: Sdn.ValueType.OPTION,
+                    value: "material-padding",
+                  },
+                  ...legendIcon,
+                },
+              },
+              {
+                component: Seldon.ComponentId.TEXT,
+                variant: "label",
+                overrides: {
+                  content: { type: Sdn.ValueType.EXACT, value: "Padding" },
+                  ...legendLabel,
+                },
+              },
+            ],
+          },
+          {
+            component: Seldon.ComponentId.MENU_ITEM,
+            overrides: {
+              width: { type: Sdn.ValueType.OPTION, value: Sdn.Resize.FIT },
+            },
+            children: [
+              {
+                component: Seldon.ComponentId.ICON,
+                overrides: {
+                  symbol: {
+                    type: Sdn.ValueType.OPTION,
+                    value: "seldon-gap",
+                  },
+                  ...legendIcon,
+                },
+              },
+              {
+                component: Seldon.ComponentId.TEXT,
+                variant: "label",
+                overrides: {
+                  content: { type: Sdn.ValueType.EXACT, value: "Gap" },
+                  ...legendLabel,
+                },
+              },
+            ],
+          },
+          {
+            component: Seldon.ComponentId.MENU_ITEM,
+            overrides: {
+              width: { type: Sdn.ValueType.OPTION, value: Sdn.Resize.FIT },
+            },
+            children: [
+              {
+                component: Seldon.ComponentId.ICON,
+                overrides: {
+                  symbol: {
+                    type: Sdn.ValueType.OPTION,
+                    value: "material-borderStyle",
+                  },
+                  ...legendIcon,
+                },
+              },
+              {
+                component: Seldon.ComponentId.TEXT,
+                variant: "label",
+                overrides: {
+                  content: { type: Sdn.ValueType.EXACT, value: "Border" },
+                  ...legendLabel,
+                },
+              },
+            ],
+          },
+          {
+            component: Seldon.ComponentId.MENU_ITEM,
+            overrides: {
+              width: { type: Sdn.ValueType.OPTION, value: Sdn.Resize.FIT },
+            },
+            children: [
+              {
+                component: Seldon.ComponentId.ICON,
+                overrides: {
+                  symbol: {
+                    type: Sdn.ValueType.OPTION,
+                    value: "material-roundedCorner",
+                  },
+                  ...legendIcon,
+                },
+              },
+              {
+                component: Seldon.ComponentId.TEXT,
+                variant: "label",
+                overrides: {
+                  content: { type: Sdn.ValueType.EXACT, value: "Corners" },
+                  ...legendLabel,
+                },
+              },
+            ],
+          },
+        ],
+      },
+      {
+        component: Seldon.ComponentId.CONTAINER,
+        overrides: container,
+        children: [
+          { component: Seldon.ComponentId.ORDINAL_CHIP },
+          { component: Seldon.ComponentId.ORDINAL_CHIP },
+          { component: Seldon.ComponentId.ORDINAL_CHIP },
+        ],
+      },
+      {
+        component: Seldon.ComponentId.CONTAINER,
+        overrides: container,
+        children: [
+          { component: Seldon.ComponentId.ORDINAL_CHIP },
+          { component: Seldon.ComponentId.ORDINAL_CHIP },
+          { component: Seldon.ComponentId.ORDINAL_CHIP },
+        ],
+      },
+      {
+        component: Seldon.ComponentId.CONTAINER,
+        overrides: container,
+        children: [
+          { component: Seldon.ComponentId.ORDINAL_CHIP },
+          { component: Seldon.ComponentId.ORDINAL_CHIP },
+          { component: Seldon.ComponentId.ORDINAL_CHIP },
+        ],
+      },
+    ],
+  },
+} as const satisfies ComponentSchema
+
+export const exportConfig: ComponentExport = {
+  react: { returns: "HTMLDiv" },
+}

--- a/packages/core/components/catalog/parts/specimens/OrdinalSpecimen.schema.ts
+++ b/packages/core/components/catalog/parts/specimens/OrdinalSpecimen.schema.ts
@@ -1,10 +1,6 @@
-import * as Sdn from "../../../../properties";
-import * as Seldon from "../../../constants";
-import { ComponentExport, ComponentSchema } from "../../../types";
-
-
-
-
+import * as Sdn from "../../../../properties"
+import * as Seldon from "../../../constants"
+import { ComponentExport, ComponentSchema } from "../../../types"
 
 export const schema = {
   name: "Ordinal Specimen",
@@ -211,7 +207,8 @@ export const schema = {
                 overrides: {
                   content: {
                     type: Sdn.ValueType.EXACT,
-                    value: "Use the controls below to see how various combinations of this theme's tokens work in practice.",
+                    value:
+                      "Use the controls below to see how various combinations of this theme's tokens work in practice.",
                   },
                   font: {
                     preset: {

--- a/packages/core/components/catalog/parts/specimens/OrdinalSpecimen.schema.ts
+++ b/packages/core/components/catalog/parts/specimens/OrdinalSpecimen.schema.ts
@@ -1,31 +1,22 @@
-import * as Sdn from "../../../../properties"
-import * as Seldon from "../../../constants"
-import { ComponentExport, ComponentSchema } from "../../../types"
+import * as Sdn from "../../../../properties";
+import * as Seldon from "../../../constants";
+import { ComponentExport, ComponentSchema } from "../../../types";
 
-const legendLabel = {
-  width: { type: Sdn.ValueType.OPTION, value: Sdn.Resize.FILL },
+
+
+
+
+const legendButtonChevron = {
+  symbol: { type: Sdn.ValueType.OPTION, value: "material-chevronDown" },
+  size: {
+    type: Sdn.ValueType.COMPUTED,
+    value: Sdn.ComputedFunction.AUTO_FIT,
+  },
   color: {
     type: Sdn.ValueType.COMPUTED,
     value: Sdn.ComputedFunction.HIGH_CONTRAST_COLOR,
   },
-  font: {
-    preset: {
-      type: Sdn.ValueType.THEME_CATEGORICAL,
-      value: "@font.label",
-    },
-    size: {
-      type: Sdn.ValueType.THEME_ORDINAL,
-      value: "@fontSize.xsmall",
-    },
-  },
-} as const
-
-const legendIcon = {
-  size: { type: Sdn.ValueType.THEME_ORDINAL, value: "@size.small" },
-  color: {
-    type: Sdn.ValueType.COMPUTED,
-    value: Sdn.ComputedFunction.HIGH_CONTRAST_COLOR,
-  },
+  cursor: { type: Sdn.ValueType.OPTION, value: Sdn.Cursor.POINTER },
 } as const
 
 const container = {
@@ -189,7 +180,7 @@ export const schema = {
             type: Sdn.ValueType.OPTION,
             value: Sdn.Orientation.HORIZONTAL,
           },
-          gap: { type: Sdn.ValueType.THEME_ORDINAL, value: "@gap.cozy" },
+          gap: { type: Sdn.ValueType.OPTION, value: Sdn.Gap.EVENLY_SPACED },
           margin: {
             top: { type: Sdn.ValueType.THEME_ORDINAL, value: "@margin.cozy" },
             right: { type: Sdn.ValueType.THEME_ORDINAL, value: "@margin.cozy" },
@@ -201,12 +192,18 @@ export const schema = {
           },
           padding: {
             top: { type: Sdn.ValueType.EMPTY, value: null },
-            right: { type: Sdn.ValueType.EMPTY, value: null },
+            right: {
+              type: Sdn.ValueType.THEME_ORDINAL,
+              value: "@padding.tight",
+            },
             bottom: {
               type: Sdn.ValueType.THEME_ORDINAL,
               value: "@padding.cozy",
             },
-            left: { type: Sdn.ValueType.EMPTY, value: null },
+            left: {
+              type: Sdn.ValueType.THEME_ORDINAL,
+              value: "@padding.tight",
+            },
           },
           borderBottom: {
             preset: {
@@ -222,10 +219,8 @@ export const schema = {
         },
         children: [
           {
-            component: Seldon.ComponentId.MENU_ITEM,
-            overrides: {
-              width: { type: Sdn.ValueType.OPTION, value: Sdn.Resize.FIT },
-            },
+            component: Seldon.ComponentId.BUTTON,
+            variant: "menu",
             children: [
               {
                 component: Seldon.ComponentId.ICON,
@@ -234,24 +229,23 @@ export const schema = {
                     type: Sdn.ValueType.OPTION,
                     value: "material-margin",
                   },
-                  ...legendIcon,
                 },
               },
               {
                 component: Seldon.ComponentId.TEXT,
-                variant: "label",
                 overrides: {
                   content: { type: Sdn.ValueType.EXACT, value: "Margin" },
-                  ...legendLabel,
                 },
+              },
+              {
+                component: Seldon.ComponentId.ICON,
+                overrides: legendButtonChevron,
               },
             ],
           },
           {
-            component: Seldon.ComponentId.MENU_ITEM,
-            overrides: {
-              width: { type: Sdn.ValueType.OPTION, value: Sdn.Resize.FIT },
-            },
+            component: Seldon.ComponentId.BUTTON,
+            variant: "menu",
             children: [
               {
                 component: Seldon.ComponentId.ICON,
@@ -260,24 +254,23 @@ export const schema = {
                     type: Sdn.ValueType.OPTION,
                     value: "material-padding",
                   },
-                  ...legendIcon,
                 },
               },
               {
                 component: Seldon.ComponentId.TEXT,
-                variant: "label",
                 overrides: {
                   content: { type: Sdn.ValueType.EXACT, value: "Padding" },
-                  ...legendLabel,
                 },
+              },
+              {
+                component: Seldon.ComponentId.ICON,
+                overrides: legendButtonChevron,
               },
             ],
           },
           {
-            component: Seldon.ComponentId.MENU_ITEM,
-            overrides: {
-              width: { type: Sdn.ValueType.OPTION, value: Sdn.Resize.FIT },
-            },
+            component: Seldon.ComponentId.BUTTON,
+            variant: "menu",
             children: [
               {
                 component: Seldon.ComponentId.ICON,
@@ -286,24 +279,23 @@ export const schema = {
                     type: Sdn.ValueType.OPTION,
                     value: "seldon-gap",
                   },
-                  ...legendIcon,
                 },
               },
               {
                 component: Seldon.ComponentId.TEXT,
-                variant: "label",
                 overrides: {
                   content: { type: Sdn.ValueType.EXACT, value: "Gap" },
-                  ...legendLabel,
                 },
+              },
+              {
+                component: Seldon.ComponentId.ICON,
+                overrides: legendButtonChevron,
               },
             ],
           },
           {
-            component: Seldon.ComponentId.MENU_ITEM,
-            overrides: {
-              width: { type: Sdn.ValueType.OPTION, value: Sdn.Resize.FIT },
-            },
+            component: Seldon.ComponentId.BUTTON,
+            variant: "menu",
             children: [
               {
                 component: Seldon.ComponentId.ICON,
@@ -312,24 +304,23 @@ export const schema = {
                     type: Sdn.ValueType.OPTION,
                     value: "material-borderStyle",
                   },
-                  ...legendIcon,
                 },
               },
               {
                 component: Seldon.ComponentId.TEXT,
-                variant: "label",
                 overrides: {
                   content: { type: Sdn.ValueType.EXACT, value: "Border" },
-                  ...legendLabel,
                 },
+              },
+              {
+                component: Seldon.ComponentId.ICON,
+                overrides: legendButtonChevron,
               },
             ],
           },
           {
-            component: Seldon.ComponentId.MENU_ITEM,
-            overrides: {
-              width: { type: Sdn.ValueType.OPTION, value: Sdn.Resize.FIT },
-            },
+            component: Seldon.ComponentId.BUTTON,
+            variant: "menu",
             children: [
               {
                 component: Seldon.ComponentId.ICON,
@@ -338,16 +329,17 @@ export const schema = {
                     type: Sdn.ValueType.OPTION,
                     value: "material-roundedCorner",
                   },
-                  ...legendIcon,
                 },
               },
               {
                 component: Seldon.ComponentId.TEXT,
-                variant: "label",
                 overrides: {
                   content: { type: Sdn.ValueType.EXACT, value: "Corners" },
-                  ...legendLabel,
                 },
+              },
+              {
+                component: Seldon.ComponentId.ICON,
+                overrides: legendButtonChevron,
               },
             ],
           },

--- a/packages/core/components/catalog/parts/specimens/OrdinalSpecimen.schema.ts
+++ b/packages/core/components/catalog/parts/specimens/OrdinalSpecimen.schema.ts
@@ -1,28 +1,6 @@
-import * as Sdn from "../../../../properties";
-import * as Seldon from "../../../constants";
-import { ComponentExport, ComponentSchema } from "../../../types";
-
-
-
-
-
-const legendButtonChevron = {
-  symbol: { type: Sdn.ValueType.OPTION, value: "material-chevronDown" },
-  size: {
-    type: Sdn.ValueType.COMPUTED,
-    value: Sdn.ComputedFunction.AUTO_FIT,
-  },
-  color: {
-    type: Sdn.ValueType.COMPUTED,
-    value: Sdn.ComputedFunction.HIGH_CONTRAST_COLOR,
-  },
-  cursor: { type: Sdn.ValueType.OPTION, value: Sdn.Cursor.POINTER },
-} as const
-
-const container = {
-  gap: { type: Sdn.ValueType.OPTION, value: Sdn.Gap.NONE },
-  columns: { type: Sdn.ValueType.EXACT, value: 6 },
-} as const
+import * as Sdn from "../../../../properties"
+import * as Seldon from "../../../constants"
+import { ComponentExport, ComponentSchema } from "../../../types"
 
 export const schema = {
   name: "Ordinal Specimen",
@@ -239,7 +217,24 @@ export const schema = {
               },
               {
                 component: Seldon.ComponentId.ICON,
-                overrides: legendButtonChevron,
+                overrides: {
+                  symbol: {
+                    type: Sdn.ValueType.OPTION,
+                    value: "material-chevronDown",
+                  },
+                  size: {
+                    type: Sdn.ValueType.COMPUTED,
+                    value: Sdn.ComputedFunction.AUTO_FIT,
+                  },
+                  color: {
+                    type: Sdn.ValueType.COMPUTED,
+                    value: Sdn.ComputedFunction.HIGH_CONTRAST_COLOR,
+                  },
+                  cursor: {
+                    type: Sdn.ValueType.OPTION,
+                    value: Sdn.Cursor.POINTER,
+                  },
+                },
               },
             ],
           },
@@ -264,7 +259,24 @@ export const schema = {
               },
               {
                 component: Seldon.ComponentId.ICON,
-                overrides: legendButtonChevron,
+                overrides: {
+                  symbol: {
+                    type: Sdn.ValueType.OPTION,
+                    value: "material-chevronDown",
+                  },
+                  size: {
+                    type: Sdn.ValueType.COMPUTED,
+                    value: Sdn.ComputedFunction.AUTO_FIT,
+                  },
+                  color: {
+                    type: Sdn.ValueType.COMPUTED,
+                    value: Sdn.ComputedFunction.HIGH_CONTRAST_COLOR,
+                  },
+                  cursor: {
+                    type: Sdn.ValueType.OPTION,
+                    value: Sdn.Cursor.POINTER,
+                  },
+                },
               },
             ],
           },
@@ -289,7 +301,24 @@ export const schema = {
               },
               {
                 component: Seldon.ComponentId.ICON,
-                overrides: legendButtonChevron,
+                overrides: {
+                  symbol: {
+                    type: Sdn.ValueType.OPTION,
+                    value: "material-chevronDown",
+                  },
+                  size: {
+                    type: Sdn.ValueType.COMPUTED,
+                    value: Sdn.ComputedFunction.AUTO_FIT,
+                  },
+                  color: {
+                    type: Sdn.ValueType.COMPUTED,
+                    value: Sdn.ComputedFunction.HIGH_CONTRAST_COLOR,
+                  },
+                  cursor: {
+                    type: Sdn.ValueType.OPTION,
+                    value: Sdn.Cursor.POINTER,
+                  },
+                },
               },
             ],
           },
@@ -314,7 +343,24 @@ export const schema = {
               },
               {
                 component: Seldon.ComponentId.ICON,
-                overrides: legendButtonChevron,
+                overrides: {
+                  symbol: {
+                    type: Sdn.ValueType.OPTION,
+                    value: "material-chevronDown",
+                  },
+                  size: {
+                    type: Sdn.ValueType.COMPUTED,
+                    value: Sdn.ComputedFunction.AUTO_FIT,
+                  },
+                  color: {
+                    type: Sdn.ValueType.COMPUTED,
+                    value: Sdn.ComputedFunction.HIGH_CONTRAST_COLOR,
+                  },
+                  cursor: {
+                    type: Sdn.ValueType.OPTION,
+                    value: Sdn.Cursor.POINTER,
+                  },
+                },
               },
             ],
           },
@@ -339,7 +385,24 @@ export const schema = {
               },
               {
                 component: Seldon.ComponentId.ICON,
-                overrides: legendButtonChevron,
+                overrides: {
+                  symbol: {
+                    type: Sdn.ValueType.OPTION,
+                    value: "material-chevronDown",
+                  },
+                  size: {
+                    type: Sdn.ValueType.COMPUTED,
+                    value: Sdn.ComputedFunction.AUTO_FIT,
+                  },
+                  color: {
+                    type: Sdn.ValueType.COMPUTED,
+                    value: Sdn.ComputedFunction.HIGH_CONTRAST_COLOR,
+                  },
+                  cursor: {
+                    type: Sdn.ValueType.OPTION,
+                    value: Sdn.Cursor.POINTER,
+                  },
+                },
               },
             ],
           },
@@ -347,7 +410,10 @@ export const schema = {
       },
       {
         component: Seldon.ComponentId.CONTAINER,
-        overrides: container,
+        overrides: {
+          gap: { type: Sdn.ValueType.OPTION, value: Sdn.Gap.NONE },
+          columns: { type: Sdn.ValueType.EXACT, value: 6 },
+        },
         children: [
           { component: Seldon.ComponentId.ORDINAL_CHIP },
           { component: Seldon.ComponentId.ORDINAL_CHIP },
@@ -356,16 +422,30 @@ export const schema = {
       },
       {
         component: Seldon.ComponentId.CONTAINER,
-        overrides: container,
+        overrides: {
+          gap: { type: Sdn.ValueType.OPTION, value: Sdn.Gap.NONE },
+          columns: { type: Sdn.ValueType.EXACT, value: 6 },
+        },
         children: [
           { component: Seldon.ComponentId.ORDINAL_CHIP },
-          { component: Seldon.ComponentId.ORDINAL_CHIP },
+          { 
+            component: Seldon.ComponentId.ORDINAL_CHIP,
+            overrides: {
+              opacity: {
+                type: Sdn.ValueType.EXACT,
+                value: { unit: Sdn.Unit.PERCENT, value: 100 },
+              },
+            },
+           },
           { component: Seldon.ComponentId.ORDINAL_CHIP },
         ],
       },
       {
         component: Seldon.ComponentId.CONTAINER,
-        overrides: container,
+        overrides: {
+          gap: { type: Sdn.ValueType.OPTION, value: Sdn.Gap.NONE },
+          columns: { type: Sdn.ValueType.EXACT, value: 6 },
+        },
         children: [
           { component: Seldon.ComponentId.ORDINAL_CHIP },
           { component: Seldon.ComponentId.ORDINAL_CHIP },

--- a/packages/core/components/catalog/screens/ThemeSpec.schema.ts
+++ b/packages/core/components/catalog/screens/ThemeSpec.schema.ts
@@ -1,6 +1,10 @@
-import * as Sdn from "../../../properties"
-import * as Seldon from "../../constants"
-import { ComponentExport, ComponentSchema } from "../../types"
+import * as Sdn from "../../../properties";
+import * as Seldon from "../../constants";
+import { ComponentExport, ComponentSchema } from "../../types";
+
+
+
+
 
 export const schema = {
   id: Seldon.ComponentId.THEME_SPEC,
@@ -57,7 +61,11 @@ export const schema = {
     children: [
       { component: Seldon.ComponentId.TOPBAR },
       { component: Seldon.ComponentId.COLOR_SPECIMEN },
-      { component: Seldon.ComponentId.LINKS_FOOTER },
+      { component: Seldon.ComponentId.ORDINAL_SPECIMEN },
+      { 
+        component: Seldon.ComponentId.FOOTER,
+        variant: "standard",
+       },
     ],
   },
 } as const satisfies ComponentSchema

--- a/packages/core/components/catalog/screens/ThemeSpec.schema.ts
+++ b/packages/core/components/catalog/screens/ThemeSpec.schema.ts
@@ -1,10 +1,6 @@
-import * as Sdn from "../../../properties";
-import * as Seldon from "../../constants";
-import { ComponentExport, ComponentSchema } from "../../types";
-
-
-
-
+import * as Sdn from "../../../properties"
+import * as Seldon from "../../constants"
+import { ComponentExport, ComponentSchema } from "../../types"
 
 export const schema = {
   id: Seldon.ComponentId.THEME_SPEC,

--- a/packages/core/components/catalog/screens/ThemeSpec.schema.ts
+++ b/packages/core/components/catalog/screens/ThemeSpec.schema.ts
@@ -60,12 +60,13 @@ export const schema = {
   default: {
     children: [
       { component: Seldon.ComponentId.TOPBAR },
+      { component: Seldon.ComponentId.JOIN_CTA },
       { component: Seldon.ComponentId.COLOR_SPECIMEN },
       { component: Seldon.ComponentId.ORDINAL_SPECIMEN },
-      { 
+      {
         component: Seldon.ComponentId.FOOTER,
         variant: "standard",
-       },
+      },
     ],
   },
 } as const satisfies ComponentSchema

--- a/packages/core/components/types/component-id.ts
+++ b/packages/core/components/types/component-id.ts
@@ -59,6 +59,8 @@ export enum ComponentId {
   MENU_ITEM = "menuItem",
   NAV = "nav",
   OPTION_GROUP = "optionGroup",
+  ORDINAL_CHIP = "ordinalChip",
+  ORDINAL_SPECIMEN = "ordinalSpecimen",
   SANDBOX = "sandbox",
   SCREEN = "screen",
   THEME_SPEC = "themeSpec",

--- a/packages/core/helpers/validation/number.ts
+++ b/packages/core/helpers/validation/number.ts
@@ -9,7 +9,9 @@ export function isNumber(
   value: string,
   options?: { min?: number; max?: number },
 ) {
-  if (!/^-?\d+(\.\d+)?$/.test(value)) {
+  // Accept an optional leading integer part, so a bare-decimal like `-.2` or
+  // `.2` validates the same as `-0.2`. Requires at least one digit.
+  if (!/^-?(?:\d+|\d*\.\d+)$/.test(value)) {
     return false
   }
 

--- a/packages/core/workspace/reducers/handlers/set/set-theme-scale-slot.ts
+++ b/packages/core/workspace/reducers/handlers/set/set-theme-scale-slot.ts
@@ -1,21 +1,44 @@
 import { produce } from "immer"
 
 import { ExtractPayload, Workspace } from "../../../../index"
+import { getComputedTheme } from "../../../compute"
 import { isEntryThemeDefault } from "../../../model/entry-theme"
 import { buildScaleCell } from "../shared/build-scale-cell"
 import { appendCustomToken } from "../shared/theme-custom-token"
 
 /**
+ * Resolves a scale token's current display name from the effective theme. A
+ * reserved step (e.g. `cozy`) carries its label (`"Cozy"`) on the base theme,
+ * not in the entry overrides, so a first-time override must read it from the
+ * computed theme to avoid falling back to the raw lowercase key.
+ */
+function getEffectiveScaleName(
+  payload: ExtractPayload<"set_theme_scale_slot">,
+  workspace: Workspace,
+): string | undefined {
+  try {
+    const theme = getComputedTheme(payload.themeId, workspace) as unknown as
+      | Record<string, Record<string, { name?: string }>>
+      | undefined
+    return theme?.[payload.section]?.[payload.key]?.name
+  } catch {
+    return undefined
+  }
+}
+
+/**
  * Replaces a scale-table cell (`${section}.${key}`) with a modulated step or an
  * exact px/rem length built from the payload. Replacing the whole cell means
  * switching directions never leaves a stale `step` or `unit/value`. Preserves
- * the existing cell `name`/`intent` so a token keeps its label across edits.
+ * the token's existing `name`/`intent` so it keeps its label across edits.
  * No-ops when the entry is missing or marked `type: "default"`.
  */
 export function setThemeScaleSlot(
   payload: ExtractPayload<"set_theme_scale_slot">,
   workspace: Workspace,
 ): Workspace {
+  const effectiveName = getEffectiveScaleName(payload, workspace)
+
   return produce(workspace, (draft) => {
     const entry = draft.themes[payload.themeId]
     if (!entry || isEntryThemeDefault(entry)) return
@@ -31,7 +54,7 @@ export function setThemeScaleSlot(
         : undefined
 
     const cell = buildScaleCell({
-      name: existing?.name ?? payload.key,
+      name: existing?.name ?? effectiveName ?? payload.key,
       intent: existing?.intent,
       ...payload.value,
     })

--- a/packages/editor/app/canvas/boards/ThemeBoard.tsx
+++ b/packages/editor/app/canvas/boards/ThemeBoard.tsx
@@ -2,7 +2,14 @@
 
 import { getThemeSpecPreviewBase } from "@lib/themes/build-theme-spec-preview"
 import { getCssFromProperties } from "@seldon/factory/styles/css-properties/get-css-from-properties"
-import { useMemo } from "react"
+import {
+  type CSSProperties,
+  type MouseEvent,
+  useCallback,
+  useMemo,
+  useRef,
+  useState,
+} from "react"
 import { Board, Properties, Scroll, Unit, ValueType } from "@seldon/core"
 import { ComponentId } from "@seldon/core/components/constants"
 import { colorValueToDisplayStrings } from "@seldon/core/helpers/color"
@@ -14,8 +21,20 @@ import { getNodeProperties } from "@seldon/core/workspace/helpers/nodes/get-node
 import { isThemeBoard } from "@seldon/core/workspace/model/components"
 import type { Workspace } from "@seldon/core/workspace/types"
 import { useNodeTheme } from "@lib/themes/hooks/use-node-theme"
+import { VMMenu, type MenuEntry } from "@lib/menus"
+import {
+  getOrdinalPreviewLayout,
+  ordinalStepName,
+  ordinalStepValueText,
+  ORDINAL_SCALES,
+  type OrdinalScale,
+} from "@lib/themes/ordinal-preview"
 import { useWorkspace } from "@lib/workspace/hooks/use-workspace"
 import { usePreview } from "@lib/hooks/use-preview"
+import {
+  useOrdinalPreviewStore,
+  useOrdinalSelection,
+} from "../hooks/use-ordinal-preview-store"
 import {
   getNodeCatalogComponentId,
   getNodeChildIds,
@@ -32,6 +51,9 @@ import { BoardPreviewNode } from "./BoardPreviewNode"
 export type ThemeBoardProps = {
   board: Board
 }
+
+/** Transparent delegation layer over a preview; adds no box of its own. */
+const previewClickLayerStyle: CSSProperties = { display: "contents" }
 
 /**
  * Theme board canvas: board chrome and a placeholder until a v0 preview fixture exists.
@@ -187,16 +209,63 @@ function ThemeVariantPreview({
   themes,
 }: ThemeVariantPreviewProps) {
   const { workspace: previewBase, rootId } = getThemeSpecPreviewBase()
+  const layout = getOrdinalPreviewLayout()
+  const setSelection = useOrdinalPreviewStore((store) => store.setSelection)
+
+  const marginStep = useOrdinalSelection(variantEntryId, "margin")
+  const paddingStep = useOrdinalSelection(variantEntryId, "padding")
+  const gapStep = useOrdinalSelection(variantEntryId, "gap")
+  const borderStep = useOrdinalSelection(variantEntryId, "border")
+  const cornersStep = useOrdinalSelection(variantEntryId, "corners")
+
+  const stepByScale = useMemo<Record<OrdinalScale, string>>(
+    () => ({
+      margin: marginStep,
+      padding: paddingStep,
+      gap: gapStep,
+      border: borderStep,
+      corners: cornersStep,
+    }),
+    [marginStep, paddingStep, gapStep, borderStep, cornersStep],
+  )
+
+  const theme = useMemo(
+    () => getComputedTheme(variantEntryId, { themes }),
+    [variantEntryId, themes],
+  )
+
+  // Text to inject per node id: color chip swatch strings, plus the selected
+  // step name on each legend button label and the resolved step value on each
+  // chip row.
+  const contentById = useMemo(() => {
+    const content: Record<string, string> = buildChipTextContent(
+      previewBase,
+      theme,
+    )
+    for (const button of layout.legendButtons) {
+      content[button.labelNodeId] = ordinalStepName(
+        button.scale,
+        stepByScale[button.scale],
+        theme,
+      )
+    }
+    for (const row of layout.chipRows) {
+      content[row.textNodeId] = ordinalStepValueText(
+        row.scale,
+        stepByScale[row.scale],
+        theme,
+      )
+    }
+    return content
+  }, [previewBase, theme, layout, stepByScale])
 
   const previewWorkspace = useMemo(() => {
     if (!rootId) {
       return null
     }
-    const theme = getComputedTheme(variantEntryId, { themes })
-    const chipContent = buildChipTextContent(previewBase, theme)
     const nodes = Object.fromEntries(
       Object.entries(previewBase.nodes).map(([id, node]) => {
-        const injected = chipContent[id]
+        const injected = contentById[id]
         return [
           id,
           {
@@ -217,7 +286,59 @@ function ThemeVariantPreview({
       themes,
       nodes,
     } as Workspace
-  }, [previewBase, rootId, themes, variantEntryId])
+  }, [previewBase, rootId, themes, variantEntryId, contentById])
+
+  const scaleByButtonId = useMemo(() => {
+    const map = new Map<string, OrdinalScale>()
+    for (const button of layout.legendButtons) {
+      map.set(button.buttonNodeId, button.scale)
+    }
+    return map
+  }, [layout])
+
+  const anchorRef = useRef<HTMLElement | null>(null)
+  const [openScale, setOpenScale] = useState<OrdinalScale | null>(null)
+
+  // Delegated click: walk up from the click target to the nearest preview node
+  // that is a legend button, anchor the menu to it, and toggle it open.
+  const handlePreviewClick = useCallback(
+    (event: MouseEvent<HTMLDivElement>) => {
+      let element = (event.target as HTMLElement).closest<HTMLElement>(
+        "[data-preview-node-id]",
+      )
+      while (element) {
+        const id = element.getAttribute("data-preview-node-id")
+        const scale = id ? scaleByButtonId.get(id) : undefined
+        if (scale) {
+          event.stopPropagation()
+          anchorRef.current = element
+          setOpenScale((current) => (current === scale ? null : scale))
+          return
+        }
+        element = element.parentElement?.closest<HTMLElement>(
+          "[data-preview-node-id]",
+        ) ?? null
+      }
+    },
+    [scaleByButtonId],
+  )
+
+  const closeMenu = useCallback(() => setOpenScale(null), [])
+
+  const menuItems = useMemo<MenuEntry[]>(() => {
+    if (!openScale) return []
+    const scale = openScale
+    const currentStep = stepByScale[scale]
+    return ORDINAL_SCALES[scale].steps.map((step) => ({
+      id: step,
+      label: ordinalStepName(scale, step, theme),
+      selected: step === currentStep,
+      activeMarker: "bullet",
+      onSelect: () => setSelection(variantEntryId, scale, step),
+    }))
+  }, [openScale, stepByScale, theme, variantEntryId, setSelection])
+
+  const menuOpen = openScale !== null
 
   if (!previewWorkspace || !rootId) {
     return null
@@ -229,11 +350,19 @@ function ThemeVariantPreview({
       selectionId={variantEntryId}
       selectionKind="theme"
     >
-      <BoardPreviewNode
-        nodeId={rootId}
-        workspace={previewWorkspace}
-        scope={variantEntryId}
-        isRoot
+      <div style={previewClickLayerStyle} onClick={handlePreviewClick}>
+        <BoardPreviewNode
+          nodeId={rootId}
+          workspace={previewWorkspace}
+          scope={variantEntryId}
+          isRoot
+        />
+      </div>
+      <VMMenu
+        open={menuOpen}
+        anchorRef={anchorRef}
+        onClose={closeMenu}
+        items={menuItems}
       />
     </PreviewItemWrapper>
   )

--- a/packages/editor/app/canvas/boards/ThemeBoard.tsx
+++ b/packages/editor/app/canvas/boards/ThemeBoard.tsx
@@ -30,6 +30,7 @@ import { getNodeProperties } from "@seldon/core/workspace/helpers/nodes/get-node
 import { isThemeBoard } from "@seldon/core/workspace/model/components"
 import type { Workspace } from "@seldon/core/workspace/types"
 import { useNodeTheme } from "@lib/themes/hooks/use-node-theme"
+import { useSelection } from "@lib/workspace/hooks/use-selection"
 import { useWorkspace } from "@lib/workspace/hooks/use-workspace"
 import { usePreview } from "@lib/hooks/use-preview"
 import {
@@ -61,6 +62,7 @@ const previewClickLayerStyle: CSSProperties = { display: "contents" }
  */
 export function ThemeBoard({ board }: ThemeBoardProps) {
   const { workspace } = useWorkspace()
+  const { selectedThemeEntryId } = useSelection()
   const boardKey = getComponentKey(board)
   const className = `board-${boardKey}`
   const properties = getNodeProperties(board, workspace)
@@ -71,9 +73,18 @@ export function ThemeBoard({ board }: ThemeBoardProps) {
   // per-variant previews below are themed individually.
   const boardTheme = useNodeTheme(board)
 
-  const variantEntryIds = isThemeBoard(board)
+  // Theme boards show one variant at a time: the one selected in the objects
+  // sidebar, falling back to the default (first) variant when the selection is
+  // empty or points at another board's variant.
+  const boardVariantIds = isThemeBoard(board)
     ? board.variants.map((variant) => variant.id)
     : []
+  const defaultVariantId = boardVariantIds[0] ?? null
+  const activeVariantId =
+    selectedThemeEntryId && boardVariantIds.includes(selectedThemeEntryId)
+      ? selectedThemeEntryId
+      : defaultVariantId
+  const variantEntryIds = activeVariantId ? [activeVariantId] : []
 
   const computedProperties: Properties = isInPreviewMode
     ? {

--- a/packages/editor/app/canvas/boards/ThemeBoard.tsx
+++ b/packages/editor/app/canvas/boards/ThemeBoard.tsx
@@ -1,6 +1,15 @@
 "use client"
 
+import { type MenuEntry, VMMenu } from "@lib/menus"
 import { getThemeSpecPreviewBase } from "@lib/themes/build-theme-spec-preview"
+import {
+  ORDINAL_SCALES,
+  type OrdinalScale,
+  getOrdinalPreviewLayout,
+  ordinalStepName,
+  ordinalStepRef,
+  ordinalStepValueText,
+} from "@lib/themes/ordinal-preview"
 import { getCssFromProperties } from "@seldon/factory/styles/css-properties/get-css-from-properties"
 import {
   type CSSProperties,
@@ -21,14 +30,6 @@ import { getNodeProperties } from "@seldon/core/workspace/helpers/nodes/get-node
 import { isThemeBoard } from "@seldon/core/workspace/model/components"
 import type { Workspace } from "@seldon/core/workspace/types"
 import { useNodeTheme } from "@lib/themes/hooks/use-node-theme"
-import { VMMenu, type MenuEntry } from "@lib/menus"
-import {
-  getOrdinalPreviewLayout,
-  ordinalStepName,
-  ordinalStepValueText,
-  ORDINAL_SCALES,
-  type OrdinalScale,
-} from "@lib/themes/ordinal-preview"
 import { useWorkspace } from "@lib/workspace/hooks/use-workspace"
 import { usePreview } from "@lib/hooks/use-preview"
 import {
@@ -201,6 +202,71 @@ function buildChipTextContent(
   return content
 }
 
+/** A THEME_ORDINAL property value pointing at a scale step token. */
+function themeOrdinalValue(ref: string) {
+  return { type: ValueType.THEME_ORDINAL as const, value: ref }
+}
+
+/**
+ * Builds the box-style overrides each Ordinal Chip takes from the selected
+ * steps, so the rendered chip's spacing, border width, and corner radius follow
+ * the previewed theme's tokens. Every chip shares the same overrides, keyed by
+ * node id. Border only overrides `width`, so the schema's preset and color stay.
+ */
+function buildChipStyleOverrides(
+  previewBase: Workspace,
+  stepByScale: Record<OrdinalScale, string>,
+): Record<string, Properties> {
+  const marginValue = themeOrdinalValue(
+    ordinalStepRef("margin", stepByScale.margin),
+  )
+  const paddingValue = themeOrdinalValue(
+    ordinalStepRef("padding", stepByScale.padding),
+  )
+  const gapValue = themeOrdinalValue(ordinalStepRef("gap", stepByScale.gap))
+  const borderValue = themeOrdinalValue(
+    ordinalStepRef("border", stepByScale.border),
+  )
+  const cornersValue = themeOrdinalValue(
+    ordinalStepRef("corners", stepByScale.corners),
+  )
+
+  // Token refs are resolved at runtime by the previewed theme, so the dynamic
+  // string values cannot satisfy the per-scale literal unions. Cast once here.
+  const overrides = {
+    margin: {
+      top: marginValue,
+      right: marginValue,
+      bottom: marginValue,
+      left: marginValue,
+    },
+    padding: {
+      top: paddingValue,
+      right: paddingValue,
+      bottom: paddingValue,
+      left: paddingValue,
+    },
+    gap: gapValue,
+    corners: {
+      topLeft: cornersValue,
+      topRight: cornersValue,
+      bottomLeft: cornersValue,
+      bottomRight: cornersValue,
+    },
+    border: { width: borderValue },
+  } as unknown as Properties
+
+  const styleById: Record<string, Properties> = {}
+  for (const node of Object.values(previewBase.nodes)) {
+    if (
+      getNodeCatalogComponentId(node, previewBase) === ComponentId.ORDINAL_CHIP
+    ) {
+      styleById[node.id] = overrides
+    }
+  }
+  return styleById
+}
+
 /**
  * Renders a single Theme Spec Sheet preview themed by one workspace theme entry.
  */
@@ -259,6 +325,11 @@ function ThemeVariantPreview({
     return content
   }, [previewBase, theme, layout, stepByScale])
 
+  const chipStyleById = useMemo(
+    () => buildChipStyleOverrides(previewBase, stepByScale),
+    [previewBase, stepByScale],
+  )
+
   const previewWorkspace = useMemo(() => {
     if (!rootId) {
       return null
@@ -266,12 +337,14 @@ function ThemeVariantPreview({
     const nodes = Object.fromEntries(
       Object.entries(previewBase.nodes).map(([id, node]) => {
         const injected = contentById[id]
+        const chipStyle = chipStyleById[id]
         return [
           id,
           {
             ...node,
             overrides: {
               ...node.overrides,
+              ...(chipStyle ?? {}),
               ...(injected !== undefined
                 ? { content: { type: ValueType.EXACT, value: injected } }
                 : {}),
@@ -286,7 +359,7 @@ function ThemeVariantPreview({
       themes,
       nodes,
     } as Workspace
-  }, [previewBase, rootId, themes, variantEntryId, contentById])
+  }, [previewBase, rootId, themes, variantEntryId, contentById, chipStyleById])
 
   const scaleByButtonId = useMemo(() => {
     const map = new Map<string, OrdinalScale>()
@@ -315,9 +388,10 @@ function ThemeVariantPreview({
           setOpenScale((current) => (current === scale ? null : scale))
           return
         }
-        element = element.parentElement?.closest<HTMLElement>(
-          "[data-preview-node-id]",
-        ) ?? null
+        element =
+          element.parentElement?.closest<HTMLElement>(
+            "[data-preview-node-id]",
+          ) ?? null
       }
     },
     [scaleByButtonId],

--- a/packages/editor/app/canvas/hooks/use-canvas.ts
+++ b/packages/editor/app/canvas/hooks/use-canvas.ts
@@ -5,6 +5,7 @@ import { InstanceId, VariantId, invariant } from "@seldon/core"
 import { getComponentSchema } from "@seldon/core/components/catalog"
 import { ComponentId } from "@seldon/core/components/constants"
 import { ErrorMessages } from "@seldon/core/workspace/constants"
+import { isThemeBoard } from "@seldon/core/workspace/model/components"
 import {
   nodeRetrievalService,
   nodeTraversalService,
@@ -58,6 +59,14 @@ export function useCanvas() {
     (event) => {
       // Don't show highlights in preview mode
       if (isInPreviewMode) {
+        setHoverState(null)
+        setHoveredId(null)
+        return
+      }
+
+      // Theme boards suppress the hover overlay. They are previews, not an
+      // editable node tree, so silently clear hover and stop.
+      if (activeBoard && isThemeBoard(activeBoard)) {
         setHoverState(null)
         setHoveredId(null)
         return
@@ -192,6 +201,7 @@ export function useCanvas() {
     },
     [
       isInPreviewMode,
+      activeBoard,
       activeTool,
       workspace,
       hoverState?.objectId,

--- a/packages/editor/app/canvas/hooks/use-ordinal-preview-store.ts
+++ b/packages/editor/app/canvas/hooks/use-ordinal-preview-store.ts
@@ -1,5 +1,5 @@
-import { create } from "zustand"
 import { ORDINAL_SCALES, type OrdinalScale } from "@lib/themes/ordinal-preview"
+import { create } from "zustand"
 
 /**
  * Per-preview ordinal step selections for theme boards. The specimen legend

--- a/packages/editor/app/canvas/hooks/use-ordinal-preview-store.ts
+++ b/packages/editor/app/canvas/hooks/use-ordinal-preview-store.ts
@@ -1,0 +1,47 @@
+import { create } from "zustand"
+import { ORDINAL_SCALES, type OrdinalScale } from "@lib/themes/ordinal-preview"
+
+/**
+ * Per-preview ordinal step selections for theme boards. The specimen legend
+ * menus write it and the theme preview reads it to render the chosen step on the
+ * button and drive the chip row values. Keyed by `${variantEntryId}:${scale}`.
+ * A missing entry means the scale's default step. Session only, not persisted.
+ */
+interface OrdinalPreviewStore {
+  selections: Record<string, string>
+  setSelection: (
+    variantEntryId: string,
+    scale: OrdinalScale,
+    step: string,
+  ) => void
+}
+
+export function ordinalSelectionKey(
+  variantEntryId: string,
+  scale: OrdinalScale,
+): string {
+  return `${variantEntryId}:${scale}`
+}
+
+export const useOrdinalPreviewStore = create<OrdinalPreviewStore>((set) => ({
+  selections: {},
+  setSelection: (variantEntryId, scale, step) =>
+    set((current) => ({
+      selections: {
+        ...current.selections,
+        [ordinalSelectionKey(variantEntryId, scale)]: step,
+      },
+    })),
+}))
+
+/** Reactive read of one preview scale's step, defaulting to the scale default. */
+export function useOrdinalSelection(
+  variantEntryId: string,
+  scale: OrdinalScale,
+): string {
+  return useOrdinalPreviewStore(
+    (store) =>
+      store.selections[ordinalSelectionKey(variantEntryId, scale)] ??
+      ORDINAL_SCALES[scale].defaultStep,
+  )
+}

--- a/packages/editor/app/tracking/CanvasTracking.tsx
+++ b/packages/editor/app/tracking/CanvasTracking.tsx
@@ -1,5 +1,7 @@
 "use client"
 
+import { isThemeBoard } from "@seldon/core/workspace/model/components"
+import { useActiveBoard } from "@lib/workspace/hooks/use-active-board"
 import { useSelectedNodeId } from "@lib/workspace/hooks/use-selection"
 import {
   useCanvasHoverState,
@@ -30,6 +32,7 @@ export function CanvasTracking() {
   const nodeIds = visibleNodes.map((node) => node.id)
   const { showSelection, wireframeMode } = useEditorConfig()
   const nodeBelongsToActiveBoard = useNodeBelongsToActiveBoard()
+  const { activeBoard } = useActiveBoard()
   const isDragging = useDragStateStore((state) => state.isDragging)
   const isTransforming = useCanvasRemeasureStore(
     (state) => state.isTransforming,
@@ -39,6 +42,10 @@ export function CanvasTracking() {
   // box reads cleanly. Explicit wireframe mode still wins, and leaving the tool
   // restores normal auto behavior without touching persisted state.
   const showWireframes = wireframeMode === "on"
+
+  // Theme boards are previews, not an editable node tree, so they show no
+  // selection or hover outline on the canvas.
+  const activeBoardIsTheme = activeBoard ? isThemeBoard(activeBoard) : false
 
   // A between-siblings gap is highlighted by the paired sibling outlines
   // (InsertGapSiblings), so the single full-node hover box is suppressed to
@@ -69,10 +76,13 @@ export function CanvasTracking() {
             />
           )
         })}
-      {showSelection && activeTool === "select" && !isDragging && (
-        <CanvasSelectionOutline wireframe={showWireframes} />
-      )}
-      {showSelection && activeTool === "select" && (
+      {showSelection &&
+        activeTool === "select" &&
+        !isDragging &&
+        !activeBoardIsTheme && (
+          <CanvasSelectionOutline wireframe={showWireframes} />
+        )}
+      {showSelection && activeTool === "select" && !activeBoardIsTheme && (
         <CanvasHoverOutline wireframe={showWireframes} />
       )}
       {activeTool === "component" && !isSiblingGap && <CanvasHoverOutline />}

--- a/packages/editor/lib/themes/ordinal-preview.ts
+++ b/packages/editor/lib/themes/ordinal-preview.ts
@@ -1,0 +1,208 @@
+import { ValueType } from "@seldon/core"
+import { ComponentId } from "@seldon/core/components/constants"
+import { resolveModulatedOrExactLength } from "@seldon/core/helpers/resolution/resolve-length-token"
+import { getThemeOption } from "@seldon/core/helpers/theme/get-theme-option"
+import { getThemeValueName } from "@seldon/core/helpers/theme/get-theme-value-name"
+import {
+  type Theme,
+  isModulatedToken,
+  isThemeExactToken,
+} from "@seldon/core/themes/types"
+import type { Workspace } from "@seldon/core/workspace/types"
+import {
+  getNodeCatalogComponentId,
+  getNodeChildIds,
+} from "@lib/workspace/node-tree"
+import { getThemeSpecPreviewBase } from "./build-theme-spec-preview"
+
+/** The five ordinal scales the specimen legend and chips expose. */
+export type OrdinalScale = "margin" | "padding" | "gap" | "border" | "corners"
+
+/** Legend buttons and chip rows are authored in this order. */
+export const ORDINAL_SCALE_ORDER: OrdinalScale[] = [
+  "margin",
+  "padding",
+  "gap",
+  "border",
+  "corners",
+]
+
+type ScaleDefinition = {
+  /** Theme token namespace used in the `@token.step` reference. */
+  token: string
+  steps: string[]
+  defaultStep: string
+}
+
+const SPACING_STEPS = ["tight", "compact", "cozy", "comfortable", "open"]
+
+/**
+ * Ordinal option sets per scale. Spacing scales share the same steps and default
+ * to `cozy`; the border scale uses the `@borderWidth` steps and defaults to
+ * `medium`.
+ */
+export const ORDINAL_SCALES: Record<OrdinalScale, ScaleDefinition> = {
+  margin: { token: "margin", steps: SPACING_STEPS, defaultStep: "cozy" },
+  padding: { token: "padding", steps: SPACING_STEPS, defaultStep: "cozy" },
+  gap: { token: "gap", steps: SPACING_STEPS, defaultStep: "cozy" },
+  border: {
+    token: "borderWidth",
+    steps: ["xsmall", "small", "medium", "large", "xlarge"],
+    defaultStep: "medium",
+  },
+  corners: { token: "corners", steps: SPACING_STEPS, defaultStep: "cozy" },
+}
+
+/** Builds the `@token.step` reference for a scale step. */
+export function ordinalStepRef(scale: OrdinalScale, step: string): string {
+  return `@${ORDINAL_SCALES[scale].token}.${step}`
+}
+
+export type OrdinalLegendButton = {
+  scale: OrdinalScale
+  /** The button node the menu anchors to. */
+  buttonNodeId: string
+  /** The label text node whose content shows the selected step. */
+  labelNodeId: string
+}
+
+export type OrdinalChipRow = {
+  scale: OrdinalScale
+  /** The row text node whose content shows the selected step value. */
+  textNodeId: string
+}
+
+export type OrdinalPreviewLayout = {
+  legendButtons: OrdinalLegendButton[]
+  chipRows: OrdinalChipRow[]
+}
+
+let cachedLayout: OrdinalPreviewLayout | null = null
+
+/** Finds the first descendant text node id under a parent node, breadth first. */
+function findFirstTextNodeId(
+  parentNodeId: string,
+  workspace: Workspace,
+): string | null {
+  const parent = workspace.nodes[parentNodeId]
+  if (!parent) return null
+
+  const queue = [...getNodeChildIds(parent, workspace)]
+  while (queue.length > 0) {
+    const id = queue.shift() as string
+    const node = workspace.nodes[id]
+    if (!node) continue
+    if (getNodeCatalogComponentId(node, workspace) === ComponentId.TEXT) {
+      return id
+    }
+    queue.push(...getNodeChildIds(node, workspace))
+  }
+  return null
+}
+
+/**
+ * Resolves the ordinal specimen's legend button nodes and chip row text nodes
+ * from the cached Theme Spec preview base, mapping each to its scale by authored
+ * order. Cached because the preview base is stable for the session.
+ */
+export function getOrdinalPreviewLayout(): OrdinalPreviewLayout {
+  if (cachedLayout) return cachedLayout
+
+  const { workspace } = getThemeSpecPreviewBase()
+  const legendButtons: OrdinalLegendButton[] = []
+  const chipRows: OrdinalChipRow[] = []
+
+  const specimen = Object.values(workspace.nodes).find(
+    (node) =>
+      getNodeCatalogComponentId(node, workspace) ===
+      ComponentId.ORDINAL_SPECIMEN,
+  )
+
+  if (specimen) {
+    const [legendFrameId, ...containerIds] = getNodeChildIds(
+      specimen,
+      workspace,
+    )
+
+    const legendFrame = legendFrameId
+      ? workspace.nodes[legendFrameId]
+      : undefined
+    if (legendFrame) {
+      getNodeChildIds(legendFrame, workspace).forEach((buttonId, index) => {
+        const scale = ORDINAL_SCALE_ORDER[index]
+        const labelNodeId = findFirstTextNodeId(buttonId, workspace)
+        if (scale && labelNodeId) {
+          legendButtons.push({ scale, buttonNodeId: buttonId, labelNodeId })
+        }
+      })
+    }
+
+    for (const containerId of containerIds) {
+      const container = workspace.nodes[containerId]
+      if (!container) continue
+      for (const chipId of getNodeChildIds(container, workspace)) {
+        const chip = workspace.nodes[chipId]
+        if (!chip) continue
+        getNodeChildIds(chip, workspace).forEach((rowId, index) => {
+          const scale = ORDINAL_SCALE_ORDER[index]
+          const textNodeId = findFirstTextNodeId(rowId, workspace)
+          if (scale && textNodeId) {
+            chipRows.push({ scale, textNodeId })
+          }
+        })
+      }
+    }
+  }
+
+  cachedLayout = { legendButtons, chipRows }
+  return cachedLayout
+}
+
+/** The friendly name of a scale step in the given theme, e.g. `Comfortable`. */
+export function ordinalStepName(
+  scale: OrdinalScale,
+  step: string,
+  theme: Theme,
+): string {
+  return getThemeValueName(ordinalStepRef(scale, step), theme)
+}
+
+/** Formats a number to at most two decimals with no trailing zeros. */
+function formatNumber(value: number): string {
+  return `${Math.round(value * 100) / 100}`
+}
+
+/** Formats a resolved length token, e.g. `1rem`. */
+function formatLength(
+  length: ReturnType<typeof resolveModulatedOrExactLength>,
+): string {
+  if (!length || length.type !== ValueType.EXACT) return ""
+  return `${formatNumber(length.value.value)}${length.value.unit}`
+}
+
+/**
+ * The chip row text for a scale step: the token's step value paired with its
+ * resolved length in the given theme, e.g. `0 | 1rem`. Modulated tokens show
+ * their modulation step; exact tokens show their raw numeric value.
+ */
+export function ordinalStepValueText(
+  scale: OrdinalScale,
+  step: string,
+  theme: Theme,
+): string {
+  const ref = ordinalStepRef(scale, step)
+  try {
+    const option = getThemeOption(ref, theme)
+    const lengthText = formatLength(resolveModulatedOrExactLength(option, theme))
+    let stepText = ""
+    if (isModulatedToken(option)) {
+      stepText = formatNumber(option.parameters.step)
+    } else if (isThemeExactToken(option)) {
+      stepText = formatNumber(option.parameters.value)
+    }
+    if (stepText && lengthText) return `${stepText} | ${lengthText}`
+    return lengthText || stepText
+  } catch {
+    return ""
+  }
+}

--- a/packages/editor/lib/themes/ordinal-preview.ts
+++ b/packages/editor/lib/themes/ordinal-preview.ts
@@ -101,6 +101,33 @@ function findFirstTextNodeId(
 }
 
 /**
+ * Finds the first descendant node id of the given component, breadth first,
+ * starting from a root node id. Traverses the board tree so it resolves the
+ * instance embedded in this board rather than a same-typed node on another
+ * board in the shared nodes map.
+ */
+function findDescendantByComponent(
+  rootNodeId: string,
+  componentId: ComponentId,
+  workspace: Workspace,
+): string | null {
+  const root = workspace.nodes[rootNodeId]
+  if (!root) return null
+
+  const queue = [...getNodeChildIds(root, workspace)]
+  while (queue.length > 0) {
+    const id = queue.shift() as string
+    const node = workspace.nodes[id]
+    if (!node) continue
+    if (getNodeCatalogComponentId(node, workspace) === componentId) {
+      return id
+    }
+    queue.push(...getNodeChildIds(node, workspace))
+  }
+  return null
+}
+
+/**
  * Resolves the ordinal specimen's legend button nodes and chip row text nodes
  * from the cached Theme Spec preview base, mapping each to its scale by authored
  * order. Cached because the preview base is stable for the session.
@@ -108,15 +135,18 @@ function findFirstTextNodeId(
 export function getOrdinalPreviewLayout(): OrdinalPreviewLayout {
   if (cachedLayout) return cachedLayout
 
-  const { workspace } = getThemeSpecPreviewBase()
+  const { workspace, rootId } = getThemeSpecPreviewBase()
   const legendButtons: OrdinalLegendButton[] = []
   const chipRows: OrdinalChipRow[] = []
 
-  const specimen = Object.values(workspace.nodes).find(
-    (node) =>
-      getNodeCatalogComponentId(node, workspace) ===
-      ComponentId.ORDINAL_SPECIMEN,
-  )
+  const specimenId = rootId
+    ? findDescendantByComponent(
+        rootId,
+        ComponentId.ORDINAL_SPECIMEN,
+        workspace,
+      )
+    : null
+  const specimen = specimenId ? workspace.nodes[specimenId] : undefined
 
   if (specimen) {
     const [legendFrameId, ...containerIds] = getNodeChildIds(

--- a/packages/editor/lib/themes/ordinal-preview.ts
+++ b/packages/editor/lib/themes/ordinal-preview.ts
@@ -128,6 +128,33 @@ function findDescendantByComponent(
 }
 
 /**
+ * Collects every descendant node id of the given component under a root, in
+ * document (pre-order) order. Targeting the component directly keeps the layout
+ * stable when the specimen adds wrapping frames or static text around the legend
+ * buttons and chips.
+ */
+function collectDescendantsByComponent(
+  rootNodeId: string,
+  componentId: ComponentId,
+  workspace: Workspace,
+): string[] {
+  const result: string[] = []
+  const root = workspace.nodes[rootNodeId]
+  if (!root) return result
+
+  const visit = (id: string) => {
+    const node = workspace.nodes[id]
+    if (!node) return
+    if (getNodeCatalogComponentId(node, workspace) === componentId) {
+      result.push(id)
+    }
+    for (const childId of getNodeChildIds(node, workspace)) visit(childId)
+  }
+  for (const childId of getNodeChildIds(root, workspace)) visit(childId)
+  return result
+}
+
+/**
  * Resolves the ordinal specimen's legend button nodes and chip row text nodes
  * from the cached Theme Spec preview base, mapping each to its scale by authored
  * order. Cached because the preview base is stable for the session.
@@ -140,47 +167,43 @@ export function getOrdinalPreviewLayout(): OrdinalPreviewLayout {
   const chipRows: OrdinalChipRow[] = []
 
   const specimenId = rootId
-    ? findDescendantByComponent(
-        rootId,
-        ComponentId.ORDINAL_SPECIMEN,
-        workspace,
-      )
+    ? findDescendantByComponent(rootId, ComponentId.ORDINAL_SPECIMEN, workspace)
     : null
   const specimen = specimenId ? workspace.nodes[specimenId] : undefined
 
-  if (specimen) {
-    const [legendFrameId, ...containerIds] = getNodeChildIds(
-      specimen,
+  if (specimenId && specimen) {
+    // Legend labels live on the specimen's menu BUTTON nodes, in authored scale
+    // order. Targeting BUTTON nodes skips any static text the specimen adds
+    // around the legend (such as a standalone title).
+    const buttonIds = collectDescendantsByComponent(
+      specimenId,
+      ComponentId.BUTTON,
       workspace,
     )
+    buttonIds.forEach((buttonId, index) => {
+      const scale = ORDINAL_SCALE_ORDER[index]
+      const labelNodeId = findFirstTextNodeId(buttonId, workspace)
+      if (scale && labelNodeId) {
+        legendButtons.push({ scale, buttonNodeId: buttonId, labelNodeId })
+      }
+    })
 
-    const legendFrame = legendFrameId
-      ? workspace.nodes[legendFrameId]
-      : undefined
-    if (legendFrame) {
-      getNodeChildIds(legendFrame, workspace).forEach((buttonId, index) => {
+    // Each ORDINAL_CHIP holds one row per scale in authored order.
+    const chipIds = collectDescendantsByComponent(
+      specimenId,
+      ComponentId.ORDINAL_CHIP,
+      workspace,
+    )
+    for (const chipId of chipIds) {
+      const chip = workspace.nodes[chipId]
+      if (!chip) continue
+      getNodeChildIds(chip, workspace).forEach((rowId, index) => {
         const scale = ORDINAL_SCALE_ORDER[index]
-        const labelNodeId = findFirstTextNodeId(buttonId, workspace)
-        if (scale && labelNodeId) {
-          legendButtons.push({ scale, buttonNodeId: buttonId, labelNodeId })
+        const textNodeId = findFirstTextNodeId(rowId, workspace)
+        if (scale && textNodeId) {
+          chipRows.push({ scale, textNodeId })
         }
       })
-    }
-
-    for (const containerId of containerIds) {
-      const container = workspace.nodes[containerId]
-      if (!container) continue
-      for (const chipId of getNodeChildIds(container, workspace)) {
-        const chip = workspace.nodes[chipId]
-        if (!chip) continue
-        getNodeChildIds(chip, workspace).forEach((rowId, index) => {
-          const scale = ORDINAL_SCALE_ORDER[index]
-          const textNodeId = findFirstTextNodeId(rowId, workspace)
-          if (scale && textNodeId) {
-            chipRows.push({ scale, textNodeId })
-          }
-        })
-      }
     }
   }
 
@@ -223,14 +246,16 @@ export function ordinalStepValueText(
   const ref = ordinalStepRef(scale, step)
   try {
     const option = getThemeOption(ref, theme)
-    const lengthText = formatLength(resolveModulatedOrExactLength(option, theme))
+    const lengthText = formatLength(
+      resolveModulatedOrExactLength(option, theme),
+    )
     let stepText = ""
     if (isModulatedToken(option)) {
       stepText = formatNumber(option.parameters.step)
     } else if (isThemeExactToken(option)) {
       stepText = formatNumber(option.parameters.value)
     }
-    if (stepText && lengthText) return `${stepText} | ${lengthText}`
+    if (stepText && lengthText) return `${stepText} · ${lengthText}`
     return lengthText || stepText
   } catch {
     return ""

--- a/packages/editor/lib/themes/ordinal-preview.ts
+++ b/packages/editor/lib/themes/ordinal-preview.ts
@@ -101,35 +101,10 @@ function findFirstTextNodeId(
 }
 
 /**
- * Finds the first descendant node id of the given component, breadth first,
- * starting from a root node id. Traverses the board tree so it resolves the
- * instance embedded in this board rather than a same-typed node on another
- * board in the shared nodes map.
- */
-function findDescendantByComponent(
-  rootNodeId: string,
-  componentId: ComponentId,
-  workspace: Workspace,
-): string | null {
-  const root = workspace.nodes[rootNodeId]
-  if (!root) return null
-
-  const queue = [...getNodeChildIds(root, workspace)]
-  while (queue.length > 0) {
-    const id = queue.shift() as string
-    const node = workspace.nodes[id]
-    if (!node) continue
-    if (getNodeCatalogComponentId(node, workspace) === componentId) {
-      return id
-    }
-    queue.push(...getNodeChildIds(node, workspace))
-  }
-  return null
-}
-
-/**
  * Collects every descendant node id of the given component under a root, in
- * document (pre-order) order. Targeting the component directly keeps the layout
+ * document (pre-order) order. Traverses the board tree, so it resolves nodes
+ * embedded in this board rather than same-typed nodes on other boards in the
+ * shared preview nodes map. Targeting the component directly keeps the layout
  * stable when the specimen adds wrapping frames or static text around the legend
  * buttons and chips.
  */
@@ -167,7 +142,11 @@ export function getOrdinalPreviewLayout(): OrdinalPreviewLayout {
   const chipRows: OrdinalChipRow[] = []
 
   const specimenId = rootId
-    ? findDescendantByComponent(rootId, ComponentId.ORDINAL_SPECIMEN, workspace)
+    ? (collectDescendantsByComponent(
+        rootId,
+        ComponentId.ORDINAL_SPECIMEN,
+        workspace,
+      )[0] ?? null)
     : null
   const specimen = specimenId ? workspace.nodes[specimenId] : undefined
 
@@ -235,7 +214,7 @@ function formatLength(
 
 /**
  * The chip row text for a scale step: the token's step value paired with its
- * resolved length in the given theme, e.g. `0 | 1rem`. Modulated tokens show
+ * resolved length in the given theme, e.g. `0 · 1rem`. Modulated tokens show
  * their modulation step; exact tokens show their raw numeric value.
  */
 export function ordinalStepValueText(


### PR DESCRIPTION
## 📝 Description

Adds an Ordinal Specimen system for theme boards and makes theme boards behave as interactive, single-variant previews.

- **New catalog schemas**: `OrdinalSpecimen` (part) and `OrdinalChip` (element) visualize a theme's ordinal scales (margin, padding, gap, border, corners) as a legend of menu buttons over grouped chip grids. Registered in the catalog index, constants, and `ComponentId`. A new `Menu` variant was added to `Button`, and `ThemeSpec` now composes the specimen (and Footer).
- **Interactive theme-board previews** (editor-side, no schema/runtime coupling): each legend button opens a `VMMenu` of `THEME_ORDINAL` steps. Selecting a step updates the button label, drives each chip's box styling (`margin`/`padding`/`gap`/`border.width`/`corners`) via `@token.step` references (the same tokens the factory emits as `--sdn-*`), and updates the chip row text to `step · resolved` (e.g. `0 · 1rem`). Selections are transient per-session view state (`useOrdinalPreviewStore`), like the state switcher.
- **Theme-board UX**: only the variant selected in the objects sidebar renders (falling back to the default variant), and canvas hover/selection outlines are suppressed while a theme board is active.
- **Bug fixes**: overriding a reserved theme scale value no longer lowercases its label (recovers the effective name from the computed theme instead of the raw key), and numeric inputs now accept bare-decimal values like `-.2`.
- **Conventions**: documented that schema files must inline `overrides` object literals rather than hoisting them into module consts, and refactored the ordinal schemas (and cleaned up sibling schemas) to comply.

## 🔗 Related Issues

## 🧪 Type of Change

- 🐛 Bug fix
- ✨ New feature
- 📚 Documentation update

## 📦 Affected Packages

- `@seldon/core`
- `@seldon/editor`

## 📸 Screenshots/Videos

_N/A_

## 🔍 Code Quality Checklist

- Code follows the project's style guidelines
- Self-review of the code has been performed
- Code is properly commented, particularly in hard-to-understand areas
- No console.log statements or debugging code left in
- TypeScript types are properly defined, no use of "as any"
- No unused imports or variables

## 📋 Breaking Changes

_None_

## 🚀 Deployment Notes

_None_

## 📚 Documentation Updates

- `.cursor/rules/components.mdc` and `.cursor/rules/engineering.mdc`: schema files must inline `overrides` object literals; the only module-level values are the `schema` export and its `exportConfig`.

## ⚠️ Additional Notes

- Theme-board menu selections are session-only view state and reset on reload; they are not persisted to the workspace.
- The interactive preview layer is entirely editor-side. It resolves legend buttons and chip rows by walking the cached Theme Spec preview tree, so it stays stable when the specimen adds wrapping frames or static text.

---

I have read the CLA and I agree to its terms.

Github: AndreiSeldon
Organization: Seldon Digital