### PR TITLE
Fix/ai tools

### DIFF
--- a/packages/ai/README.md
+++ b/packages/ai/README.md
@@ -212,8 +212,12 @@ Tools come in two groups, assembled per turn in [pi/tools/](./pi/tools), one too
 | Tool | Proposes |
 | --- | --- |
 | `set_properties` | Property values on a node or its component source |
-| `add_component` | A new component board |
-| `insert_variant_instance` | A variant, or an instance inside a tree |
+| `add_component` | Add a catalog component to the workspace as its own board |
+| `insert_component` | Insert a catalog component under a parent, creating its board if needed |
+| `insert_variant_instance` | Insert an instance of a specific existing variant |
+| `duplicate_component` | Paste a copy under a parent, or duplicate a node in place |
+| `move_component` | Relocate an instance under a new parent in the same variant |
+| `reorder_component` | Reposition an instance among its siblings |
 | `remove_instance` | Delete an instance |
 | `set_board_label` | Rename a board |
 | `apply_actions` | A batch of raw actions, the escape hatch for the long tail |

--- a/packages/ai/README.md
+++ b/packages/ai/README.md
@@ -234,6 +234,7 @@ Tools come in two groups, assembled per turn in [pi/tools/](./pi/tools), one too
 | `list_boards`, `find_nodes`, `board_summary` | Boards and nodes across the workspace |
 | `get_component_vocabulary` | Settable properties and value shapes for a component |
 | `list_theme_tokens`, `search_theme_tokens` | Theme token ids and paths |
+| `search_icons` | Enabled icon ids for the symbol property |
 | `list_catalog_ids` | Component catalog ids |
 | `list_action_types`, `get_action_spec`, `suggest_action` | Action reference for `apply_actions` |
 

--- a/packages/ai/pi/system-prompt.ts
+++ b/packages/ai/pi/system-prompt.ts
@@ -99,8 +99,9 @@ Other tools:
   and its immediate children, then describe_node on a child id to expand only
   that branch. Call get_node_properties for a node's effective values,
   board_summary to see the active board's variants at a glance,
-  get_selection_ancestry to trace inherited color up the parent chain, and
-  search_theme_tokens for a few tokens instead of the whole set.
+  get_selection_ancestry to trace inherited color up the parent chain,
+  search_theme_tokens for a few tokens instead of the whole set, and
+  search_icons to resolve an icon name to its id.
 - To make several edits at once, batch them into one apply_actions call. Order
   edits so any node you create exists before you set its properties.
 - If a tool returns an error or reports an action as rejected, read the reason,
@@ -120,6 +121,8 @@ Rules:
 - Visible text lives on a Text node in its "content" property. To change what a
   button or label says, set "content" on the child Text node. There is no "text"
   property.
+- Icons live on the "symbol" property, which takes an icon id like "seldon-plus",
+  never a display name like "Seldon Plus". Call search_icons to find the id.
 - Prefer theme token references over literals for color, spacing, corners, and
   shadows. Author a reference with a single prefix, for example "@swatch.primary",
   "@fontSize.medium", "@font.body".

--- a/packages/ai/pi/system-prompt.ts
+++ b/packages/ai/pi/system-prompt.ts
@@ -43,8 +43,7 @@ How to work:
     (family) or set_font_collection_family_variant (one weight). No component edits.
   - Icon Set: toggle a subcategory with set_icon_set_subcategory_preset, or one
     icon with set_icon_set_override at includedIcons.<iconId>. No component edits.
-- Rename a board with set_board_label. Structural edits (add, insert, remove,
-  reorder) use their dedicated tools or apply_actions.
+- Rename a board with set_board_label.
 
 Editing node properties with set_properties:
 - target is "selection" for the selected node, or { "nodeId" } for a specific id.
@@ -57,6 +56,25 @@ Editing node properties with set_properties:
   string becomes a theme reference. You need not build the tagged object.
 - Pass "match" (a label or catalog id) when the target may be out of scope, to
   find it in one step instead of a search loop.
