### PR TITLE
Handle missing Ollama default model

### DIFF
--- a/packages/editor/lib/ai/run-agent-chat.ts
+++ b/packages/editor/lib/ai/run-agent-chat.ts
@@ -35,6 +35,7 @@ export type AgentConfig = {
     model: string
     thinkingLevel: ThinkingLevelOption
   }
+  warnings?: string[]
 }
 
 export type AgentChatResponse = {
@@ -125,7 +126,16 @@ export async function getAgentConfig(): Promise<AgentConfig | undefined> {
   try {
     const response = await fetch("/api/agent/config")
     if (!response.ok) return undefined
-    return (await response.json()) as AgentConfig
+    const config = (await response.json()) as AgentConfig
+    for (const warning of config.warnings ?? []) {
+      console.warn(
+        "%c[seldon/ai]%c %s",
+        "color:#a855f7;font-weight:bold",
+        "",
+        warning,
+      )
+    }
+    return config
   } catch {
     return undefined
   }
@@ -150,7 +160,14 @@ export async function warmAgent(warm?: {
     body: JSON.stringify(warm ?? {}),
   })
   if (!response.ok) {
-    throw new Error("Agent warm-up failed.")
+    let message = "Agent warm-up failed."
+    try {
+      const data = (await response.json()) as { error?: string }
+      if (data?.error) message = data.error
+    } catch {
+      // Response was not JSON; keep the default message.
+    }
+    throw new Error(message)
   }
   return (await response.json()) as WarmResponse
 }

--- a/packages/editor/lib/hooks/ai-chat/log-turn.ts
+++ b/packages/editor/lib/hooks/ai-chat/log-turn.ts
@@ -45,6 +45,11 @@ function aiLog(message: string, ...args: unknown[]): void {
   console.log(`${AI_TAG} ${message}`, AI_TAG_STYLE, "", ...args)
 }
 
+/** Logs an AI warning with the same browser-console badge as the debug rows. */
+export function logAiWarning(message: string, ...args: unknown[]): void {
+  console.warn(`${AI_TAG} ${message}`, AI_TAG_STYLE, "", ...args)
+}
+
 /** Logs one applied action's target header and each property's before -> after. */
 function logActionChange(
   before: Workspace,

--- a/packages/editor/lib/hooks/use-ai-chat.ts
+++ b/packages/editor/lib/hooks/use-ai-chat.ts
@@ -26,7 +26,12 @@ import {
   findActiveBoardKey,
 } from "./ai-chat/apply-report"
 import { describeChanges } from "./ai-chat/change-summary"
-import { isLoggingEnabled, logAiTurn, logWarm } from "./ai-chat/log-turn"
+import {
+  isLoggingEnabled,
+  logAiTurn,
+  logAiWarning,
+  logWarm,
+} from "./ai-chat/log-turn"
 import { collectVocabularyWarnings } from "./ai-chat/vocabulary-warnings"
 import { useDebugStore } from "./use-debug-mode"
 import { usePanel } from "./use-panel"
@@ -119,7 +124,10 @@ const useStore = create<AiChatState>((set) => ({
   setConfig: (config) =>
     set((state) => ({
       config,
-      model: state.model ?? config.defaults.model,
+      model:
+        state.model && config.models.includes(state.model)
+          ? state.model
+          : config.defaults.model,
       thinkingLevel: state.thinkingLevel ?? config.defaults.thinkingLevel,
     })),
   setModel: (model) => set({ model }),
@@ -321,7 +329,12 @@ export function useHari() {
         const { model } = useStore.getState()
         const { metrics } = await warmAgent({ model })
         if (isLoggingEnabled()) logWarm(metrics)
-      } catch {
+      } catch (error) {
+        if (isLoggingEnabled()) {
+          logAiWarning(
+            error instanceof Error ? error.message : "Agent warm-up failed.",
+          )
+        }
         // Warm-up is best-effort; a failure just means the first turn loads cold.
       } finally {
         warmInFlight = null

--- a/packages/editor/scripts/ensure-ollama.mjs
+++ b/packages/editor/scripts/ensure-ollama.mjs
@@ -19,6 +19,7 @@ import { spawn } from "node:child_process"
 
 const HOST = process.env.OLLAMA_HOST ?? "http://127.0.0.1:11434"
 const PROBE_URL = `${HOST}/api/tags`
+const DEFAULT_MODEL = process.env.SELDON_AI_MODEL ?? "gpt-oss:20b"
 const READY_TIMEOUT_MS = 20_000
 const POLL_INTERVAL_MS = 500
 
@@ -53,6 +54,39 @@ async function isRunning(timeoutMs = 1_000) {
 }
 
 const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms))
+
+/** Returns local Ollama model names, best-effort. */
+async function getInstalledModels(timeoutMs = 2_000) {
+  try {
+    const controller = new AbortController()
+    const timer = setTimeout(() => controller.abort(), timeoutMs)
+    const response = await fetch(PROBE_URL, { signal: controller.signal })
+    clearTimeout(timer)
+    if (!response.ok) return []
+    const data = await response.json()
+    return (data.models ?? [])
+      .map((entry) => entry.model ?? entry.name)
+      .filter((name) => typeof name === "string")
+  } catch {
+    return []
+  }
+}
+
+/** Warns when the configured default model is not present in Ollama. */
+async function warnIfDefaultModelMissing() {
+  const models = await getInstalledModels()
+  if (models.length === 0) {
+    console.warn(
+      `No Ollama models are installed. Pull one before using Hari, for example: ollama pull ${DEFAULT_MODEL}`,
+    )
+    return
+  }
+  if (!models.includes(DEFAULT_MODEL)) {
+    console.warn(
+      `Configured AI model "${DEFAULT_MODEL}" is not installed in Ollama. Available models: ${models.join(", ")}. Pull it with: ollama pull ${DEFAULT_MODEL}`,
+    )
+  }
+}
 
 /**
  * Spawns `ollama serve` detached so it outlives this short-lived script. The
@@ -95,6 +129,7 @@ async function main() {
     console.log(
       `Ollama already running at ${HOST}. Performance settings apply only to a server this script starts; run "npm run ollama:kill" then "npm run dev" to apply them.`,
     )
+    await warnIfDefaultModelMissing()
     return
   }
 
@@ -108,6 +143,7 @@ async function main() {
   while (Date.now() < deadline) {
     if (await isRunning()) {
       console.log(`Ollama is ready at ${HOST}.`)
+      await warnIfDefaultModelMissing()
       return
     }
     await delay(POLL_INTERVAL_MS)

--- a/packages/editor/vite/agent-handler.ts
+++ b/packages/editor/vite/agent-handler.ts
@@ -66,7 +66,7 @@ export async function runAgent(
     selectedBoardId: body.selectedBoardId,
     scope: body.scope,
     resourceTargetId: body.resourceTargetId,
-    model: body.model,
+    model: await resolveAvailableModel(body.model),
     thinkingLevel: body.thinkingLevel,
     noThink: body.noThink,
     onEvent,
@@ -84,6 +84,7 @@ export type AgentConfig = {
     model: string
     thinkingLevel: ThinkingLevelOption
   }
+  warnings?: string[]
 }
 
 /** Lists the local Ollama models, best-effort. Empty when Ollama is unreachable. */
@@ -104,21 +105,52 @@ async function listOllamaModels(): Promise<string[]> {
   }
 }
 
+function missingModelMessage(model: string, models: string[]): string {
+  if (models.length === 0) {
+    return `AI model "${model}" is not installed in Ollama. No local Ollama models are installed. Pull it with: ollama pull ${model}`
+  }
+  return `AI model "${model}" is not installed in Ollama. Available models: ${models.join(", ")}. Pull it with: ollama pull ${model}`
+}
+
+async function resolveAvailableModel(requestedModel: string | undefined) {
+  const configuredDefaultModel = resolvePiModelId()
+  const models = await listOllamaModels()
+  if (models.length === 0) return requestedModel ?? configuredDefaultModel
+  if (requestedModel) {
+    if (!models.includes(requestedModel)) {
+      throw new Error(missingModelMessage(requestedModel, models))
+    }
+    return requestedModel
+  }
+  return models.includes(configuredDefaultModel)
+    ? configuredDefaultModel
+    : models[0]
+}
+
 /**
  * Returns the session-config choices for the Hari palette: the locally available
  * models, the thinking levels, and the current defaults. The model list is
  * best-effort and comes from the local Ollama server.
  */
 export async function agentConfig(): Promise<AgentConfig> {
-  const defaultModel = resolvePiModelId()
+  const configuredDefaultModel = resolvePiModelId()
   const models = await listOllamaModels()
+  const availableModels = models.length > 0 ? models : [configuredDefaultModel]
+  const defaultModel = availableModels.includes(configuredDefaultModel)
+    ? configuredDefaultModel
+    : availableModels[0]
+  const warnings =
+    models.length > 0 && !models.includes(configuredDefaultModel)
+      ? [missingModelMessage(configuredDefaultModel, models)]
+      : undefined
   return {
-    models: models.includes(defaultModel) ? models : [defaultModel, ...models],
+    models: availableModels,
     thinkingLevels: THINKING_LEVEL_OPTIONS,
     defaults: {
       model: defaultModel,
       thinkingLevel: "minimal",
     },
+    warnings,
   }
 }
 
@@ -135,6 +167,8 @@ export type WarmResult = {
 export async function warmAgent(body?: {
   model?: string
 }): Promise<WarmResult> {
-  const metrics = await warmModel({ model: body?.model })
+  const metrics = await warmModel({
+    model: await resolveAvailableModel(body?.model),
+  })
   return { ok: true, metrics }
 }


### PR DESCRIPTION
## Summary

- Default Hari to an installed local Ollama model when the configured default is missing.
- Drop missing configured defaults from the Hari model selector instead of inserting them into the available model list.
- Reset stale client-side model selection when refreshed config no longer includes that model.
- Surface missing-model warnings in the browser console through `/api/agent/config`, matching the existing `[seldon/ai]` debug style.
- Reject stale warm/chat requests for missing models with a clear Ollama install message instead of logging them as warmed.
- Keep the dev-server startup warning that suggests `ollama pull gpt-oss:20b` when the configured default is absent.

## Why

Hari could show or keep `gpt-oss:20b` selected even when that model was not installed locally. That made the browser console look successful while the useful missing-model signal only appeared in the terminal.

The config endpoint now reports only locally installed models, defaults to an installed model, warns the browser when the configured default is missing, and the backend rejects stale requests that still name a missing model.

## Validation

- `npm exec eslint -- packages/editor/lib/ai/run-agent-chat.ts packages/editor/lib/hooks/ai-chat/log-turn.ts packages/editor/lib/hooks/use-ai-chat.ts packages/editor/vite/agent-handler.ts packages/editor/scripts/ensure-ollama.mjs`
- `npm exec tsc -- -p packages/editor/tsconfig.json --noEmit`
- `git diff --check`
- `curl -sS http://localhost:5174/api/agent/config | jq .`
- `curl -sS -i -X POST http://localhost:5174/api/agent/warm -H "Content-Type: application/json" --data "{\"model\":\"gpt-oss:20b\"}"`
- `curl -sS -i -X POST http://localhost:5174/api/agent/warm -H "Content-Type: application/json" --data "{\"model\":\"llama3.2:1b\"}"`