### PR TITLE
Refactor TypeScript configurations and enhance test coverage

### DIFF
--- a/packages/core/helpers/color/contrast.test.ts
+++ b/packages/core/helpers/color/contrast.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it } from "vitest"
 
-import { ValueType } from "../../index"
+import { Color, ValueType } from "../../index"
 import { isDarkBackgroundColor } from "./contrast"
 
-const hex = (value: string) => ({ type: ValueType.EXACT as const, value })
+const hex = (value: `#${string}`) => ({ type: ValueType.EXACT as const, value })
 
 describe("isDarkBackgroundColor", () => {
   it("classifies dark and light colors", () => {
@@ -25,7 +25,10 @@ describe("isDarkBackgroundColor", () => {
       isDarkBackgroundColor({ type: ValueType.EMPTY, value: null }),
     ).toThrow()
     expect(() =>
-      isDarkBackgroundColor({ type: ValueType.OPTION, value: "transparent" }),
+      isDarkBackgroundColor({
+        type: ValueType.OPTION,
+        value: Color.TRANSPARENT,
+      }),
     ).toThrow()
   })
 })

--- a/packages/core/properties/values/appearance/background/background-seeds.test.ts
+++ b/packages/core/properties/values/appearance/background/background-seeds.test.ts
@@ -35,7 +35,7 @@ describe("BACKGROUND_KIND_SEEDS", () => {
 
 describe("backgroundLayerForKind", () => {
   it("returns the seed layer for each kind", () => {
-    expect(backgroundLayerForKind("none").kind).toEqual({
+    expect(backgroundLayerForKind("none")!.kind).toEqual({
       type: ValueType.OPTION,
       value: BackgroundKind.NONE,
     })

--- a/packages/core/properties/values/layout/board/apply-board-preset.test.ts
+++ b/packages/core/properties/values/layout/board/apply-board-preset.test.ts
@@ -45,7 +45,7 @@ describe("matchBoardCompoundPreset", () => {
       ...applyBoardDevicePreset("iphone"),
       width: { type: ValueType.EXACT, value: { value: 1, unit: Unit.PX } },
     }
-    expect(matchBoardCompoundPreset(tampered)).toBeNull()
+    expect(matchBoardCompoundPreset(tampered as BoardCompound)).toBeNull()
     expect(matchBoardCompoundPreset(undefined)).toBeNull()
     expect(matchBoardCompoundPreset({})).toBeNull()
   })

--- a/packages/core/themes/helpers/theme-helpers.test.ts
+++ b/packages/core/themes/helpers/theme-helpers.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest"
 import { Colorspace } from "../constants/colorspace"
 import { TokenType } from "../constants/token-type"
 import { defaultTheme } from "../index"
+import type { ThemePipelineInput } from "../types"
 import { buildEmptyCustomTokenPayload } from "./build-empty-custom-token-payload"
 import { modulate, modulateWithTheme } from "./modulate"
 import { normalizeTheme } from "./normalize-theme"
@@ -12,7 +13,9 @@ import {
 } from "./reserved-token-names"
 
 describe("modulateWithTheme", () => {
-  const theme = { modulation: { parameters: { ratio: 2, baseSize: 16 } } }
+  const theme = {
+    modulation: { parameters: { ratio: 2, baseSize: 16 } },
+  } as unknown as ThemePipelineInput
 
   it("returns the base size at step 0", () => {
     expect(modulateWithTheme({ theme, parameters: { step: 0 } })).toBe(16)

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -32,12 +32,6 @@
     "./index.ts",
     "./constants.ts"
   ],
-  "exclude": [
-    "./dist",
-    "node_modules",
-    "**/generated-ai-action-schema.json",
-    "**/*.spec.ts",
-    "**/*.test.ts"
-  ],
+  "exclude": ["./dist", "node_modules", "**/generated-ai-action-schema.json"],
   "references": []
 }

--- a/packages/core/workspace/compute/compute-node-properties.test.ts
+++ b/packages/core/workspace/compute/compute-node-properties.test.ts
@@ -13,7 +13,7 @@ import {
 } from "./compute-node-properties"
 
 const exact = (value: unknown) =>
-  ({ type: ValueType.EXACT, value }) as unknown as Properties[string]
+  ({ type: ValueType.EXACT, value }) as unknown as Properties[keyof Properties]
 
 describe("mergeEffectiveProperties", () => {
   it("returns an empty object for no sources", () => {

--- a/packages/core/workspace/helpers/graph/build-node-parent-index.test.ts
+++ b/packages/core/workspace/helpers/graph/build-node-parent-index.test.ts
@@ -16,7 +16,7 @@ describe("buildNodeParentIndex", () => {
               id: "root",
               children: [
                 { id: "child1", children: [{ id: "grandchild" }] },
-                "child2",
+                { id: "child2" },
               ],
             },
           ],

--- a/packages/core/workspace/reducers/handlers/board-metadata.integration.test.ts
+++ b/packages/core/workspace/reducers/handlers/board-metadata.integration.test.ts
@@ -42,7 +42,9 @@ describe("board label", () => {
   it("sets a label and resets to the catalog default", () => {
     const set = setBoardLabel(pay({ label: "Custom" }), componentWorkspace())
     expect(board(set, boardKey).label).toBe("Custom")
-    expect(resetBoardLabel(pay({}), set).label).not.toBe("Custom")
+    expect(board(resetBoardLabel(pay({}), set), boardKey).label).not.toBe(
+      "Custom",
+    )
   })
 })
 

--- a/packages/core/workspace/reducers/handlers/insert/insert-instance-happy.integration.test.ts
+++ b/packages/core/workspace/reducers/handlers/insert/insert-instance-happy.integration.test.ts
@@ -46,7 +46,7 @@ describe("insertDefaultInstance (happy path)", () => {
     )
 
     expect(result).not.toBe(ws)
-    expect(variantRef(result, userVariantId).children.length).toBe(
+    expect(variantRef(result, userVariantId).children!.length).toBe(
       beforeChildren + 1,
     )
   })
@@ -55,8 +55,8 @@ describe("insertDefaultInstance (happy path)", () => {
 describe("insertDuplicateInstance (happy path)", () => {
   it("duplicates an existing instance into a non-default user variant", () => {
     const { ws, userVariantId } = withUserVariant()
-    const instanceId = variantRef(ws, userVariantId).children[0].id as string
-    const beforeChildren = variantRef(ws, userVariantId).children.length
+    const instanceId = variantRef(ws, userVariantId).children![0]!.id as string
+    const beforeChildren = variantRef(ws, userVariantId).children!.length
 
     const result = insertDuplicateInstance(
       { instanceId, target: { parentId: userVariantId, index: 0 } } as never,
@@ -64,7 +64,7 @@ describe("insertDuplicateInstance (happy path)", () => {
     )
 
     expect(result).not.toBe(ws)
-    expect(variantRef(result, userVariantId).children.length).toBe(
+    expect(variantRef(result, userVariantId).children!.length).toBe(
       beforeChildren + 1,
     )
   })

--- a/packages/core/workspace/reducers/handlers/insert/insert-variant-instance.integration.test.ts
+++ b/packages/core/workspace/reducers/handlers/insert/insert-variant-instance.integration.test.ts
@@ -17,7 +17,7 @@ const workspace = addComponent(
   createEmptyWorkspace(),
 )
 const board = workspace.boards[ComponentId.BUTTON]!
-const defaultRoot = board.variants[0]!
+const defaultRoot = board.variants[0]! as ComponentTreeRef
 const userVariant = board.variants[1]!
 
 const insert = (variantId: string, parentId: string) =>
@@ -80,6 +80,6 @@ describe("insertVariantInstance (happy path)", () => {
     )
 
     expect(result).not.toBe(ws)
-    expect(targetRef(result).children.length).toBe(before + 1)
+    expect(targetRef(result).children!.length).toBe(before + 1)
   })
 })

--- a/packages/core/workspace/reducers/handlers/move/move-instance-directional.integration.test.ts
+++ b/packages/core/workspace/reducers/handlers/move/move-instance-directional.integration.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest"
 
 import { ComponentId } from "../../../../components/constants"
-import type { ExtractPayload } from "../../../../index"
+import type { ComponentTreeRef, ExtractPayload } from "../../../../index"
 import { createEmptyWorkspace } from "../../../helpers/create-empty-workspace"
 import { addComponent } from "../add/add-component"
 import { moveInstanceDirectional } from "./move-instance-directional"
@@ -11,8 +11,9 @@ const workspace = addComponent(
   createEmptyWorkspace(),
 )
 const board = workspace.boards[ComponentId.BUTTON]!
-const defaultRoot = board.variants[0]!
-const userVariant = board.variants
+const variants = board.variants as ComponentTreeRef[]
+const defaultRoot = variants[0]!
+const userVariant = variants
   .slice(1)
   .find((variant) => (variant.children?.length ?? 0) >= 2)!
 

--- a/packages/core/workspace/reducers/handlers/move/move-instance.integration.test.ts
+++ b/packages/core/workspace/reducers/handlers/move/move-instance.integration.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest"
 
 import { ComponentId } from "../../../../components/constants"
-import type { ExtractPayload } from "../../../../index"
+import type { ComponentTreeRef, ExtractPayload } from "../../../../index"
 import { createEmptyWorkspace } from "../../../helpers/create-empty-workspace"
 import { addComponent } from "../add/add-component"
 import { moveInstance } from "./move-instance"
@@ -13,7 +13,7 @@ const buildButton = () =>
   )
 
 const defaultTree = (workspace: ReturnType<typeof buildButton>) =>
-  workspace.boards[ComponentId.BUTTON]!.variants[0]!
+  workspace.boards[ComponentId.BUTTON]!.variants[0]! as ComponentTreeRef
 
 describe("moveInstance", () => {
   it("moves a schema instance to a new index under its parent", () => {

--- a/packages/core/workspace/reducers/handlers/node-reset-misc.integration.test.ts
+++ b/packages/core/workspace/reducers/handlers/node-reset-misc.integration.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest"
 
 import { ComponentId } from "../../../components/constants"
 import type { ComponentBoard, ExtractPayload, Workspace } from "../../../index"
-import { ValueType } from "../../../properties/constants"
+import { Unit, ValueType } from "../../../properties/constants"
 import { createEmptyWorkspace } from "../../helpers/create-empty-workspace"
 import { addComponent } from "./add/add-component"
 import { addPlayground } from "./add/add-playground"
@@ -62,7 +62,12 @@ describe("resetNodeState / resetNodeStateProperty", () => {
       {
         nodeId: rootId(ws),
         state: "hover",
-        properties: { opacity: { type: ValueType.EXACT, value: 0.5 } },
+        properties: {
+          opacity: {
+            type: ValueType.EXACT,
+            value: { value: 0.5, unit: Unit.PERCENT },
+          },
+        },
       } as ExtractPayload<"set_node_state_properties">,
       ws,
     )

--- a/packages/core/workspace/reducers/handlers/remove/remove-custom-state.integration.test.ts
+++ b/packages/core/workspace/reducers/handlers/remove/remove-custom-state.integration.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest"
 
 import { ComponentId } from "../../../../components/constants"
 import type { ExtractPayload } from "../../../../index"
-import { ValueType } from "../../../../properties/constants"
+import { Unit, ValueType } from "../../../../properties/constants"
 import { createEmptyWorkspace } from "../../../helpers/create-empty-workspace"
 import { addComponent } from "../add/add-component"
 import { addCustomState } from "../add/add-custom-state"
@@ -28,7 +28,12 @@ describe("removeCustomState", () => {
       {
         nodeId,
         state: "warning",
-        properties: { opacity: { type: ValueType.EXACT, value: 0.5 } },
+        properties: {
+          opacity: {
+            type: ValueType.EXACT,
+            value: { value: 0.5, unit: Unit.PERCENT },
+          },
+        },
       } as ExtractPayload<"set_node_state_properties">,
       registered,
     )

--- a/packages/core/workspace/reducers/handlers/reorder/reorder-instance-in-parent.integration.test.ts
+++ b/packages/core/workspace/reducers/handlers/reorder/reorder-instance-in-parent.integration.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest"
 
 import { ComponentId } from "../../../../components/constants"
-import type { ExtractPayload } from "../../../../index"
+import type { ComponentTreeRef, ExtractPayload } from "../../../../index"
 import { createEmptyWorkspace } from "../../../helpers/create-empty-workspace"
 import { addComponent } from "../add/add-component"
 import { reorderInstanceInParent } from "./reorder-instance-in-parent"
@@ -11,8 +11,9 @@ const workspace = addComponent(
   createEmptyWorkspace(),
 )
 const board = workspace.boards[ComponentId.BUTTON]!
-const defaultRoot = board.variants[0]!
-const userVariant = board.variants
+const variants = board.variants as ComponentTreeRef[]
+const defaultRoot = variants[0]!
+const userVariant = variants
   .slice(1)
   .find((variant) => (variant.children?.length ?? 0) >= 2)!
 
@@ -28,9 +29,11 @@ describe("reorderInstanceInParent", () => {
       workspace,
     )
 
-    const after = next.boards[ComponentId.BUTTON]!.variants.find(
-      (variant) => variant.id === userVariant.id,
-    )!.children!.map((child) => child.id)
+    const after = (
+      next.boards[ComponentId.BUTTON]!.variants as ComponentTreeRef[]
+    )
+      .find((variant) => variant.id === userVariant.id)!
+      .children!.map((child) => child.id)
 
     expect(next).not.toBe(workspace)
     expect(after[0]).not.toBe(firstChild)

--- a/packages/core/workspace/reducers/handlers/reset/reset-instance-to-source.integration.test.ts
+++ b/packages/core/workspace/reducers/handlers/reset/reset-instance-to-source.integration.test.ts
@@ -2,7 +2,7 @@ import { produce } from "immer"
 import { describe, expect, it } from "vitest"
 
 import { ComponentId } from "../../../../components/constants"
-import { ValueType } from "../../../../properties/constants"
+import { Unit, ValueType } from "../../../../properties/constants"
 import { createEmptyWorkspace } from "../../../helpers/create-empty-workspace"
 import { formatNodeLink } from "../../../model/template-ref"
 import type {
@@ -78,14 +78,24 @@ describe("resetInstanceToSource", () => {
     let withOverrides = setNodeProperties(
       {
         nodeId: instanceRootId,
-        properties: { opacity: { type: ValueType.EXACT, value: 40 } },
+        properties: {
+          opacity: {
+            type: ValueType.EXACT,
+            value: { value: 40, unit: Unit.PERCENT },
+          },
+        },
       } as ExtractPayload<"set_node_properties">,
       ws,
     )
     withOverrides = setNodeProperties(
       {
         nodeId: instanceChildId,
-        properties: { opacity: { type: ValueType.EXACT, value: 60 } },
+        properties: {
+          opacity: {
+            type: ValueType.EXACT,
+            value: { value: 60, unit: Unit.PERCENT },
+          },
+        },
       } as ExtractPayload<"set_node_properties">,
       withOverrides,
     )
@@ -112,7 +122,12 @@ describe("resetInstanceToSource", () => {
     const drifted = produce(ws, (draft) => {
       const child = draft.nodes[instanceChildId] as EntryNode
       child.template = formatNodeLink("component-icon-default")
-      child.overrides = { opacity: { type: ValueType.EXACT, value: 80 } }
+      child.overrides = {
+        opacity: {
+          type: ValueType.EXACT,
+          value: { value: 80, unit: Unit.PERCENT },
+        },
+      }
     })
     expect(templateOf(drifted, instanceChildId)).not.toBe(
       formatNodeLink(sourceChildId),

--- a/packages/core/workspace/reducers/handlers/reset/reset-node.integration.test.ts
+++ b/packages/core/workspace/reducers/handlers/reset/reset-node.integration.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest"
 
 import { ComponentId } from "../../../../components/constants"
-import { ValueType } from "../../../../properties/constants"
+import { Unit, ValueType } from "../../../../properties/constants"
 import { createEmptyWorkspace } from "../../../helpers/create-empty-workspace"
 import type { EntryNode, ExtractPayload, Workspace } from "../../../types"
 import { addComponent } from "../add/add-component"
@@ -22,7 +22,12 @@ describe("resetNode", () => {
     const withOverride = setNodeProperties(
       {
         nodeId,
-        properties: { opacity: { type: ValueType.EXACT, value: 50 } },
+        properties: {
+          opacity: {
+            type: ValueType.EXACT,
+            value: { value: 50, unit: Unit.PERCENT },
+          },
+        },
       } as ExtractPayload<"set_node_properties">,
       workspace,
     )

--- a/packages/core/workspace/reducers/handlers/reset/reset-variant-instances.integration.test.ts
+++ b/packages/core/workspace/reducers/handlers/reset/reset-variant-instances.integration.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest"
 
 import { ComponentId } from "../../../../components/constants"
-import { ValueType } from "../../../../properties/constants"
+import { Unit, ValueType } from "../../../../properties/constants"
 import { createEmptyWorkspace } from "../../../helpers/create-empty-workspace"
 import { parseNodeLink } from "../../../model/template-ref"
 import type {
@@ -44,7 +44,12 @@ const setOpacity = (ws: Workspace, nodeId: string) =>
   setNodeProperties(
     {
       nodeId,
-      properties: { opacity: { type: ValueType.EXACT, value: 50 } },
+      properties: {
+        opacity: {
+          type: ValueType.EXACT,
+          value: { value: 50, unit: Unit.PERCENT },
+        },
+      },
     } as ExtractPayload<"set_node_properties">,
     ws,
   )

--- a/packages/core/workspace/reducers/handlers/reset/reset-variant-to-catalog.integration.test.ts
+++ b/packages/core/workspace/reducers/handlers/reset/reset-variant-to-catalog.integration.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest"
 
 import { ComponentId } from "../../../../components/constants"
-import { ValueType } from "../../../../properties/constants"
+import { Unit, ValueType } from "../../../../properties/constants"
 import { createEmptyWorkspace } from "../../../helpers/create-empty-workspace"
 import type { EntryNode, ExtractPayload, Workspace } from "../../../types"
 import { addComponent } from "../add/add-component"
@@ -24,7 +24,12 @@ describe("resetVariantToCatalog", () => {
     const withOverride = setNodeProperties(
       {
         nodeId: userVariantId,
-        properties: { opacity: { type: ValueType.EXACT, value: 25 } },
+        properties: {
+          opacity: {
+            type: ValueType.EXACT,
+            value: { value: 25, unit: Unit.PERCENT },
+          },
+        },
       } as ExtractPayload<"set_node_properties">,
       workspace,
     )

--- a/packages/core/workspace/reducers/handlers/resource-metadata.integration.test.ts
+++ b/packages/core/workspace/reducers/handlers/resource-metadata.integration.test.ts
@@ -36,6 +36,15 @@ const themeEntry = (ws: Workspace, id: string) => ws.themes[id]
 const fcEntry = (ws: Workspace, id: string) => ws["font-collections"][id]
 const iconEntry = (ws: Workspace, id: string) => ws["icon-sets"][id]
 
+/** Reads a dot-path out of a dynamic overrides map, returning unknown. */
+const at = (value: unknown, path: string): unknown =>
+  path
+    .split(".")
+    .reduce<unknown>(
+      (acc, key) => (acc as Record<string, unknown> | undefined)?.[key],
+      value,
+    )
+
 const variantTheme = () =>
   duplicateTheme(
     {
@@ -94,7 +103,7 @@ describe("theme tokens (variant entry)", () => {
   it("writes a scale slot, renames it, and clears it", () => {
     const seeded = seedSlot(variantTheme())
     expect(
-      (themeEntry(seeded, variantThemeId).overrides.size ?? {}).custom1,
+      at(themeEntry(seeded, variantThemeId).overrides, "size.custom1"),
     ).toBeDefined()
 
     const renamed = setThemeCustomTokenName(
@@ -107,7 +116,7 @@ describe("theme tokens (variant entry)", () => {
       seeded,
     )
     expect(
-      themeEntry(renamed, variantThemeId).overrides.size.custom1.name,
+      at(themeEntry(renamed, variantThemeId).overrides, "size.custom1.name"),
     ).toBe("Renamed Token")
 
     const removed = resetThemeOverride(
@@ -118,7 +127,7 @@ describe("theme tokens (variant entry)", () => {
       seeded,
     )
     expect(
-      (themeEntry(removed, variantThemeId).overrides.size ?? {}).custom1,
+      at(themeEntry(removed, variantThemeId).overrides, "size.custom1"),
     ).toBeUndefined()
 
     const cleared = resetThemeTokens(
@@ -186,12 +195,12 @@ describe("font collection entry metadata", () => {
       { fontCollectionId: id, path: "a.b", value: 5 } as never,
       ws,
     )
-    expect(fcEntry(set, id).overrides.a.b).toBe(5)
+    expect(at(fcEntry(set, id).overrides, "a.b")).toBe(5)
     const reset = resetFontCollectionOverride(
       { fontCollectionId: id, path: "a.b" } as never,
       set,
     )
-    expect((fcEntry(reset, id).overrides.a ?? {}).b).toBeUndefined()
+    expect(at(fcEntry(reset, id).overrides, "a.b")).toBeUndefined()
     const cleared = resetFontCollection(
       { fontCollectionId: id } as ExtractPayload<"reset_font_collection">,
       set,
@@ -215,16 +224,17 @@ describe("font collection entry metadata", () => {
       } as never,
       variant,
     )
-    const families = fcEntry(added, "fc-variant").overrides.families ?? {}
+    const families = (at(fcEntry(added, "fc-variant").overrides, "families") ??
+      {}) as Record<string, unknown>
     const key = Object.keys(families)[0]!
-    expect(families[key].name).toBe("My Font")
+    expect(at(families, `${key}.name`)).toBe("My Font")
 
     const removed = removeFontCollectionCustomFamily(
       { fontCollectionId: "fc-variant", key } as never,
       added,
     )
     expect(
-      (fcEntry(removed, "fc-variant").overrides.families ?? {})[key],
+      at(fcEntry(removed, "fc-variant").overrides, `families.${key}`),
     ).toBeUndefined()
   })
 })
@@ -250,12 +260,12 @@ describe("icon set entry metadata", () => {
       { iconSetId: id, path: "a.b", value: 9 } as never,
       ws,
     )
-    expect(iconEntry(set, id).overrides.a.b).toBe(9)
+    expect(at(iconEntry(set, id).overrides, "a.b")).toBe(9)
     const reset = resetIconSetOverride(
       { iconSetId: id, path: "a.b" } as never,
       set,
     )
-    expect((iconEntry(reset, id).overrides.a ?? {}).b).toBeUndefined()
+    expect(at(iconEntry(reset, id).overrides, "a.b")).toBeUndefined()
     const cleared = resetIconSet(
       { iconSetId: id } as ExtractPayload<"reset_icon_set">,
       set,

--- a/packages/core/workspace/reducers/handlers/set-reset-node-property.integration.test.ts
+++ b/packages/core/workspace/reducers/handlers/set-reset-node-property.integration.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest"
 
 import { ComponentId } from "../../../components/constants"
-import { ValueType } from "../../../properties/constants"
+import { Unit, ValueType } from "../../../properties/constants"
 import { createEmptyWorkspace } from "../../helpers/create-empty-workspace"
 import type { EntryNode, ExtractPayload, Workspace } from "../../types"
 import { addComponent } from "./add/add-component"
@@ -28,13 +28,18 @@ describe("setNodeProperties then resetNodeProperty", () => {
     const afterSet = setNodeProperties(
       {
         nodeId,
-        properties: { opacity: { type: ValueType.EXACT, value: 50 } },
+        properties: {
+          opacity: {
+            type: ValueType.EXACT,
+            value: { value: 50, unit: Unit.PERCENT },
+          },
+        },
       } as ExtractPayload<"set_node_properties">,
       workspace,
     )
     expect(overridesOf(afterSet, nodeId).opacity).toEqual({
       type: ValueType.EXACT,
-      value: 50,
+      value: { value: 50, unit: Unit.PERCENT },
     })
 
     const afterReset = resetNodeProperty(

--- a/packages/core/workspace/reducers/handlers/set/set-node-state-properties.integration.test.ts
+++ b/packages/core/workspace/reducers/handlers/set/set-node-state-properties.integration.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from "vitest"
 
 import { ComponentId } from "../../../../components/constants"
-import type { ExtractPayload } from "../../../../index"
-import { ValueType } from "../../../../properties/constants"
+import type { ComponentTreeRef, ExtractPayload } from "../../../../index"
+import { Unit, ValueType } from "../../../../properties/constants"
 import { createEmptyWorkspace } from "../../../helpers/create-empty-workspace"
 import { addComponent } from "../add/add-component"
 import { setNodeStateProperties } from "./set-node-state-properties"
@@ -11,14 +11,20 @@ const workspace = addComponent(
   { boardKey: ComponentId.BUTTON } as ExtractPayload<"add_component">,
   createEmptyWorkspace(),
 )
-const defaultRoot = workspace.boards[ComponentId.BUTTON]!.variants[0]!
+const defaultRoot = workspace.boards[ComponentId.BUTTON]!
+  .variants[0]! as ComponentTreeRef
 
 const hoverOpacity = (nodeId: string) =>
   setNodeStateProperties(
     {
       nodeId,
       state: "hover",
-      properties: { opacity: { type: ValueType.EXACT, value: 0.5 } },
+      properties: {
+        opacity: {
+          type: ValueType.EXACT,
+          value: { value: 0.5, unit: Unit.PERCENT },
+        },
+      },
     } as ExtractPayload<"set_node_state_properties">,
     workspace,
   )
@@ -30,7 +36,10 @@ describe("setNodeStateProperties", () => {
 
     expect(states?.hover).toBeDefined()
     expect(states!.hover).toMatchObject({
-      opacity: { type: ValueType.EXACT, value: 0.5 },
+      opacity: {
+        type: ValueType.EXACT,
+        value: { value: 0.5, unit: Unit.PERCENT },
+      },
     })
   })
 

--- a/packages/core/workspace/reducers/handlers/set/set-node-theme.integration.test.ts
+++ b/packages/core/workspace/reducers/handlers/set/set-node-theme.integration.test.ts
@@ -17,7 +17,7 @@ describe("setNodeTheme", () => {
     const nodeId = workspace.boards[ComponentId.BUTTON]!.variants[0]!.id
 
     const next = setNodeTheme(
-      { nodeId, theme: themeId } as ExtractPayload<"set_node_theme">,
+      { nodeId, theme: themeId } as unknown as ExtractPayload<"set_node_theme">,
       workspace,
     )
 

--- a/packages/core/workspace/reducers/reducer-dispatch.exhaustive.test.ts
+++ b/packages/core/workspace/reducers/reducer-dispatch.exhaustive.test.ts
@@ -13,7 +13,7 @@ import { createEmptyWorkspace } from "../helpers/create-empty-workspace"
 import { DEFAULT_FONT_COLLECTION_BOARD_KEY } from "../helpers/seed/seed-default-font-collection-board"
 import { DEFAULT_ICON_SET_BOARD_KEY } from "../helpers/seed/seed-default-icon-set-board"
 import { DEFAULT_THEME_BOARD_KEY } from "../helpers/seed/seed-default-theme-board"
-import type { Workspace, WorkspaceAction } from "../types"
+import type { ComponentTreeRef, Workspace, WorkspaceAction } from "../types"
 import { workspaceReducer } from "./reducer"
 
 const dispatch = (ws: Workspace, action: WorkspaceAction): Workspace =>
@@ -140,7 +140,7 @@ function buildBase() {
     }),
   )
 
-  const buttonVariants = ws.boards[BOARD]!.variants
+  const buttonVariants = ws.boards[BOARD]!.variants as ComponentTreeRef[]
   const defaultRootId = buttonVariants[0]!.id
   const uv1Id = buttonVariants[1]!.id
   const uv2Id = buttonVariants[2]!.id

--- a/packages/core/workspace/services/nodes/node-move-navigation.service.test.ts
+++ b/packages/core/workspace/services/nodes/node-move-navigation.service.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest"
 import { ComponentId } from "../../../components/constants"
 import { createEmptyWorkspace } from "../../helpers/create-empty-workspace"
 import { addComponent } from "../../reducers/handlers/add/add-component"
+import type { ComponentTreeRef } from "../../types"
 import {
   canMoveInstance,
   resolveInstanceMoveTarget,
@@ -13,8 +14,9 @@ const workspace = addComponent(
   createEmptyWorkspace(),
 )
 const board = workspace.boards[ComponentId.BUTTON]!
-const defaultRoot = board.variants[0]!
-const userVariant = board.variants
+const variants = board.variants as ComponentTreeRef[]
+const defaultRoot = variants[0]!
+const userVariant = variants
   .slice(1)
   .find((variant) => (variant.children?.length ?? 0) >= 2)!
 

--- a/packages/core/workspace/services/propagation/propagation.service.test.ts
+++ b/packages/core/workspace/services/propagation/propagation.service.test.ts
@@ -5,6 +5,7 @@ import { createEmptyWorkspace } from "../../helpers/create-empty-workspace"
 import { parseWorkspace } from "../../helpers/parse-workspace"
 import { workspaceReducer } from "../../reducers/reducer"
 import type {
+  ComponentTreeRef,
   EntryNodeId,
   Instance,
   Variant,
@@ -35,7 +36,8 @@ function buildScenario() {
     ws,
     act("insert_default_instance", { boardKey: BOARD, parentId: uv1Id }),
   )
-  const childId = ws.boards[BOARD]!.variants[0]!.children![0]!.id as EntryNodeId
+  const childId = (ws.boards[BOARD]!.variants[0] as ComponentTreeRef)
+    .children![0]!.id as EntryNodeId
   return { ws, defaultRootId, uv1Id, childId }
 }
 
@@ -61,7 +63,7 @@ describe("WorkspacePropagationService.propagateNodeOperation", () => {
     const result = service.propagateNodeOperation({
       nodeId: defaultRootId,
       propagation: "none",
-      apply: (_node, current) => ({ workspace: current, data: 7 }),
+      apply: (_node, current) => ({ workspace: current }),
       workspace: ws,
     })
     expect(result.boards).toBeTruthy()

--- a/packages/editor/tsconfig.json
+++ b/packages/editor/tsconfig.json
@@ -29,8 +29,6 @@
     "node_modules",
     "**/generated-ai-action-schema.json",
     ".next",
-    "dist",
-    "**/*.spec.ts",
-    "**/*.test.ts"
+    "dist"
   ]
 }

--- a/packages/factory/styles/css-properties/get-color-css-value.ts
+++ b/packages/factory/styles/css-properties/get-color-css-value.ts
@@ -89,7 +89,7 @@ export function getColorCSSValue({
 }: {
   color: ColorValue | EmptyValue
   opacity?: PercentageValue | EmptyValue | number
-  brightness?: PercentageValue | EmptyValue
+  brightness?: PercentageValue | EmptyValue | number
   theme: Theme
   useThemeVariableReferences?: boolean
 }): string {

--- a/packages/factory/tsconfig.json
+++ b/packages/factory/tsconfig.json
@@ -30,5 +30,5 @@
       "@seldon/core/*": ["../core/*"]
     }
   },
-  "exclude": ["node_modules", "**/*.spec.ts", "**/*.test.ts"]
+  "exclude": ["node_modules"]
 }


### PR DESCRIPTION
## 📝 Description

Bring test files under TypeScript type checking. The `tsconfig.json` files for `@seldon/core`, `@seldon/editor`, and `@seldon/factory` previously excluded `**/*.spec.ts` and `**/*.test.ts`, so type errors in tests went uncaught. This removes those exclusions and fixes the type errors that surfaced across the test suite, so `tsc` now covers tests too.

Also widens the `brightness` parameter of `getColorCSSValue` to accept a plain `number` alongside `PercentageValue | EmptyValue`, matching how callers pass it.

## 🔗 Related Issues

## 🧪 Type of Change

- 🐛 Bug fix

## 📦 Affected Packages

- `@seldon/core`
- `@seldon/factory`
- `@seldon/editor`

## 📸 Screenshots/Videos

_N/A_

## 🔍 Code Quality Checklist

- Code follows the project's style guidelines
- Self-review of the code has been performed
- Code is properly commented, particularly in hard-to-understand areas
- No console.log statements or debugging code left in
- TypeScript types are properly defined, no use of "as any"
- No unused imports or variables

## 📋 Breaking Changes

_None_

## 🚀 Deployment Notes

_None_

## 📚 Documentation Updates

_None_

## ⚠️ Additional Notes

Test files are now included in `tsc` runs for all three packages. New or edited tests must pass type checking.

---

I have read the CLA and I agree to its terms.

Github: AndreiSeldon
Organization: SeldonDigital