+
+Adding, inserting, and duplicating components:
+- add_component adds a catalog component to the workspace as its own board; pass
+  its catalogId from list_catalog_ids. Adding from the catalog is what creates
+  the board, so there is no separate "make a board" step.
+- insert_component places a catalog component under a parent; pass the selected
+  node id to put it in the selection. It creates the board if needed in one step,
+  so never add first and then insert.
+- For a bare "add X" while a node is selected: insert it under the selection when
+  that node's level can hold X. If the level cannot, ask the user whether to add
+  X on its own board or place it elsewhere. Do not silently create a board.
+- insert_variant_instance adds another instance of a specific existing variant.
+- duplicate_component copies an existing node: with a parentId it pastes under
+  that parent, without one it duplicates in place.
+- move_component relocates an instance under a new parent in the same variant,
+  reorder_component changes its position among siblings, and remove_instance
+  deletes one.
+- If an insert or move is rejected by the hierarchy, read the reason and ask the
+  user rather than retrying the same nest.
 
 Finding a target you cannot see:
 - The context is scoped to the selection: an instance's own subtree, a variant,

--- a/packages/ai/pi/tools/context/index.ts
+++ b/packages/ai/pi/tools/context/index.ts
@@ -14,6 +14,7 @@ import { createListActionTypesTool } from "./list-action-types"
 import { createListBoardsTool } from "./list-boards"
 import { createListCatalogIdsTool } from "./list-catalog-ids"
 import { createListThemeTokensTool } from "./list-theme-tokens"
+import { createSearchIconsTool } from "./search-icons"
 import { createSearchThemeTokensTool } from "./search-theme-tokens"
 import { createSuggestActionTool } from "./suggest-action"
 import { createWidenScopeTool } from "./widen-scope"
@@ -38,6 +39,7 @@ export function createContextTools(
     createGetComponentVocabularyTool(resolved),
     createListThemeTokensTool(resolved),
     createSearchThemeTokensTool(resolved),
+    createSearchIconsTool(resolved),
     createListCatalogIdsTool(),
     createListActionTypesTool(),
     createGetActionSpecTool(),

--- a/packages/ai/pi/tools/context/search-icons.ts
+++ b/packages/ai/pi/tools/context/search-icons.ts
@@ -1,0 +1,34 @@
+import {
+  type ToolDefinition,
+  defineTool,
+} from "@earendil-works/pi-coding-agent"
+import { Type } from "typebox"
+
+import { searchIconsSection } from "../../../prompt/context-sections/icons"
+import type { ResolvedContext } from "../../editor-context"
+import { joinOrEmpty, textResult } from "./shared"
+
+/** Returns enabled icon ids whose id or label matches the query. */
+export function createSearchIconsTool(
+  resolved: ResolvedContext,
+): ToolDefinition {
+  const { workspace } = resolved
+  return defineTool({
+    name: "search_icons",
+    label: "Search Icons",
+    description:
+      'Return enabled icon ids whose id or label matches the query, for example "plus". Use it to find the id for the symbol property, which takes an id like "seldon-plus", never a display name.',
+    parameters: Type.Object({
+      query: Type.String({
+        description: "Text to match against icon ids and labels.",
+      }),
+    }),
+    execute: async (_id, params) =>
+      textResult(
+        joinOrEmpty(
+          searchIconsSection(workspace, params.query),
+          `No enabled icons match "${params.query}".`,
+        ),
+      ),
+  })
+}

--- a/packages/ai/pi/tools/mutations/add-component.ts
+++ b/packages/ai/pi/tools/mutations/add-component.ts
@@ -9,33 +9,35 @@ import type { WorkspaceAction } from "@seldon/core/workspace/types"
 import type { PiTurnState } from "../turn-state"
 import { commit, textResult } from "./commit"
 
-/** Adds a catalog component instance under an existing parent node. */
+/**
+ * Adds a component from the catalog to the workspace, which materializes its
+ * board. There is no separate "make a board" step: adding the catalog component
+ * is what creates the board. To place an instance inside an existing node, use
+ * insert_component instead.
+ */
 export function createAddComponentTool(state: PiTurnState): ToolDefinition {
   return defineTool({
     name: "add_component",
     label: "Add Component",
     description:
-      "Add a component instance from the catalog under an existing parent node. Only nest what the hierarchy allows.",
+      "Add a component from the catalog to the workspace as its own board. Pass its catalog id (from list_catalog_ids). To place it inside an existing node, use insert_component.",
     parameters: Type.Object({
-      boardKey: Type.String({
-        description: "Catalog id of the component to add.",
+      catalogId: Type.String({
+        description: "Catalog id of the component to add (from list_catalog_ids).",
       }),
-      parentId: Type.String({ description: "Existing parent node id." }),
-      index: Type.Optional(
-        Type.Number({
-          description: "Insertion index among the parent's children.",
-        }),
-      ),
     }),
-    execute: async (_id, params) =>
-      textResult(
+    execute: async (_id, params) => {
+      if (state.workspace.boards[params.catalogId]) {
+        return textResult(
+          `Component "${params.catalogId}" is already in the workspace. Select its board, or use insert_component to place an instance of it under a parent node.`,
+        )
+      }
+      return textResult(
         commit(state, {
-          type: "add_component_and_insert_default_instance",
-          payload: {
-            boardKey: params.boardKey,
-            target: { parentId: params.parentId, index: params.index },
-          },
+          type: "add_component",
+          payload: { boardKey: params.catalogId },
         } as WorkspaceAction),
-      ),
+      )
+    },
   })
 }

--- a/packages/ai/pi/tools/mutations/add-component.ts
+++ b/packages/ai/pi/tools/mutations/add-component.ts
@@ -23,7 +23,8 @@ export function createAddComponentTool(state: PiTurnState): ToolDefinition {
       "Add a component from the catalog to the workspace as its own board. Pass its catalog id (from list_catalog_ids). To place it inside an existing node, use insert_component.",
     parameters: Type.Object({
       catalogId: Type.String({
-        description: "Catalog id of the component to add (from list_catalog_ids).",
+        description:
+          "Catalog id of the component to add (from list_catalog_ids).",
       }),
     }),
     execute: async (_id, params) => {

--- a/packages/ai/pi/tools/mutations/duplicate-component.ts
+++ b/packages/ai/pi/tools/mutations/duplicate-component.ts
@@ -1,0 +1,59 @@
+import {
+  type ToolDefinition,
+  defineTool,
+} from "@earendil-works/pi-coding-agent"
+import { Type } from "typebox"
+
+import type { WorkspaceAction } from "@seldon/core/workspace/types"
+
+import type { PiTurnState } from "../turn-state"
+import { commit, textResult } from "./commit"
+
+/**
+ * Duplicates an existing node. With a parent, it pastes a copy of an instance
+ * under that parent; without one, it duplicates the node in place next to its
+ * source. The parent's level must allow the component, or the reducer rejects
+ * the paste.
+ */
+export function createDuplicateComponentTool(
+  state: PiTurnState,
+): ToolDefinition {
+  return defineTool({
+    name: "duplicate_component",
+    label: "Duplicate Component",
+    description:
+      "Duplicate an existing component. Pass parentId to paste a copy under that node (for example the selection); omit it to duplicate in place next to the original.",
+    parameters: Type.Object({
+      nodeId: Type.String({
+        description: "Node id to duplicate, from the context.",
+      }),
+      parentId: Type.Optional(
+        Type.String({
+          description:
+            "Parent node id to paste the copy under. Omit to duplicate in place.",
+        }),
+      ),
+      index: Type.Optional(
+        Type.Number({
+          description: "Insertion index among the parent's children.",
+        }),
+      ),
+    }),
+    execute: async (_id, params) => {
+      const action: WorkspaceAction =
+        params.parentId !== undefined
+          ? ({
+              type: "insert_duplicate_instance",
+              payload: {
+                instanceId: params.nodeId,
+                target: { parentId: params.parentId, index: params.index },
+              },
+            } as WorkspaceAction)
+          : ({
+              type: "duplicate_node",
+              payload: { nodeId: params.nodeId },
+            } as WorkspaceAction)
+      return textResult(commit(state, action))
+    },
+  })
+}

--- a/packages/ai/pi/tools/mutations/index.ts
+++ b/packages/ai/pi/tools/mutations/index.ts
@@ -4,8 +4,12 @@ import type { ResolvedContext } from "../../editor-context"
 import type { PiTurnState } from "../turn-state"
 import { createAddComponentTool } from "./add-component"
 import { createApplyActionsTool } from "./apply-actions"
+import { createDuplicateComponentTool } from "./duplicate-component"
+import { createInsertComponentTool } from "./insert-component"
 import { createInsertVariantInstanceTool } from "./insert-variant-instance"
+import { createMoveComponentTool } from "./move-component"
 import { createRemoveInstanceTool } from "./remove-instance"
+import { createReorderComponentTool } from "./reorder-component"
 import { createSetBoardLabelTool } from "./set-board-label"
 import { createSetFontCollectionFamilyPresetTool } from "./set-font-collection-family-preset"
 import { createSetFontCollectionFamilyVariantTool } from "./set-font-collection-family-variant"
@@ -33,7 +37,11 @@ export function createMutationTools(
   const tools: ToolDefinition[] = [
     createSetPropertiesTool(state, resolved),
     createAddComponentTool(state),
+    createInsertComponentTool(state),
     createInsertVariantInstanceTool(state),
+    createDuplicateComponentTool(state),
+    createMoveComponentTool(state),
+    createReorderComponentTool(state),
     createRemoveInstanceTool(state),
     createSetBoardLabelTool(state),
     createApplyActionsTool(state),

--- a/packages/ai/pi/tools/mutations/insert-component.ts
+++ b/packages/ai/pi/tools/mutations/insert-component.ts
@@ -23,7 +23,8 @@ export function createInsertComponentTool(state: PiTurnState): ToolDefinition {
       "Insert a catalog component under an existing parent node (for example the selection). Pass its catalog id (from list_catalog_ids). Creates the board if it does not exist yet. Only nest what the hierarchy allows.",
     parameters: Type.Object({
       catalogId: Type.String({
-        description: "Catalog id of the component to insert (from list_catalog_ids).",
+        description:
+          "Catalog id of the component to insert (from list_catalog_ids).",
       }),
       parentId: Type.String({ description: "Existing parent node id." }),
       index: Type.Optional(

--- a/packages/ai/pi/tools/mutations/insert-component.ts
+++ b/packages/ai/pi/tools/mutations/insert-component.ts
@@ -1,0 +1,55 @@
+import {
+  type ToolDefinition,
+  defineTool,
+} from "@earendil-works/pi-coding-agent"
+import { Type } from "typebox"
+
+import type { WorkspaceAction } from "@seldon/core/workspace/types"
+
+import type { PiTurnState } from "../turn-state"
+import { commit, textResult } from "./commit"
+
+/**
+ * Inserts a catalog component's default instance under an existing parent node.
+ * Board existence decides the action, so the model does not: a missing board is
+ * created and inserted in one step, an existing board is inserted into. The
+ * parent's level must allow the component, or the reducer rejects the insert.
+ */
+export function createInsertComponentTool(state: PiTurnState): ToolDefinition {
+  return defineTool({
+    name: "insert_component",
+    label: "Insert Component",
+    description:
+      "Insert a catalog component under an existing parent node (for example the selection). Pass its catalog id (from list_catalog_ids). Creates the board if it does not exist yet. Only nest what the hierarchy allows.",
+    parameters: Type.Object({
+      catalogId: Type.String({
+        description: "Catalog id of the component to insert (from list_catalog_ids).",
+      }),
+      parentId: Type.String({ description: "Existing parent node id." }),
+      index: Type.Optional(
+        Type.Number({
+          description: "Insertion index among the parent's children.",
+        }),
+      ),
+    }),
+    execute: async (_id, params) => {
+      const action: WorkspaceAction = state.workspace.boards[params.catalogId]
+        ? ({
+            type: "insert_default_instance",
+            payload: {
+              boardKey: params.catalogId,
+              parentId: params.parentId,
+              index: params.index,
+            },
+          } as WorkspaceAction)
+        : ({
+            type: "add_component_and_insert_default_instance",
+            payload: {
+              boardKey: params.catalogId,
+              target: { parentId: params.parentId, index: params.index },
+            },
+          } as WorkspaceAction)
+      return textResult(commit(state, action))
+    },
+  })
+}

--- a/packages/ai/pi/tools/mutations/move-component.ts
+++ b/packages/ai/pi/tools/mutations/move-component.ts
@@ -9,20 +9,22 @@ import type { WorkspaceAction } from "@seldon/core/workspace/types"
 import type { PiTurnState } from "../turn-state"
 import { commit, textResult } from "./commit"
 
-/** Inserts an instance of an existing variant under an existing parent node. */
-export function createInsertVariantInstanceTool(
-  state: PiTurnState,
-): ToolDefinition {
+/**
+ * Relocates an instance under a new parent within the same variant. The reducer
+ * rejects a move across variants, into a default variant, into the instance's
+ * own subtree, or under a parent whose level cannot hold it.
+ */
+export function createMoveComponentTool(state: PiTurnState): ToolDefinition {
   return defineTool({
-    name: "insert_variant_instance",
-    label: "Insert Variant Instance",
+    name: "move_component",
+    label: "Move Component",
     description:
-      "Insert an instance of a specific existing variant under an existing parent node. Use insert_component to add a component from the catalog by its catalog id.",
+      "Move an existing instance under a new parent node in the same variant. Only nest what the hierarchy allows.",
     parameters: Type.Object({
-      variantId: Type.String({
-        description: "Variant node id from the context.",
+      instanceId: Type.String({
+        description: "Instance node id to move, from the context.",
       }),
-      parentId: Type.String({ description: "Existing parent node id." }),
+      parentId: Type.String({ description: "New parent node id." }),
       index: Type.Optional(
         Type.Number({
           description: "Insertion index among the parent's children.",
@@ -32,9 +34,9 @@ export function createInsertVariantInstanceTool(
     execute: async (_id, params) =>
       textResult(
         commit(state, {
-          type: "insert_variant_instance",
+          type: "move_instance",
           payload: {
-            variantId: params.variantId,
+            instanceId: params.instanceId,
             target: { parentId: params.parentId, index: params.index },
           },
         } as WorkspaceAction),

--- a/packages/ai/pi/tools/mutations/reorder-component.ts
+++ b/packages/ai/pi/tools/mutations/reorder-component.ts
@@ -1,0 +1,40 @@
+import {
+  type ToolDefinition,
+  defineTool,
+} from "@earendil-works/pi-coding-agent"
+import { Type } from "typebox"
+
+import type { WorkspaceAction } from "@seldon/core/workspace/types"
+
+import type { PiTurnState } from "../turn-state"
+import { commit, textResult } from "./commit"
+
+/** Reorders an instance among its siblings under the same parent. */
+export function createReorderComponentTool(
+  state: PiTurnState,
+): ToolDefinition {
+  return defineTool({
+    name: "reorder_component",
+    label: "Reorder Component",
+    description:
+      "Move an existing instance to a new position among its siblings under the same parent.",
+    parameters: Type.Object({
+      instanceId: Type.String({
+        description: "Instance node id to reorder, from the context.",
+      }),
+      index: Type.Number({
+        description: "New index among the parent's children.",
+      }),
+    }),
+    execute: async (_id, params) =>
+      textResult(
+        commit(state, {
+          type: "reorder_instance_in_parent",
+          payload: {
+            instanceId: params.instanceId,
+            newIndex: params.index,
+          },
+        } as WorkspaceAction),
+      ),
+  })
+}

--- a/packages/ai/pi/tools/mutations/reorder-component.ts
+++ b/packages/ai/pi/tools/mutations/reorder-component.ts
@@ -10,9 +10,7 @@ import type { PiTurnState } from "../turn-state"
 import { commit, textResult } from "./commit"
 
 /** Reorders an instance among its siblings under the same parent. */
-export function createReorderComponentTool(
-  state: PiTurnState,
-): ToolDefinition {
+export function createReorderComponentTool(state: PiTurnState): ToolDefinition {
   return defineTool({
     name: "reorder_component",
     label: "Reorder Component",

--- a/packages/ai/prompt/context-sections/component-values.ts
+++ b/packages/ai/prompt/context-sections/component-values.ts
@@ -135,6 +135,12 @@ function describeChoices(schemaKey: string, theme?: Theme): string | null {
   const supports = schema.supports ?? []
   const parts: string[] = []
 
+  // The icon catalog is thousands of ids, far too many to inline and not scoped
+  // to the workspace. Point the model at search_icons to resolve an id instead.
+  if (schemaKey === "symbol") {
+    return 'icon id like "seldon-plus" (call search_icons to find one)'
+  }
+
   if (supports.includes("option")) {
     const options = getPresetOptions(schemaKey).map(String)
     if (options.length > 0) parts.push(options.join(" / "))

--- a/packages/ai/prompt/context-sections/icons.ts
+++ b/packages/ai/prompt/context-sections/icons.ts
@@ -1,0 +1,37 @@
+import { getPresetOptionsAsLabelValue } from "@seldon/core/properties/schemas/helpers/property-options"
+import type { Workspace } from "@seldon/core/workspace/types"
+
+import { section } from "./section"
+
+const SEARCH_LIMIT = 30
+
+/**
+ * Context section: Icon search.
+ *
+ * The `symbol` property takes an icon id like "seldon-plus", not a display name.
+ * There are far too many icons to inline, so this matches a query against the
+ * ids and labels of the icons enabled in the workspace and returns each as
+ * "id (Label)". The model resolves a word like "plus" to the real id instead of
+ * guessing one that renders as a missing icon. Falls back to nothing on no
+ * match, so the caller can report a clean miss.
+ */
+export function searchIconsSection(
+  workspace: Workspace,
+  query: string,
+): string[] {
+  const needle = query.trim().toLowerCase()
+  if (needle === "") return []
+
+  const matches: string[] = []
+  for (const { label, value } of getPresetOptionsAsLabelValue(
+    "symbol",
+    workspace,
+  )) {
+    const id = String(value)
+    const haystack = `${id} ${label}`.toLowerCase()
+    if (haystack.includes(needle)) matches.push(`${id} (${label})`)
+    if (matches.length >= SEARCH_LIMIT) break
+  }
+
+  return section(`Icons matching "${query}" (set symbol to the id):`, matches)
+}

--- a/packages/editor/app/palettes/hari/HariMarkdown.bespoke.tsx
+++ b/packages/editor/app/palettes/hari/HariMarkdown.bespoke.tsx
@@ -152,6 +152,8 @@ const styles: Record<string, CSSProperties> = {
     margin: "0 0 8px",
     paddingLeft: 10,
     borderLeft: "3px solid var(--sdn-swatch-gray)",
+    fontSize: "var(--sdn-font-size-xsmall)",
+    lineHeight: 1.5,
     color: "var(--sdn-swatch-gray)",
   },
   rule: {


### PR DESCRIPTION
## 📝 Description

Gives the AI harness a complete, intent-named set of component-authoring tools that map to the correct core `WorkspaceAction`s, so the agent can add, insert, duplicate, move, and reorder components instead of stalling.

The old `add_component` tool was misnamed (its `boardKey` param was really a catalog id) and could only nest under an existing parent, so the model would ask the user for a "board key" or conclude it had no tool to add from the catalog. This reworks it and adds the missing gestures:

- `add_component` now takes `catalogId` and emits the plain `add_component` action to add a catalog component as its own board (adding from the catalog is what creates the board). It reports when the board already exists rather than failing.
- `insert_component` (new) places a catalog component under a parent. It reads the working copy and picks `add_component_and_insert_default_instance` when the board is missing or `insert_default_instance` when it already exists, so "add X here" is a single call.
- `duplicate_component` (new) pastes a copy under a parent (`insert_duplicate_instance`) or duplicates in place (`duplicate_node`).
- `move_component` (new) relocates an instance (`move_instance`); `reorder_component` (new) repositions among siblings (`reorder_instance_in_parent`).
- `insert_variant_instance` description clarified to point at `insert_component` for catalog adds.

The system prompt gains a decision block covering which tool to use per gesture, the bare-request behavior (insert into the selection when the level allows, otherwise ask), and the level-rejection behavior (read the reason and ask, do not retry the same nest). All tools flow through the existing `commit` → `workspaceReducer` validation and verification gate, so illegal nests come back as correctable errors rather than malformed saves.

## 🔗 Related Issues

## 🧪 Type of Change

- 🐛 Bug fix
- ✨ New feature
- 📚 Documentation update

## 📦 Affected Packages

- `@seldon/ai`

## 📸 Screenshots/Videos

_N/A_

## 🔍 Code Quality Checklist

- Code follows the project's style guidelines
- Self-review of the code has been performed
- Code is properly commented, particularly in hard-to-understand areas
- No console.log statements or debugging code left in
- TypeScript types are properly defined, no use of "as any"
- No unused imports or variables

## 📋 Breaking Changes

_None._ Changes are internal to the AI tool schema; no shipped public API changes. Note that the `add_component` tool's parameter was renamed `boardKey` -> `catalogId` and it no longer inserts an instance (use `insert_component` for that).

## 🚀 Deployment Notes

_None._

## 📚 Documentation Updates

- Updated the mutation-tools table in `packages/ai/README.md` with the new tools.
- Expanded `packages/ai/pi/system-prompt.ts` with an "Adding, inserting, and duplicating components" decision block.

## ⚠️ Additional Notes

Verified with `tsc -b packages/ai packages/editor` (clean) and lints on the touched files. All emitted payloads were confirmed against `packages/core/workspace/reducers/types.ts` (`reorder_instance_in_parent` uses `newIndex`).

---

I have read the CLA and I agree to its terms.

Github: AndreiSeldon
Organization: SeldonDigital