### PR TITLE
Feature/sidebar tabs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2397,14 +2397,12 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@types/whatwg-mimetype/-/whatwg-mimetype-3.0.2.tgz",
       "integrity": "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/ws": {
       "version": "8.18.1",
       "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
       "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -3114,7 +3112,6 @@
       "version": "0.6.4",
       "resolved": "https://registry.npmjs.org/buffer-image-size/-/buffer-image-size-0.6.4.tgz",
       "integrity": "sha512-nEh+kZOPY1w+gcCMobZ6ETUp9WfibndnosbpwB1iJk/8Gt5ZF2bhS6+B6bPYz424KtwsR6Rflc3tCz1/ghX2dQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -3481,7 +3478,6 @@
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
       "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.12"
@@ -4126,7 +4122,6 @@
       "version": "20.10.6",
       "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.10.6.tgz",
       "integrity": "sha512-6QD0ilzDDt93tX44y8tbmZdAcdTRYDhUP+Asgi6pC8Pp5IA3cvaZGyoVN/EGtlq9ziT65iPuBBn3ASLr6hCgVw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": ">=20.0.0",
@@ -7519,7 +7514,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
       "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -10323,7 +10317,8 @@
       "name": "@seldon/factory",
       "dependencies": {
         "change-case": "^5.4.4",
-        "csstype": "^3.1.3"
+        "csstype": "^3.1.3",
+        "happy-dom": "^20.10.6"
       },
       "devDependencies": {
         "@seldon/core": "file:../core",

--- a/packages/editor/app/canvas/boards/ComponentBoard.tsx
+++ b/packages/editor/app/canvas/boards/ComponentBoard.tsx
@@ -21,7 +21,6 @@ import { Frame } from "@seldon/components/frames/Frame"
 import { CssPortal } from "../CssPortal"
 import { CanvasNode } from "../Node"
 import { StyleTag } from "../StyleTag.bespoke"
-import { BoardStateSwitcher } from "./BoardStateSwitcher"
 
 export type ComponentBoardProps = {
   board: Board
@@ -151,7 +150,6 @@ export function ComponentBoard({ board }: ComponentBoardProps) {
         />
       </CssPortal>
       <Frame style={boardWrapperStyle}>
-        <BoardStateSwitcher boardKey={stateBoardKey} />
         <Frame
           ref={boardRootRef}
           data-board-id={boardKey}

--- a/packages/editor/app/palettes/hari/HariController.tsx
+++ b/packages/editor/app/palettes/hari/HariController.tsx
@@ -35,12 +35,6 @@ const HARI_INITIAL_HEIGHT = 480
 /** Class that renders a header ButtonToggle in its activated (on) state. */
 const ACTIVE_TOGGLE_CLASS = "sdn-state-activated"
 
-/** Class that suppresses the hover highlight on a header ButtonToggle. */
-const NO_HOVER_TOGGLE_CLASS = "hari-toggle-no-hover"
-
-/** Header toggle class list for the on and off states, hover suppressed. */
-const ACTIVE_NO_HOVER_TOGGLE_CLASS = `${ACTIVE_TOGGLE_CLASS} ${NO_HOVER_TOGGLE_CLASS}`
-
 /**
  * The button label for a thinking value: the matching option label when the
  * value is in the menu, an empty value as "Default", else the titled value.
@@ -330,23 +324,21 @@ function Hari({
   const titleSlot = { children: "Hari" }
   const clampToggleSlot = {
     onClick: toggleNoThink,
-    className: noThink ? ACTIVE_NO_HOVER_TOGGLE_CLASS : NO_HOVER_TOGGLE_CLASS,
+    className: noThink ? ACTIVE_TOGGLE_CLASS : undefined,
     "aria-pressed": noThink,
     title: "Clamp Thinking",
     "data-testid": "ai-chat-clamp",
   }
   const toolsToggleSlot = {
     onClick: toggleShowTools,
-    className: showTools ? ACTIVE_NO_HOVER_TOGGLE_CLASS : NO_HOVER_TOGGLE_CLASS,
+    className: showTools ? ACTIVE_TOGGLE_CLASS : undefined,
     "aria-pressed": showTools,
     title: "Show Tools",
     "data-testid": "ai-chat-tools",
   }
   const outcomeToggleSlot = {
     onClick: toggleShowOutcome,
-    className: showOutcome
-      ? ACTIVE_NO_HOVER_TOGGLE_CLASS
-      : NO_HOVER_TOGGLE_CLASS,
+    className: showOutcome ? ACTIVE_TOGGLE_CLASS : undefined,
     "aria-pressed": showOutcome,
     title: "Show Outcome",
     "data-testid": "ai-chat-outcome",

--- a/packages/editor/app/palettes/hari/hari.css
+++ b/packages/editor/app/palettes/hari/hari.css
@@ -1,36 +1,4 @@
 /*
- * Suppresses the hover highlight on the Hari header toggle buttons while
- * leaving every other state intact. On hover the button keeps its resting
- * appearance, which differs between the default and activated states. The
- * `:not(:active):not(:focus-visible)` guards keep the press and keyboard-focus
- * states working.
- */
-
-.sdn-button-toggle.hari-toggle-no-hover:hover:not(:active):not(:focus-visible) {
-  background-color: var(--sdn-swatch-primary-b75);
-  border: var(--hairline) solid var(--sdn-swatch-primary);
-}
-
-.sdn-button-toggle.hari-toggle-no-hover:hover:not(:active):not(:focus-visible)
-  .sdn-icon--ovkd {
-  opacity: 1;
-  color: var(--sdn-hc-on-primary-b75);
-}
-
-.sdn-button-toggle.hari-toggle-no-hover.sdn-state-activated:hover:not(
-    :active
-  ):not(:focus-visible) {
-  background-color: var(--sdn-swatch-offWhite);
-}
-
-.sdn-button-toggle.hari-toggle-no-hover.sdn-state-activated:hover:not(
-    :active
-  ):not(:focus-visible)
-  .sdn-icon--ovkd {
-  color: var(--sdn-swatch-active);
-}
-
-/*
  * While a turn streams, its reply is provisional: the model may still be
  * emitting mid-turn commentary before the final result. Mark it as in-progress
  * with italic offBlack text at half opacity. When the turn finishes the class

--- a/packages/editor/app/sidebars/objects/BoardController.tsx
+++ b/packages/editor/app/sidebars/objects/BoardController.tsx
@@ -197,9 +197,14 @@ function BoardRow({
         selectionId={boardKey}
         selectionKind={BOARD_SELECTION_KIND}
       >
+        {/* Boards have no `display` property, so the nodeDisplay slot is off
+        (`buttonIconic2={null}`) and only the actions menu (`buttonIconic3`)
+        renders. */}
         <ItemNode
           buttonIconic={{}}
           comboboxField={comboboxField}
+          buttonIconic2={null}
+          buttonIconic3={{}}
           seldonRefs={seldonRefs}
           onClick={onClick}
           onDoubleClick={onDoubleClick}

--- a/packages/editor/app/sidebars/objects/NodeController.tsx
+++ b/packages/editor/app/sidebars/objects/NodeController.tsx
@@ -1,3 +1,4 @@
+import { ComboboxListbox } from "@lib/menus"
 import { useRowActionsMenu } from "@lib/menus/use-row-actions-menu"
 import {
   buildDisabledRefProps,
@@ -13,6 +14,7 @@ import { useWorkspace } from "@lib/workspace/hooks/use-workspace"
 import { useSidebarCanvasTracking } from "../../tracking/hooks/use-sidebar-canvas-tracking"
 import { IndentationLevel } from "../hooks/use-indentation"
 import { useRenameInput } from "../hooks/use-rename-input"
+import { useRowDisplayPicker } from "./hooks/use-row-display-picker"
 import { useRowNode } from "./hooks/use-row-node"
 import { getNode } from "@lib/workspace/workspace-accessors"
 import { ItemNode } from "@seldon/components/elements/ItemNode"
@@ -71,6 +73,11 @@ const NodeInner = function NodeInner({
     icon,
     icon2,
     actions,
+    displayOptionGroups,
+    displayValue,
+    selectDisplay,
+    resolveDisplayOptionIcon,
+    displayIcon,
     onClick,
     onDoubleClick,
     isExpanded,
@@ -84,9 +91,9 @@ const NodeInner = function NodeInner({
     dragging,
     ref,
     properties,
-    isExcluded,
-    isHidden,
-    isStub,
+    isDimmed,
+    dimStyle,
+    labelDecorationStyle,
     isDuplicateLabel,
     nodeTypeColor,
     isPrimaryShared,
@@ -102,6 +109,16 @@ const NodeInner = function NodeInner({
 
   const actionsMenu = useRowActionsMenu(actions, {
     focusTargetRef: ref,
+  })
+
+  // The row Display picker reuses the same floating `ComboboxListbox` widget as
+  // the properties Display control. Its trigger stays visible (unlike the
+  // on-demand actions menu), so a row's display is always one click away.
+  const displayPicker = useRowDisplayPicker({
+    optionGroups: displayOptionGroups,
+    value: displayValue,
+    onSelect: selectDisplay,
+    resolveIcon: resolveDisplayOptionIcon,
   })
 
   const { handleCanvasTrackingEnter, handleCanvasTrackingLeave } =
@@ -197,29 +214,22 @@ const NodeInner = function NodeInner({
     },
   }
 
-  // A hidden, stub, or excluded node reads as disabled. Excluded rows
-  // italicize and strike through the name shown in the combobox input;
-  // stub rows italicize it.
-  const isDimmed = isHidden || isStub || isExcluded
-  const excludedLabelStyle = {
-    ...nameInput.style,
-    fontStyle: "italic" as const,
-    textDecoration: "line-through" as const,
-  }
-  const stubLabelStyle = {
-    ...nameInput.style,
-    fontStyle: "italic" as const,
-  }
-  const nodeLabel = isExcluded
-    ? { ...nameInput, style: excludedLabelStyle }
-    : isStub
-      ? { ...nameInput, style: stubLabelStyle }
-      : nameInput
+  // Hide, stub, mock, and exclude dim the row. The row's italic label
+  // decoration comes from the hook, so the name shown in the combobox input
+  // matches the row label.
+  const renameStyle = labelDecorationStyle
+    ? { ...nameInput.style, ...labelDecorationStyle }
+    : nameInput.style
+  const nodeLabel = { ...nameInput, style: renameStyle }
 
   // Disabled is not owned by the combobox-field, so it never cascades from the
   // field to these leaves. Forward `aria-disabled` onto each leaf ref so their
   // own `[aria-disabled]` styles dim the row.
   const disabledRef = buildDisabledRefProps(isDimmed)
+
+  // Dimmed rows read as gray (from `aria-disabled`) at 50% opacity. The fade
+  // applies to the same icon and label leaves that carry the gray.
+  const dimRef = dimStyle ? { style: dimStyle } : undefined
 
   // A duplicate variant label is an error state. The name label sits outside
   // the combobox-field, so forward `aria-invalid` onto the icon and label leaves
@@ -239,13 +249,21 @@ const NodeInner = function NodeInner({
   const seldonRefs = {
     nodeToggle: { ...buttonIconic },
     nodeToggleIcon: mergeStateProps(toggleIcon, disabledRef),
-    nodeIcon: mergeStateProps(icon2, disabledRef, nodeTypeStyle, invalidRef),
-    nodeLabel: mergeStateProps(
-      nodeLabel,
+    nodeIcon: mergeStateProps(
+      icon2,
       disabledRef,
+      dimRef,
       nodeTypeStyle,
       invalidRef,
     ),
+    nodeLabel: mergeStateProps(
+      nodeLabel,
+      disabledRef,
+      dimRef,
+      nodeTypeStyle,
+      invalidRef,
+    ),
+    nodeDisplay: { ...displayPicker.buttonProps },
     nodeActions: { ...actionsMenu.buttonIconic },
   }
 
@@ -278,6 +296,11 @@ const NodeInner = function NodeInner({
       : {}),
   }
 
+  // Echo rows are stripped leaves with no display of their own, so their
+  // nodeDisplay slot is removed. Real rows keep the slot on its generated
+  // default and drive it through the `nodeDisplay` ref.
+  const displayButtonSlot = isEcho ? null : undefined
+
   // Root-level row state. Selection lives on the combobox-field and disabled on
   // the leaves; these mirror the row's logical state for selectors and tests.
   const itemNodeState = {
@@ -305,6 +328,9 @@ const NodeInner = function NodeInner({
           <ItemNode
             buttonIconic={{}}
             comboboxField={comboboxField}
+            buttonIconic2={displayButtonSlot}
+            icon3={displayIcon}
+            buttonIconic3={{}}
             seldonRefs={seldonRefs}
             onClick={onClick}
             onDoubleClick={onDoubleClick}
@@ -320,6 +346,7 @@ const NodeInner = function NodeInner({
           />
         </SidebarTracking>
       </RowSelectionTarget>
+      <ComboboxListbox {...displayPicker.listbox} />
       {actionsMenu.menu}
 
       {childrenSection}

--- a/packages/editor/app/sidebars/objects/ObjectsSidebar.tsx
+++ b/packages/editor/app/sidebars/objects/ObjectsSidebar.tsx
@@ -14,6 +14,7 @@ import {
   useStore as useSelectionStore,
 } from "@lib/workspace/hooks/use-selection"
 import { useWorkspace } from "@lib/workspace/hooks/use-workspace"
+import { useEditorConfig } from "@lib/hooks/use-editor-config"
 import { useTool } from "@lib/hooks/use-tool"
 import { useRenameInput } from "../hooks/use-rename-input"
 import { useIsSectionExpanded } from "../hooks/use-section-expansion"
@@ -31,6 +32,9 @@ import { useAddToast } from "@app/toaster/hooks/use-add-toast"
 import { BoardSection } from "../helpers/get-board-sections"
 import { BoardController } from "./BoardController"
 import { Section } from "./Section"
+
+/** Class that renders a header ButtonToggle in its activated (on) state. */
+const ACTIVE_TOGGLE_CLASS = "sdn-state-activated"
 
 /**
  * View-model for the objects sidebar. Feeds the generated `SidebarObjects`
@@ -50,6 +54,7 @@ export function ObjectsSidebar() {
   const { activeBoard } = useActiveBoard()
   const { selectWorkspace } = useSelectionActions()
   const { activeTool } = useTool()
+  const { objectsView, setObjectsView } = useEditorConfig()
   const workspaceSelected = useSelectionStore(
     (state) => state.workspaceSelected,
   )
@@ -119,6 +124,31 @@ export function ObjectsSidebar() {
   }
   const projectActions = { onClick: handleForceSave }
 
+  // Header view toggles behave as a radio pair: one is always active. The
+  // activated state renders through the generated button-toggle `on` styling.
+  const showComponents = useCallback(
+    () => setObjectsView("components"),
+    [setObjectsView],
+  )
+  const showResources = useCallback(
+    () => setObjectsView("resources"),
+    [setObjectsView],
+  )
+  const componentsActive = objectsView === "components"
+  const resourcesActive = objectsView === "resources"
+  const componentsToggle = {
+    onClick: showComponents,
+    className: componentsActive ? ACTIVE_TOGGLE_CLASS : undefined,
+    "aria-pressed": componentsActive,
+    title: "Components",
+  }
+  const resourcesToggle = {
+    onClick: showResources,
+    className: resourcesActive ? ACTIVE_TOGGLE_CLASS : undefined,
+    "aria-pressed": resourcesActive,
+    title: "Resources",
+  }
+
   const sectionGroups = sections.map((section) => (
     <ObjectsSectionGroup key={section.label} section={section} />
   ))
@@ -151,6 +181,8 @@ export function ObjectsSidebar() {
       comboboxFieldProject={projectField}
       input={nameInput}
       buttonIconic={projectActions}
+      buttonToggle={componentsToggle}
+      buttonToggle2={resourcesToggle}
       seldonRefs={seldonRefs}
       style={styles.sidebar}
     />

--- a/packages/editor/app/sidebars/objects/ResourceEntry.tsx
+++ b/packages/editor/app/sidebars/objects/ResourceEntry.tsx
@@ -109,9 +109,14 @@ export function ResourceEntry({
         selectionId={entryId}
         selectionKind={config.selectionKind}
       >
+        {/* Resource entries have no `display` property, so the nodeDisplay slot
+        is off (`buttonIconic2={null}`) and only the actions menu
+        (`buttonIconic3`) renders. */}
         <ItemNode
           buttonIconic={{}}
           comboboxField={comboboxField}
+          buttonIconic2={null}
+          buttonIconic3={{}}
           seldonRefs={seldonRefs}
           onClick={onClick}
           onDoubleClick={onDoubleClick}

--- a/packages/editor/app/sidebars/objects/hooks/row-display-style.ts
+++ b/packages/editor/app/sidebars/objects/hooks/row-display-style.ts
@@ -1,0 +1,78 @@
+import { CSSProperties } from "react"
+import { Display } from "@seldon/core"
+
+/**
+ * Maps a node's `Display` state, and any state inherited from its instance
+ * ancestors, to the visual notation of its objects-sidebar row. This is the one
+ * place the state-to-style rules live, so the row label and the inline rename
+ * input cannot drift apart.
+ *
+ * Facets compose across the node and its ancestor chain: a row is dimmed,
+ * faded, or italic when any collected state belongs to the matching set. The
+ * resulting matrix for a node's own state is:
+ *
+ * - `SHOW`: normal
+ * - `HIDE`: dimmed
+ * - `STUB`: dimmed + italic
+ * - `MOCK`: dimmed + faded
+ * - `EXCLUDE`: dimmed + italic + faded
+ *
+ * Dimmed rows read as gray (leaf `[aria-disabled]` style). Faded rows drop that
+ * gray to 65% opacity.
+ */
+
+/** Opacity applied to the icon and label of a faded row, over its gray color. */
+const FADED_OPACITY = 0.65
+
+/** States that dim the row to gray through the leaf `[aria-disabled]` style. */
+export const DIMMED_DISPLAY_STATES: ReadonlySet<Display> = new Set([
+  Display.HIDE,
+  Display.STUB,
+  Display.MOCK,
+  Display.EXCLUDE,
+])
+
+/** States that fade the row's gray to 50% opacity. */
+export const FADED_DISPLAY_STATES: ReadonlySet<Display> = new Set([
+  Display.MOCK,
+  Display.EXCLUDE,
+])
+
+/** States that italicize the row label. */
+export const ITALIC_DISPLAY_STATES: ReadonlySet<Display> = new Set([
+  Display.STUB,
+  Display.EXCLUDE,
+])
+
+export interface RowDisplayDecoration {
+  /** Row reads as disabled/gray. Drives `aria-disabled` on the row leaves. */
+  isDimmed: boolean
+  /** Faded appearance (65% opacity), applied to the icon and label leaves. */
+  dimStyle?: CSSProperties
+  /** Inline label decoration (italic), or `undefined`. */
+  labelStyle?: CSSProperties
+}
+
+/**
+ * Resolves the row decoration from the set of `Display` states affecting a
+ * node. Pass the node's own state plus every state inherited from its instance
+ * ancestors.
+ */
+export function resolveRowDisplayDecoration(
+  states: Iterable<Display>,
+): RowDisplayDecoration {
+  let isDimmed = false
+  let isFaded = false
+  let isItalic = false
+
+  for (const state of states) {
+    if (DIMMED_DISPLAY_STATES.has(state)) isDimmed = true
+    if (FADED_DISPLAY_STATES.has(state)) isFaded = true
+    if (ITALIC_DISPLAY_STATES.has(state)) isItalic = true
+  }
+
+  const decoration: RowDisplayDecoration = { isDimmed }
+  if (isFaded) decoration.dimStyle = { opacity: FADED_OPACITY }
+  if (isItalic) decoration.labelStyle = { fontStyle: "italic" }
+  return decoration
+}

--- a/packages/editor/app/sidebars/objects/hooks/row-node-label.ts
+++ b/packages/editor/app/sidebars/objects/hooks/row-node-label.ts
@@ -1,0 +1,88 @@
+import { removeNewLines } from "@lib/helpers/new-lines"
+import { getComponentName } from "@seldon/factory/export/react/discovery/get-component-name"
+import { Properties } from "@seldon/core"
+import { isEmptyValue } from "@seldon/core/helpers/type-guards/value/is-empty-value"
+import { IconId, iconLabels } from "@seldon/core/icon-sets"
+import { typeCheckingService } from "@seldon/core/workspace/services"
+import type { EntryNode } from "@seldon/core/workspace/types"
+import { IconProps } from "@seldon/components/primitives/Icon"
+
+type Workspace = Parameters<typeof getComponentName>[1]
+
+interface NodeLabelOptions {
+  showNodeIds: boolean
+  showCodeNames: boolean
+  nodeExistsInWorkspace: boolean
+  properties: Properties
+}
+
+/**
+ * Resolves the text shown for a node row. Debug "Show Node Ids" wins, then
+ * "Show Code Names" swaps in the export component name. Instances fall back to
+ * their content text or icon label. Display only; the node label and rename
+ * behavior are unchanged.
+ */
+export function getNodeLabel(
+  node: EntryNode,
+  workspace: Workspace,
+  { showNodeIds, showCodeNames, nodeExistsInWorkspace, properties }: NodeLabelOptions,
+): string {
+  if (showNodeIds) {
+    return `${node.id} | ${node.template}`
+  }
+
+  if (showCodeNames && nodeExistsInWorkspace) {
+    return getComponentName(node, workspace)
+  }
+
+  if (
+    typeCheckingService.isInstance(node) &&
+    properties?.content &&
+    !isEmptyValue(properties.content)
+  ) {
+    return removeNewLines(properties.content.value)
+  }
+
+  if (
+    typeCheckingService.isInstance(node) &&
+    properties?.symbol &&
+    !isEmptyValue(properties.symbol) &&
+    iconLabels[properties.symbol.value as IconId]
+  ) {
+    return iconLabels[properties.symbol.value as IconId] + " icon"
+  }
+
+  return node.label
+}
+
+/** Icon for the node's entity type shown left of the row label. */
+export function getComponentTypeIcon(node: EntryNode): IconProps["icon"] {
+  if (typeCheckingService.isVariant(node)) {
+    if (typeCheckingService.isDefaultVariant(node)) {
+      return "seldon-componentDefault"
+    }
+    if (typeCheckingService.isUserVariant(node)) {
+      return "seldon-componentVariant"
+    }
+  }
+  return "seldon-stub"
+}
+
+/**
+ * Debug "Show Node Types" tint for the row icon and label. User variants use the
+ * Punch swatch and instances a lighter tint. Boards and default variants keep
+ * the default color.
+ */
+export function getNodeTypeColor(
+  node: EntryNode,
+  showNodeTypes: boolean,
+): string | undefined {
+  if (!showNodeTypes) return undefined
+  if (typeCheckingService.isInstance(node)) {
+    return "color-mix(in srgb, var(--sdn-swatch-punch) 80%, var(--sdn-swatch-white))"
+  }
+  if (typeCheckingService.isUserVariant(node)) {
+    return "var(--sdn-swatch-punch)"
+  }
+  return undefined
+}

--- a/packages/editor/app/sidebars/objects/hooks/row-node-label.ts
+++ b/packages/editor/app/sidebars/objects/hooks/row-node-label.ts
@@ -25,7 +25,12 @@ interface NodeLabelOptions {
 export function getNodeLabel(
   node: EntryNode,
   workspace: Workspace,
-  { showNodeIds, showCodeNames, nodeExistsInWorkspace, properties }: NodeLabelOptions,
+  {
+    showNodeIds,
+    showCodeNames,
+    nodeExistsInWorkspace,
+    properties,
+  }: NodeLabelOptions,
 ): string {
   if (showNodeIds) {
     return `${node.id} | ${node.template}`

--- a/packages/editor/app/sidebars/objects/hooks/use-objects-sidebar.ts
+++ b/packages/editor/app/sidebars/objects/hooks/use-objects-sidebar.ts
@@ -5,7 +5,10 @@ import { useSelection } from "@lib/workspace/hooks/use-selection"
 import { useWorkspace } from "@lib/workspace/hooks/use-workspace"
 import { useEditorConfig } from "@lib/hooks/use-editor-config"
 import { getComponentKey } from "@lib/workspace/workspace-accessors"
-import { BoardSection, getBoardSections } from "../../helpers/get-board-sections"
+import {
+  BoardSection,
+  getBoardSections,
+} from "../../helpers/get-board-sections"
 
 /** Section levels that belong to the Resources view of the objects sidebar. */
 const RESOURCE_SECTION_LEVELS: ReadonlySet<BoardSection["level"]> = new Set([

--- a/packages/editor/app/sidebars/objects/hooks/use-objects-sidebar.ts
+++ b/packages/editor/app/sidebars/objects/hooks/use-objects-sidebar.ts
@@ -5,7 +5,15 @@ import { useSelection } from "@lib/workspace/hooks/use-selection"
 import { useWorkspace } from "@lib/workspace/hooks/use-workspace"
 import { useEditorConfig } from "@lib/hooks/use-editor-config"
 import { getComponentKey } from "@lib/workspace/workspace-accessors"
-import { getBoardSections } from "../../helpers/get-board-sections"
+import { BoardSection, getBoardSections } from "../../helpers/get-board-sections"
+
+/** Section levels that belong to the Resources view of the objects sidebar. */
+const RESOURCE_SECTION_LEVELS: ReadonlySet<BoardSection["level"]> = new Set([
+  "THEME",
+  "FONT_COLLECTION",
+  "ICON_SET",
+  "MEDIA",
+])
 
 /**
  * Boards list, section grouping, and default-board selection for the objects
@@ -14,7 +22,7 @@ import { getBoardSections } from "../../helpers/get-board-sections"
 export function useObjectsSidebar() {
   const { workspace } = useWorkspace({ usePreview: false })
   const { activeBoard } = useActiveBoard()
-  const { showPlayground } = useEditorConfig()
+  const { showPlayground, objectsView } = useEditorConfig()
   const {
     selectBoard,
     selectedNodeId,
@@ -34,9 +42,14 @@ export function useObjectsSidebar() {
 
   const sections = useMemo(() => {
     const allSections = getBoardSections(boards, playgrounds)
-    if (showPlayground) return allSections
-    return allSections.filter((section) => section.level !== "PLAYGROUND")
-  }, [boards, playgrounds, showPlayground])
+    const viewSections = allSections.filter((section) =>
+      objectsView === "resources"
+        ? RESOURCE_SECTION_LEVELS.has(section.level)
+        : !RESOURCE_SECTION_LEVELS.has(section.level),
+    )
+    if (showPlayground) return viewSections
+    return viewSections.filter((section) => section.level !== "PLAYGROUND")
+  }, [boards, playgrounds, showPlayground, objectsView])
 
   useEffect(() => {
     if (

--- a/packages/editor/app/sidebars/objects/hooks/use-row-display-picker.ts
+++ b/packages/editor/app/sidebars/objects/hooks/use-row-display-picker.ts
@@ -1,15 +1,22 @@
 "use client"
 
-import { CSSProperties, MouseEvent, RefObject, useCallback, useRef, useState } from "react"
 import {
   ComboboxOptionItem,
   ComboboxPosition,
   OptionIconRender,
   useComboboxPosition,
 } from "@lib/menus"
+import {
+  CSSProperties,
+  MouseEvent,
+  RefObject,
+  useCallback,
+  useRef,
+  useState,
+} from "react"
 import { ButtonIconicProps } from "@seldon/components/elements/ButtonIconic"
 
-// Fixed panel width for the floating display picker. 
+// Fixed panel width for the floating display picker.
 const PANEL_WIDTH = 200
 
 interface DisplayPickerInput {

--- a/packages/editor/app/sidebars/objects/hooks/use-row-display-picker.ts
+++ b/packages/editor/app/sidebars/objects/hooks/use-row-display-picker.ts
@@ -9,9 +9,7 @@ import {
 } from "@lib/menus"
 import { ButtonIconicProps } from "@seldon/components/elements/ButtonIconic"
 
-// Fixed panel width for the floating display picker. The trigger is a small
-// icon button near the right edge of the row, so the panel is right-aligned to
-// it at a comfortable reading width.
+// Fixed panel width for the floating display picker. 
 const PANEL_WIDTH = 200
 
 interface DisplayPickerInput {

--- a/packages/editor/app/sidebars/objects/hooks/use-row-display-picker.ts
+++ b/packages/editor/app/sidebars/objects/hooks/use-row-display-picker.ts
@@ -1,0 +1,120 @@
+"use client"
+
+import { CSSProperties, MouseEvent, RefObject, useCallback, useRef, useState } from "react"
+import {
+  ComboboxOptionItem,
+  ComboboxPosition,
+  OptionIconRender,
+  useComboboxPosition,
+} from "@lib/menus"
+import { ButtonIconicProps } from "@seldon/components/elements/ButtonIconic"
+
+// Fixed panel width for the floating display picker. The trigger is a small
+// icon button near the right edge of the row, so the panel is right-aligned to
+// it at a comfortable reading width.
+const PANEL_WIDTH = 200
+
+interface DisplayPickerInput {
+  optionGroups: ComboboxOptionItem[][]
+  value: string
+  onSelect: (value: string) => void
+  resolveIcon: (option?: { value: string; name: string }) => OptionIconRender
+}
+
+interface DisplayPickerResult {
+  /** Slot props for the row's `nodeDisplay` iconic-button trigger. */
+  buttonProps: ButtonIconicProps & { ref: RefObject<HTMLButtonElement | null> }
+  /** Props for the floating `ComboboxListbox` value list. */
+  listbox: {
+    open: boolean
+    position: ComboboxPosition
+    handleClose: () => void
+    onPointerLeave: () => void
+    filteredOptions: ComboboxOptionItem[][]
+    hasSections: boolean
+    value: string
+    highlightedValue?: string
+    resolveIcon: (option?: { value: string; name: string }) => OptionIconRender
+    onSelect: (value: string) => void
+    onHighlight: (value: string | undefined) => void
+  }
+}
+
+const TRIGGER_STYLE: CSSProperties = { position: "relative", zIndex: 10 }
+
+/**
+ * Drives the objects-sidebar row Display picker with the same floating
+ * `ComboboxListbox` widget the properties Display control uses. Owns the open
+ * state, keyboard highlight, and the panel position anchored to the row's
+ * Display button.
+ */
+export function useRowDisplayPicker({
+  optionGroups,
+  value,
+  onSelect,
+  resolveIcon,
+}: DisplayPickerInput): DisplayPickerResult {
+  const [open, setOpen] = useState(false)
+  const [highlightedValue, setHighlightedValue] = useState<string | undefined>(
+    undefined,
+  )
+  const buttonRef = useRef<HTMLButtonElement | null>(null)
+
+  // Reuse the shared anchor positioning, then right-align a fixed-width panel to
+  // the small icon-button trigger (its own width is too narrow for the list).
+  const anchor = useComboboxPosition({ open, frameRef: buttonRef })
+  const position: ComboboxPosition = {
+    x: anchor.x + anchor.w - PANEL_WIDTH,
+    y: anchor.y,
+    w: PANEL_WIDTH,
+    positionAbove: anchor.positionAbove,
+  }
+
+  const handleOpen = useCallback(
+    (event: MouseEvent<HTMLButtonElement>) => {
+      event.stopPropagation()
+      setHighlightedValue(value)
+      setOpen((current) => !current)
+    },
+    [value],
+  )
+
+  const handleClose = useCallback(() => setOpen(false), [])
+
+  const handleSelect = useCallback(
+    (next: string) => {
+      onSelect(next)
+      setOpen(false)
+    },
+    [onSelect],
+  )
+
+  const handlePointerLeave = useCallback(
+    () => setHighlightedValue(value),
+    [value],
+  )
+
+  return {
+    buttonProps: {
+      ref: buttonRef,
+      type: "button",
+      "aria-haspopup": "listbox",
+      "aria-expanded": open,
+      onClick: handleOpen,
+      style: TRIGGER_STYLE,
+    },
+    listbox: {
+      open,
+      position,
+      handleClose,
+      onPointerLeave: handlePointerLeave,
+      filteredOptions: optionGroups,
+      hasSections: true,
+      value,
+      highlightedValue,
+      resolveIcon,
+      onSelect: handleSelect,
+      onHighlight: setHighlightedValue,
+    },
+  }
+}

--- a/packages/editor/app/sidebars/objects/hooks/use-row-node-actions.ts
+++ b/packages/editor/app/sidebars/objects/hooks/use-row-node-actions.ts
@@ -19,11 +19,11 @@ import {
   typeCheckingService,
 } from "@seldon/core/workspace/services"
 import type { EntryNode } from "@seldon/core/workspace/types"
-import { getNodeCatalogComponentId } from "@lib/workspace/node-tree"
-import { hasNode } from "@lib/workspace/workspace-accessors"
 import { usePropertiesClipboard } from "@lib/workspace/hooks/use-properties-clipboard"
 import { useSelectionActions } from "@lib/workspace/hooks/use-selection"
 import { useWorkspace } from "@lib/workspace/hooks/use-workspace"
+import { getNodeCatalogComponentId } from "@lib/workspace/node-tree"
+import { hasNode } from "@lib/workspace/workspace-accessors"
 import { useAddToast } from "@app/toaster/hooks/use-add-toast"
 
 type Workspace = ReturnType<typeof useWorkspace>["workspace"]

--- a/packages/editor/app/sidebars/objects/hooks/use-row-node-actions.ts
+++ b/packages/editor/app/sidebars/objects/hooks/use-row-node-actions.ts
@@ -1,0 +1,395 @@
+import {
+  buildDefaultSnippet,
+  buildVariantSnippet,
+} from "@lib/copy-schema/build-schema-snippet"
+import { serializeSchemaSnippet } from "@lib/copy-schema/serialize-schema-ts"
+import { MenuEntry } from "@lib/menus"
+import { buildResetMenuEntry } from "@lib/menus/build-reset-menu-entry"
+import { InstanceId, VariantId } from "@seldon/core"
+import { getComponentSchema } from "@seldon/core/components/catalog"
+import { isComponentId } from "@seldon/core/components/constants"
+import { componentBoardSchemaVariantNodeId } from "@seldon/core/workspace/helpers/components/entry-node-ids"
+import { isVariantInUse } from "@seldon/core/workspace/helpers/general/is-variant-in-use"
+import { isSandboxNode } from "@seldon/core/workspace/helpers/nodes/sandbox"
+import {
+  nodeRelationshipService,
+  nodeRetrievalService,
+  resolveOriginalNodeId,
+  resolveSourceNodeId,
+  typeCheckingService,
+} from "@seldon/core/workspace/services"
+import type { EntryNode } from "@seldon/core/workspace/types"
+import { getNodeCatalogComponentId } from "@lib/workspace/node-tree"
+import { hasNode } from "@lib/workspace/workspace-accessors"
+import { usePropertiesClipboard } from "@lib/workspace/hooks/use-properties-clipboard"
+import { useSelectionActions } from "@lib/workspace/hooks/use-selection"
+import { useWorkspace } from "@lib/workspace/hooks/use-workspace"
+import { useAddToast } from "@app/toaster/hooks/use-add-toast"
+
+type Workspace = ReturnType<typeof useWorkspace>["workspace"]
+type Dispatch = ReturnType<typeof useWorkspace>["dispatch"]
+
+interface RowNodeActionsInput {
+  node: EntryNode
+  workspace: Workspace
+  dispatch: Dispatch
+  isSelected: boolean
+  isEcho: boolean
+}
+
+/**
+ * Builds the objects-sidebar row actions menu for a node. The menu adapts to the
+ * node's entity type and only fills out for the selected row; unselected rows and
+ * echo rows return an empty menu. Reset entries depend on how the node resolves
+ * through its template chain, so the enabled targets are computed here too.
+ */
+export function useRowNodeActions({
+  node,
+  workspace,
+  dispatch,
+  isSelected,
+  isEcho,
+}: RowNodeActionsInput): MenuEntry[] {
+  const addToast = useAddToast()
+  const { selectNode } = useSelectionActions()
+  const hasClipboardProperties = usePropertiesClipboard(
+    (state) => state.properties !== null,
+  )
+
+  const nodeExistsInWorkspace = hasNode(workspace, node.id)
+  const catalogComponentId = nodeExistsInWorkspace
+    ? getNodeCatalogComponentId(node, workspace)
+    : null
+
+  // A schema-backed user variant has a catalog template in the component schema:
+  // its root id matches a schema variant id. Only those reset to catalog. A user
+  // variant a person built from scratch has no catalog variant to reset to.
+  const isSchemaBackedVariant =
+    typeCheckingService.isUserVariant(node) &&
+    !!catalogComponentId &&
+    isComponentId(catalogComponentId) &&
+    (getComponentSchema(catalogComponentId).variants ?? []).some(
+      (variant) =>
+        componentBoardSchemaVariantNodeId(catalogComponentId, variant.id) ===
+        node.id,
+    )
+
+  // Instance resets walk the template chain. Source is the node one hop up;
+  // Original is the chain terminal. Disable a target that does not resolve to a
+  // different node, and drop Original when it matches Source.
+  const isInstanceNode =
+    nodeExistsInWorkspace && typeCheckingService.isInstance(node)
+  const instanceSourceId = isInstanceNode
+    ? resolveSourceNodeId(workspace, node.id)
+    : null
+  const instanceOriginalId = isInstanceNode
+    ? resolveOriginalNodeId(workspace, node.id)
+    : null
+  const canResetToSource = !!instanceSourceId && instanceSourceId !== node.id
+  const canResetToOriginal =
+    !!instanceOriginalId &&
+    instanceOriginalId !== node.id &&
+    instanceOriginalId !== instanceSourceId
+
+  // A user variant can reset its instances when at least one instance links
+  // straight to it as its source. Enables the "Reset Instances" action.
+  const canResetVariantInstances =
+    nodeExistsInWorkspace &&
+    typeCheckingService.isUserVariant(node) &&
+    Object.values(workspace.nodes).some(
+      (candidate) =>
+        typeCheckingService.isInstance(candidate) &&
+        resolveSourceNodeId(workspace, candidate.id) === node.id,
+    )
+
+  function handleResetDefaultVariantToCatalog() {
+    dispatch({
+      type: "reset_default_variant_to_catalog",
+      payload: { defaultVariantRootId: node.id as VariantId },
+    })
+  }
+
+  function handleResetVariantToCatalog() {
+    dispatch({
+      type: "reset_variant_to_catalog",
+      payload: { variantRootId: node.id as VariantId },
+    })
+  }
+
+  function handleResetVariantInstances() {
+    dispatch({
+      type: "reset_variant_instances",
+      payload: { variantRootId: node.id as VariantId },
+    })
+  }
+
+  function handleResetInstanceToSource() {
+    dispatch({
+      type: "reset_instance_to_source",
+      payload: { instanceId: node.id as InstanceId },
+    })
+  }
+
+  function handleResetInstanceToOriginal() {
+    dispatch({
+      type: "reset_instance_to_original",
+      payload: { instanceId: node.id as InstanceId },
+    })
+  }
+
+  // The default variant always resets to its catalog schema. A custom variant
+  // resets to its schema variant, disabled when it has no catalog template.
+  function buildVariantResetAction(): MenuEntry {
+    if (typeCheckingService.isDefaultVariant(node)) {
+      return buildResetMenuEntry({
+        id: "reset-to-catalog",
+        label: "Reset to Catalog",
+        onSelect: handleResetDefaultVariantToCatalog,
+        testId: `object-panel-node-${node.id}-reset-to-catalog`,
+      })
+    }
+    return buildResetMenuEntry({
+      id: "reset-to-catalog",
+      label: "Reset to Catalog",
+      onSelect: handleResetVariantToCatalog,
+      disabled: !isSchemaBackedVariant,
+      testId: `object-panel-node-${node.id}-reset-to-catalog`,
+    })
+  }
+
+  function buildInstanceResetActions(): MenuEntry[] {
+    return [
+      buildResetMenuEntry({
+        id: "reset-to-source",
+        label: "Reset to Source",
+        onSelect: handleResetInstanceToSource,
+        disabled: !canResetToSource,
+        testId: `object-panel-node-${node.id}-reset-to-source`,
+      }),
+      buildResetMenuEntry({
+        id: "reset-to-original",
+        label: "Reset to Original",
+        onSelect: handleResetInstanceToOriginal,
+        disabled: !canResetToOriginal,
+        testId: `object-panel-node-${node.id}-reset-to-original`,
+      }),
+    ]
+  }
+
+  function handleDuplicate() {
+    dispatch({
+      type: "duplicate_node",
+      payload: { nodeId: node.id as VariantId },
+    })
+  }
+
+  async function handleCopyJson() {
+    if (typeCheckingService.isInstance(node)) {
+      addToast("Nested children cannot be copied as schema JSON")
+      return
+    }
+    const snippet = typeCheckingService.isDefaultVariant(node)
+      ? buildDefaultSnippet(node, workspace)
+      : buildVariantSnippet(node, workspace)
+    if (!snippet) {
+      addToast("Could not resolve a catalog component for the selection")
+      return
+    }
+    await navigator.clipboard.writeText(serializeSchemaSnippet(snippet))
+    addToast("Schema JSON copied to clipboard")
+  }
+
+  function handleCopyProperties() {
+    usePropertiesClipboard
+      .getState()
+      .setProperties(structuredClone(node.overrides))
+    addToast("Properties copied")
+  }
+
+  function handlePasteProperties() {
+    const clipboard = usePropertiesClipboard.getState().properties
+    if (!clipboard) {
+      addToast("No properties to paste")
+      return
+    }
+    dispatch({
+      type: "set_node_properties",
+      payload: {
+        nodeId: node.id as VariantId,
+        properties: clipboard,
+        options: { mergeSubProperties: true },
+      },
+    })
+  }
+
+  function handleDelete() {
+    const isVariant = typeCheckingService.isVariant(node)
+    if (isVariant && isVariantInUse(node.id, workspace)) {
+      const confirmed = window.confirm(
+        "This variant is used in other components. Deleting it will also remove it from those components. Delete anyway?",
+      )
+      if (!confirmed) return
+    }
+    const subject = nodeRetrievalService.getNode(node.id, workspace)
+    const adjacentId =
+      nodeRelationshipService.findAdjacent(subject, "before", workspace)?.id ??
+      nodeRelationshipService.findAdjacent(subject, "after", workspace)?.id ??
+      null
+    if (isVariant) {
+      dispatch({
+        type: "remove_variant",
+        payload: { variantRootId: node.id as VariantId },
+      })
+    } else {
+      dispatch({
+        type: "remove_instance",
+        payload: { instanceId: node.id as InstanceId },
+      })
+    }
+    selectNode(adjacentId as VariantId | InstanceId | null)
+  }
+
+  function buildNodeActions(): MenuEntry[] {
+    const isDefault = typeCheckingService.isDefaultVariant(node)
+    const isUser = typeCheckingService.isUserVariant(node)
+    const isInstance = typeCheckingService.isInstance(node)
+    const isAuthored = typeCheckingService.isAuthored(node)
+
+    // Sandbox roots have no catalog default and are not exported, so they skip
+    // Copy JSON and Reset. Their child instances keep the standard menus below.
+    if (isSelected && isSandboxNode(node)) {
+      return [
+        {
+          id: "duplicate",
+          label: `Duplicate ${node.label}`,
+          onSelect: handleDuplicate,
+          testId: `object-panel-node-${node.id}-duplicate`,
+        },
+        "separator",
+        {
+          id: "copy-properties",
+          label: "Copy Properties",
+          onSelect: handleCopyProperties,
+          testId: `object-panel-node-${node.id}-copy-properties`,
+        },
+        {
+          id: "paste-properties",
+          label: "Paste Properties",
+          onSelect: handlePasteProperties,
+          disabled: !hasClipboardProperties,
+          testId: `object-panel-node-${node.id}-paste-properties`,
+        },
+        "separator",
+        {
+          id: "delete",
+          label: `Delete ${node.label}`,
+          onSelect: handleDelete,
+          testId: `object-panel-node-${node.id}-delete`,
+        },
+      ]
+    }
+
+    // Selected instance (child) rows get the variant menu minus "Copy JSON",
+    // which only applies to default and user variant rows.
+    if (isSelected && isInstance) {
+      return [
+        {
+          id: "duplicate",
+          label: `Duplicate ${node.label}`,
+          onSelect: handleDuplicate,
+          testId: `object-panel-node-${node.id}-duplicate`,
+        },
+        "separator",
+        {
+          id: "copy-properties",
+          label: "Copy Properties",
+          onSelect: handleCopyProperties,
+          testId: `object-panel-node-${node.id}-copy-properties`,
+        },
+        {
+          id: "paste-properties",
+          label: "Paste Properties",
+          onSelect: handlePasteProperties,
+          disabled: !hasClipboardProperties,
+          testId: `object-panel-node-${node.id}-paste-properties`,
+        },
+        "separator",
+        {
+          id: "delete",
+          label: `Delete ${node.label}`,
+          onSelect: handleDelete,
+          testId: `object-panel-node-${node.id}-delete`,
+        },
+        ...buildInstanceResetActions(),
+      ]
+    }
+
+    // Only the selected default, user, or authored variant row gets the full
+    // action menu. Unselected rows keep the reset-only menu below.
+    if (isSelected && (isDefault || isUser || isAuthored)) {
+      const entries: MenuEntry[] = [
+        {
+          id: "duplicate",
+          label: isDefault
+            ? `Duplicate ${node.label} Default`
+            : `Duplicate ${node.label}`,
+          onSelect: handleDuplicate,
+          testId: `object-panel-node-${node.id}-duplicate`,
+        },
+        "separator",
+        {
+          id: "copy-json",
+          label: "Copy JSON",
+          onSelect: handleCopyJson,
+          testId: `object-panel-node-${node.id}-copy-json`,
+        },
+        "separator",
+        {
+          id: "copy-properties",
+          label: "Copy Properties",
+          onSelect: handleCopyProperties,
+          testId: `object-panel-node-${node.id}-copy-properties`,
+        },
+        {
+          id: "paste-properties",
+          label: "Paste Properties",
+          onSelect: handlePasteProperties,
+          disabled: !hasClipboardProperties,
+          testId: `object-panel-node-${node.id}-paste-properties`,
+        },
+        "separator",
+      ]
+
+      if (isUser) {
+        entries.push({
+          id: "delete",
+          label: `Delete ${node.label}`,
+          onSelect: handleDelete,
+          testId: `object-panel-node-${node.id}-delete`,
+        })
+      }
+
+      if (isUser) {
+        entries.push(
+          buildResetMenuEntry({
+            id: "reset-variant-instances",
+            label: "Reset Instances",
+            onSelect: handleResetVariantInstances,
+            disabled: !canResetVariantInstances,
+            testId: `object-panel-node-${node.id}-reset-instances`,
+          }),
+        )
+      }
+
+      // Authored roots are schema-free, so reset-to-catalog does not apply.
+      if (!isAuthored) {
+        entries.push(buildVariantResetAction())
+      }
+      return entries
+    }
+
+    return []
+  }
+
+  return isEcho ? [] : buildNodeActions()
+}

--- a/packages/editor/app/sidebars/objects/hooks/use-row-node-display.ts
+++ b/packages/editor/app/sidebars/objects/hooks/use-row-node-display.ts
@@ -1,5 +1,5 @@
-import { CSSProperties } from "react"
 import { ComboboxOptionItem, OptionIconRender } from "@lib/menus"
+import { CSSProperties } from "react"
 import { Display, Properties, Value, ValueType, VariantId } from "@seldon/core"
 import {
   PROPERTY_ICONS,

--- a/packages/editor/app/sidebars/objects/hooks/use-row-node-display.ts
+++ b/packages/editor/app/sidebars/objects/hooks/use-row-node-display.ts
@@ -1,0 +1,212 @@
+import { CSSProperties } from "react"
+import { ComboboxOptionItem, OptionIconRender } from "@lib/menus"
+import { Display, Properties, Value, ValueType, VariantId } from "@seldon/core"
+import {
+  PROPERTY_ICONS,
+  PROPERTY_OPTION_ICONS,
+} from "@seldon/core/properties/schemas/data/property-icons"
+import { getNodeProperties } from "@seldon/core/workspace/helpers/nodes/get-node-properties"
+import {
+  nodeTraversalService,
+  typeCheckingService,
+} from "@seldon/core/workspace/services"
+import type { EntryNode } from "@seldon/core/workspace/types"
+import { useWorkspace } from "@lib/workspace/hooks/use-workspace"
+import { IconProps } from "@seldon/components/primitives/Icon"
+import { resolveRowDisplayDecoration } from "./row-display-style"
+
+type Workspace = ReturnType<typeof useWorkspace>["workspace"]
+type Dispatch = ReturnType<typeof useWorkspace>["dispatch"]
+
+// Neutral Display glyph for the row picker trigger and the Default/Inherit
+// options, matching the properties Display control's property icon.
+const DISPLAY_NEUTRAL_ICON: string = PROPERTY_ICONS.display
+
+interface RowNodeDisplayInput {
+  node: EntryNode
+  workspace: Workspace
+  dispatch: Dispatch
+  properties: Properties
+  nodeExistsInWorkspace: boolean
+  isEcho: boolean
+}
+
+interface RowNodeDisplay {
+  /** Option groups for the row's `ComboboxListbox` Display picker. */
+  displayOptionGroups: ComboboxOptionItem[][]
+  /** Current picker value key: "default", "inherit", or a `Display` state. */
+  displayValue: string
+  /** Applies a picker value, clearing or storing the `display` override. */
+  selectDisplay: (value: string) => void
+  /** Resolves the Material glyph for a picker option. */
+  resolveDisplayOptionIcon: (option?: {
+    value: string
+    name: string
+  }) => OptionIconRender
+  /** Trigger glyph for the row's Display button. */
+  displayIcon: IconProps
+  /** Row reads as disabled/gray (hide/stub/mock/exclude in the ancestor chain). */
+  isDimmed: boolean
+  /** Faded appearance for mock/exclude rows, applied to icon and label leaves. */
+  dimStyle?: CSSProperties
+  /** Italic label decoration for stub/exclude rows. */
+  labelDecorationStyle?: CSSProperties
+}
+
+/**
+ * Row Display model for a node: the picker options and selection handler, the
+ * trigger glyph, and the row's dim/italic decoration composed across the node's
+ * instance-ancestor chain. The picker mirrors the properties Display control, so
+ * both surfaces read and write the same `display` override.
+ */
+export function useRowNodeDisplay({
+  node,
+  workspace,
+  dispatch,
+  properties,
+  nodeExistsInWorkspace,
+  isEcho,
+}: RowNodeDisplayInput): RowNodeDisplay {
+  const ownDisplayValue = properties?.display
+  // `display` also stores an inherit value at runtime, which its narrow
+  // `DisplayValue` type does not model, so read the tag as a plain string.
+  const ownDisplayType: string | undefined = ownDisplayValue?.type
+  const currentDisplayKey =
+    !ownDisplayValue || ownDisplayType === ValueType.EMPTY
+      ? "default"
+      : ownDisplayType === ValueType.INHERIT
+        ? "inherit"
+        : String(ownDisplayValue.value)
+
+  function setDisplay(value: Value) {
+    dispatch({
+      type: "set_node_properties",
+      payload: {
+        nodeId: node.id as VariantId,
+        properties: { display: value } as Properties,
+      },
+    })
+  }
+
+  function resetDisplay() {
+    dispatch({
+      type: "reset_node_property",
+      payload: { nodeId: node.id as VariantId, propertyKey: "display" },
+    })
+  }
+
+  // Selecting a display value from the row's picker. "default" clears the
+  // override, "inherit" stores an inherit value, and every other value stores
+  // the matching option. Mirrors the Display control in the properties sidebar.
+  function selectDisplay(value: string) {
+    if (value === "default") {
+      resetDisplay()
+    } else if (value === "inherit") {
+      setDisplay({ type: ValueType.INHERIT, value: null })
+    } else {
+      setDisplay({ type: ValueType.OPTION, value: value as Display })
+    }
+  }
+
+  // The row Display picker reuses the same floating `ComboboxListbox` as the
+  // properties Display control. Two sections: Default/Inherit, then the concrete
+  // states. Option values match `currentDisplayKey`.
+  const displayOptionGroups: ComboboxOptionItem[][] = isEcho
+    ? []
+    : [
+        [
+          { value: "default", name: "Default" },
+          { value: "inherit", name: "Inherit" },
+        ],
+        [
+          { value: Display.SHOW, name: "Show" },
+          { value: Display.HIDE, name: "Hide" },
+          { value: Display.STUB, name: "Stub" },
+          { value: Display.MOCK, name: "Mock" },
+          { value: Display.EXCLUDE, name: "Exclude" },
+        ],
+      ]
+
+  // Trigger glyph and every option glyph resolve to a Material icon from the
+  // shared property-icon catalog. Default and Inherit use the neutral display
+  // icon, so the trigger never swaps icon families (and apparent size) between
+  // states, matching the properties Display control.
+  function resolveDisplayGlyph(key: string): string {
+    if (key === "default" || key === "inherit") {
+      return DISPLAY_NEUTRAL_ICON
+    }
+    return PROPERTY_OPTION_ICONS.display[key] ?? DISPLAY_NEUTRAL_ICON
+  }
+
+  function resolveDisplayOptionIcon(option?: {
+    value: string
+    name: string
+  }): OptionIconRender {
+    return {
+      kind: "iconId",
+      icon: resolveDisplayGlyph(option?.value ?? "default"),
+    }
+  }
+
+  const displayIcon: IconProps = {
+    icon: resolveDisplayGlyph(currentDisplayKey) as IconProps["icon"],
+  }
+
+  // Collects the node's own display plus every display inherited from its
+  // instance-ancestor chain. The walk climbs while each parent is an instance
+  // and includes the first non-instance parent, so a variant root's state still
+  // reaches its instance children. Non-instance rows reflect only their own
+  // display.
+  function collectDisplayChainStates(): Display[] {
+    if (!nodeExistsInWorkspace) {
+      return []
+    }
+
+    const states: Display[] = []
+    const ownDisplay = properties?.display?.value
+    if (ownDisplay) states.push(ownDisplay)
+
+    if (!typeCheckingService.isInstance(node)) {
+      return states
+    }
+
+    let currentParent = nodeTraversalService.findParentNode(node.id, workspace)
+    while (currentParent) {
+      const parentDisplay = getNodeProperties(
+        currentParent as EntryNode,
+        workspace,
+      )?.display?.value
+      if (parentDisplay) states.push(parentDisplay)
+      if (typeCheckingService.isInstance(currentParent)) {
+        currentParent = nodeTraversalService.findParentNode(
+          currentParent.id,
+          workspace,
+        )
+      } else {
+        break
+      }
+    }
+
+    return states
+  }
+
+  // Row notation for the node's display, composed across its ancestor chain:
+  // dimmed for hide/stub/mock/exclude, italic for stub/exclude. Faded rows drop
+  // the gray to a lower opacity. See `resolveRowDisplayDecoration`.
+  const {
+    isDimmed,
+    dimStyle,
+    labelStyle: labelDecorationStyle,
+  } = resolveRowDisplayDecoration(collectDisplayChainStates())
+
+  return {
+    displayOptionGroups,
+    displayValue: currentDisplayKey,
+    selectDisplay,
+    resolveDisplayOptionIcon,
+    displayIcon,
+    isDimmed,
+    dimStyle,
+    labelDecorationStyle,
+  }
+}

--- a/packages/editor/app/sidebars/objects/hooks/use-row-node.ts
+++ b/packages/editor/app/sidebars/objects/hooks/use-row-node.ts
@@ -1,45 +1,9 @@
-import {
-  buildDefaultSnippet,
-  buildVariantSnippet,
-} from "@lib/copy-schema/build-schema-snippet"
-import { serializeSchemaSnippet } from "@lib/copy-schema/serialize-schema-ts"
-import { removeNewLines } from "@lib/helpers/new-lines"
-import { ComboboxOptionItem, MenuEntry, OptionIconRender } from "@lib/menus"
-import { buildResetMenuEntry } from "@lib/menus/build-reset-menu-entry"
-import { getComponentName } from "@seldon/factory/export/react/discovery/get-component-name"
-import { CSSProperties } from "react"
-import {
-  Display,
-  InstanceId,
-  Properties,
-  Value,
-  ValueType,
-  VariantId,
-} from "@seldon/core"
-import {
-  PROPERTY_ICONS,
-  PROPERTY_OPTION_ICONS,
-} from "@seldon/core/properties/schemas/data/property-icons"
-import { getComponentSchema } from "@seldon/core/components/catalog"
-import { ComponentId, isComponentId } from "@seldon/core/components/constants"
-import { isEmptyValue } from "@seldon/core/helpers/type-guards/value/is-empty-value"
-import { IconId, iconLabels } from "@seldon/core/icon-sets"
+import { Properties, VariantId } from "@seldon/core"
 import { rules } from "@seldon/core/rules/config/rules.config"
 import { isDuplicateVariantLabel } from "@seldon/core/workspace/helpers/components/duplicate-variant-labels"
-import { componentBoardSchemaVariantNodeId } from "@seldon/core/workspace/helpers/components/entry-node-ids"
-import { isVariantInUse } from "@seldon/core/workspace/helpers/general/is-variant-in-use"
 import { getNodeProperties } from "@seldon/core/workspace/helpers/nodes/get-node-properties"
-import { isSandboxNode } from "@seldon/core/workspace/helpers/nodes/sandbox"
-import {
-  nodeRelationshipService,
-  nodeRetrievalService,
-  nodeTraversalService,
-  resolveOriginalNodeId,
-  resolveSourceNodeId,
-  typeCheckingService,
-} from "@seldon/core/workspace/services"
+import { typeCheckingService } from "@seldon/core/workspace/services"
 import type { EntryNode } from "@seldon/core/workspace/types"
-import { usePropertiesClipboard } from "@lib/workspace/hooks/use-properties-clipboard"
 import {
   useSelectionActions,
   useStore as useSelectionStore,
@@ -49,10 +13,7 @@ import { useDebugMode } from "@lib/hooks/use-debug-mode"
 import { useEditorConfig } from "@lib/hooks/use-editor-config"
 import { useTool } from "@lib/hooks/use-tool"
 import { useSharedNodeHighlight } from "../../../tracking/hooks/use-shared-node-highlight"
-import {
-  getNodeCatalogComponentId,
-  getNodeChildIds,
-} from "@lib/workspace/node-tree"
+import { getNodeChildIds } from "@lib/workspace/node-tree"
 import {
   getSelectionTarget,
   selectFromTarget,
@@ -64,22 +25,27 @@ import { useAddToast } from "@app/toaster/hooks/use-add-toast"
 import { useDraggable } from "./use-draggable"
 import { useEditState } from "./use-edit-state"
 import { useExpansion, useIsExpanded } from "./use-expansion"
-import { resolveRowDisplayDecoration } from "./row-display-style"
+import {
+  getComponentTypeIcon,
+  getNodeLabel,
+  getNodeTypeColor,
+} from "./row-node-label"
 import { useRowButton } from "./use-row-button"
 import { useRowClick } from "./use-row-click"
+import { useRowNodeActions } from "./use-row-node-actions"
+import { useRowNodeDisplay } from "./use-row-node-display"
 import { useRowToggle } from "./use-row-toggle"
 import {
   useIsAncestorOfSelection,
   useIsParentOfSelection,
 } from "./use-selection-relations"
 
-// Neutral Display glyph for the row picker trigger and the Default/Inherit
-// options, matching the properties Display control's property icon.
-const DISPLAY_NEUTRAL_ICON: string = PROPERTY_ICONS.display
-
 /**
- * Hook that provides all state and handlers for rendering a node row in the objects sidebar.
- * Children come from the board variant tree via `getNodeChildIds` (1:1 with saved JSON).
+ * Assembles the view model for a node row in the objects sidebar: selection and
+ * lineage state, drag/click/toggle wiring, the row label, the actions menu, and
+ * the Display picker. Children come from the board variant tree via
+ * `getNodeChildIds` (1:1 with saved JSON). The heavier concerns live in
+ * `useRowNodeActions`, `useRowNodeDisplay`, and the `row-node-label` helpers.
  */
 export function useRowNode(
   node: EntryNode,
@@ -90,8 +56,8 @@ export function useRowNode(
     disableReordering?: boolean
     /**
      * Render this row as a repeat echo: a stripped leaf (no chevron, no child
-     * rows, no actions) with an italic label. Selection still routes to the
-     * underlying node, which is index 0 of the repeat.
+     * rows, no actions). Selection still routes to the underlying node, which is
+     * index 0 of the repeat.
      */
     isEcho?: boolean
   },
@@ -103,9 +69,6 @@ export function useRowNode(
   const { showNodeIds, showNodeTypes } = useDebugMode()
   const { showCodeNames } = useEditorConfig()
   const addToast = useAddToast()
-  const hasClipboardProperties = usePropertiesClipboard(
-    (state) => state.properties !== null,
-  )
 
   const { toggle, expandObjects, collapseObjects, getAllDescendantNodeIds } =
     useExpansion()
@@ -216,549 +179,48 @@ export function useRowNode(
     }
   }
 
-  function getNodeLabel() {
-    if (showNodeIds) {
-      return `${node.id} | ${node.template}`
-    }
-
-    // Show Code Names swaps the friendly label for the export component name,
-    // e.g. a "Simple" Button variant reads "ButtonSimple". Display only; the
-    // node label and rename behavior are unchanged.
-    if (showCodeNames && nodeExistsInWorkspace) {
-      return getComponentName(node, workspace)
-    }
-
-    if (
-      typeCheckingService.isInstance(node) &&
-      properties?.content &&
-      !isEmptyValue(properties.content)
-    ) {
-      return removeNewLines(properties.content.value)
-    }
-
-    if (
-      typeCheckingService.isInstance(node) &&
-      properties?.symbol &&
-      !isEmptyValue(properties.symbol) &&
-      iconLabels[properties.symbol.value as IconId]
-    ) {
-      return iconLabels[properties.symbol.value as IconId] + " icon"
-    }
-
-    return node.label
-  }
-
   const icon = createToggleIcon()
   const buttonIconic = createToggleButton()
+  const icon2: IconProps = { icon: getComponentTypeIcon(node) }
 
-  const getComponentTypeIcon = (): IconProps["icon"] => {
-    if (typeCheckingService.isVariant(node)) {
-      if (typeCheckingService.isDefaultVariant(node)) {
-        return "seldon-componentDefault"
-      }
-      if (typeCheckingService.isUserVariant(node)) {
-        return "seldon-componentVariant"
-      }
-    }
-    return "seldon-stub"
-  }
-
-  const icon2: IconProps = {
-    icon: getComponentTypeIcon(),
-  }
-
-  // Show Node Types debug mode tints the row's icon and label by node type:
-  // user variants use the Punch swatch and instances a lighter tint. Boards and
-  // default variants keep the default color. NodeController applies this onto the icon
-  // and label refs only, so borders, buttons, and the disclosure arrow are
+  // Show Node Types debug tint by node type. NodeController applies it onto the
+  // icon and label refs only, so borders, buttons, and the disclosure arrow are
   // unaffected.
-  function getNodeTypeColor(): string | undefined {
-    if (!showNodeTypes) return undefined
-    if (typeCheckingService.isInstance(node)) {
-      return "color-mix(in srgb, var(--sdn-swatch-punch) 80%, var(--sdn-swatch-white))"
-    }
-    if (typeCheckingService.isUserVariant(node)) {
-      return "var(--sdn-swatch-punch)"
-    }
-    return undefined
-  }
-  const nodeTypeColor = getNodeTypeColor()
+  const nodeTypeColor = getNodeTypeColor(node, showNodeTypes)
 
-  const catalogComponentId = nodeExistsInWorkspace
-    ? getNodeCatalogComponentId(node, workspace)
-    : null
+  const actions = useRowNodeActions({
+    node,
+    workspace,
+    dispatch,
+    isSelected,
+    isEcho,
+  })
 
-  // A schema-backed user variant has a catalog template in the component schema:
-  // its root id matches a schema variant id. Only those reset to catalog. A user
-  // variant a person built from scratch has no catalog variant to reset to.
-  const isSchemaBackedVariant =
-    typeCheckingService.isUserVariant(node) &&
-    !!catalogComponentId &&
-    isComponentId(catalogComponentId) &&
-    (getComponentSchema(catalogComponentId).variants ?? []).some(
-      (variant) =>
-        componentBoardSchemaVariantNodeId(catalogComponentId, variant.id) ===
-        node.id,
-    )
-
-  // Instance resets walk the template chain. Source is the node one hop up;
-  // Original is the chain terminal. Disable a target that does not resolve to a
-  // different node, and drop Original when it matches Source.
-  const isInstanceNode =
-    nodeExistsInWorkspace && typeCheckingService.isInstance(node)
-  const instanceSourceId = isInstanceNode
-    ? resolveSourceNodeId(workspace, node.id)
-    : null
-  const instanceOriginalId = isInstanceNode
-    ? resolveOriginalNodeId(workspace, node.id)
-    : null
-  const canResetToSource = !!instanceSourceId && instanceSourceId !== node.id
-  const canResetToOriginal =
-    !!instanceOriginalId &&
-    instanceOriginalId !== node.id &&
-    instanceOriginalId !== instanceSourceId
-
-  // A user variant can reset its instances when at least one instance links
-  // straight to it as its source. Enables the "Reset Instances" action.
-  const canResetVariantInstances =
-    nodeExistsInWorkspace &&
-    typeCheckingService.isUserVariant(node) &&
-    Object.values(workspace.nodes).some(
-      (candidate) =>
-        typeCheckingService.isInstance(candidate) &&
-        resolveSourceNodeId(workspace, candidate.id) === node.id,
-    )
-
-  function handleResetDefaultVariantToCatalog() {
-    dispatch({
-      type: "reset_default_variant_to_catalog",
-      payload: { defaultVariantRootId: node.id as VariantId },
-    })
-  }
-
-  function handleResetVariantToCatalog() {
-    dispatch({
-      type: "reset_variant_to_catalog",
-      payload: { variantRootId: node.id as VariantId },
-    })
-  }
-
-  function handleResetVariantInstances() {
-    dispatch({
-      type: "reset_variant_instances",
-      payload: { variantRootId: node.id as VariantId },
-    })
-  }
-
-  function handleResetInstanceToSource() {
-    dispatch({
-      type: "reset_instance_to_source",
-      payload: { instanceId: node.id as InstanceId },
-    })
-  }
-
-  function handleResetInstanceToOriginal() {
-    dispatch({
-      type: "reset_instance_to_original",
-      payload: { instanceId: node.id as InstanceId },
-    })
-  }
-
-  // The default variant always resets to its catalog schema. A custom variant
-  // resets to its schema variant, disabled when it has no catalog template.
-  function buildVariantResetAction(): MenuEntry {
-    if (typeCheckingService.isDefaultVariant(node)) {
-      return buildResetMenuEntry({
-        id: "reset-to-catalog",
-        label: "Reset to Catalog",
-        onSelect: handleResetDefaultVariantToCatalog,
-        testId: `object-panel-node-${node.id}-reset-to-catalog`,
-      })
-    }
-    return buildResetMenuEntry({
-      id: "reset-to-catalog",
-      label: "Reset to Catalog",
-      onSelect: handleResetVariantToCatalog,
-      disabled: !isSchemaBackedVariant,
-      testId: `object-panel-node-${node.id}-reset-to-catalog`,
-    })
-  }
-
-  function buildInstanceResetActions(): MenuEntry[] {
-    return [
-      buildResetMenuEntry({
-        id: "reset-to-source",
-        label: "Reset to Source",
-        onSelect: handleResetInstanceToSource,
-        disabled: !canResetToSource,
-        testId: `object-panel-node-${node.id}-reset-to-source`,
-      }),
-      buildResetMenuEntry({
-        id: "reset-to-original",
-        label: "Reset to Original",
-        onSelect: handleResetInstanceToOriginal,
-        disabled: !canResetToOriginal,
-        testId: `object-panel-node-${node.id}-reset-to-original`,
-      }),
-    ]
-  }
-
-  function handleDuplicate() {
-    dispatch({
-      type: "duplicate_node",
-      payload: { nodeId: node.id as VariantId },
-    })
-  }
-
-  async function handleCopyJson() {
-    if (typeCheckingService.isInstance(node)) {
-      addToast("Nested children cannot be copied as schema JSON")
-      return
-    }
-    const snippet = typeCheckingService.isDefaultVariant(node)
-      ? buildDefaultSnippet(node, workspace)
-      : buildVariantSnippet(node, workspace)
-    if (!snippet) {
-      addToast("Could not resolve a catalog component for the selection")
-      return
-    }
-    await navigator.clipboard.writeText(serializeSchemaSnippet(snippet))
-    addToast("Schema JSON copied to clipboard")
-  }
-
-  function handleCopyProperties() {
-    usePropertiesClipboard
-      .getState()
-      .setProperties(structuredClone(node.overrides))
-    addToast("Properties copied")
-  }
-
-  function handlePasteProperties() {
-    const clipboard = usePropertiesClipboard.getState().properties
-    if (!clipboard) {
-      addToast("No properties to paste")
-      return
-    }
-    dispatch({
-      type: "set_node_properties",
-      payload: {
-        nodeId: node.id as VariantId,
-        properties: clipboard,
-        options: { mergeSubProperties: true },
-      },
-    })
-  }
-
-  function handleDelete() {
-    const isVariant = typeCheckingService.isVariant(node)
-    if (isVariant && isVariantInUse(node.id, workspace)) {
-      const confirmed = window.confirm(
-        "This variant is used in other components. Deleting it will also remove it from those components. Delete anyway?",
-      )
-      if (!confirmed) return
-    }
-    const subject = nodeRetrievalService.getNode(node.id, workspace)
-    const adjacentId =
-      nodeRelationshipService.findAdjacent(subject, "before", workspace)?.id ??
-      nodeRelationshipService.findAdjacent(subject, "after", workspace)?.id ??
-      null
-    if (isVariant) {
-      dispatch({
-        type: "remove_variant",
-        payload: { variantRootId: node.id as VariantId },
-      })
-    } else {
-      dispatch({
-        type: "remove_instance",
-        payload: { instanceId: node.id as InstanceId },
-      })
-    }
-    selectNode(adjacentId as VariantId | InstanceId | null)
-  }
-
-  function buildNodeActions(): MenuEntry[] {
-    const isDefault = typeCheckingService.isDefaultVariant(node)
-    const isUser = typeCheckingService.isUserVariant(node)
-    const isInstance = typeCheckingService.isInstance(node)
-    const isAuthored = typeCheckingService.isAuthored(node)
-
-    // Sandbox roots have no catalog default and are not exported, so they skip
-    // Copy JSON and Reset. Their child instances keep the standard menus below.
-    if (isSelected && isSandboxNode(node)) {
-      return [
-        {
-          id: "duplicate",
-          label: `Duplicate ${node.label}`,
-          onSelect: handleDuplicate,
-          testId: `object-panel-node-${node.id}-duplicate`,
-        },
-        "separator",
-        {
-          id: "copy-properties",
-          label: "Copy Properties",
-          onSelect: handleCopyProperties,
-          testId: `object-panel-node-${node.id}-copy-properties`,
-        },
-        {
-          id: "paste-properties",
-          label: "Paste Properties",
-          onSelect: handlePasteProperties,
-          disabled: !hasClipboardProperties,
-          testId: `object-panel-node-${node.id}-paste-properties`,
-        },
-        "separator",
-        {
-          id: "delete",
-          label: `Delete ${node.label}`,
-          onSelect: handleDelete,
-          testId: `object-panel-node-${node.id}-delete`,
-        },
-      ]
-    }
-
-    // Selected instance (child) rows get the variant menu minus "Copy JSON",
-    // which only applies to default and user variant rows.
-    if (isSelected && isInstance) {
-      return [
-        {
-          id: "duplicate",
-          label: `Duplicate ${node.label}`,
-          onSelect: handleDuplicate,
-          testId: `object-panel-node-${node.id}-duplicate`,
-        },
-        "separator",
-        {
-          id: "copy-properties",
-          label: "Copy Properties",
-          onSelect: handleCopyProperties,
-          testId: `object-panel-node-${node.id}-copy-properties`,
-        },
-        {
-          id: "paste-properties",
-          label: "Paste Properties",
-          onSelect: handlePasteProperties,
-          disabled: !hasClipboardProperties,
-          testId: `object-panel-node-${node.id}-paste-properties`,
-        },
-        "separator",
-        {
-          id: "delete",
-          label: `Delete ${node.label}`,
-          onSelect: handleDelete,
-          testId: `object-panel-node-${node.id}-delete`,
-        },
-        ...buildInstanceResetActions(),
-      ]
-    }
-
-    // Only the selected default, user, or authored variant row gets the full
-    // action menu. Unselected rows keep the reset-only menu below.
-    if (isSelected && (isDefault || isUser || isAuthored)) {
-      const entries: MenuEntry[] = [
-        {
-          id: "duplicate",
-          label: isDefault
-            ? `Duplicate ${node.label} Default`
-            : `Duplicate ${node.label}`,
-          onSelect: handleDuplicate,
-          testId: `object-panel-node-${node.id}-duplicate`,
-        },
-        "separator",
-        {
-          id: "copy-json",
-          label: "Copy JSON",
-          onSelect: handleCopyJson,
-          testId: `object-panel-node-${node.id}-copy-json`,
-        },
-        "separator",
-        {
-          id: "copy-properties",
-          label: "Copy Properties",
-          onSelect: handleCopyProperties,
-          testId: `object-panel-node-${node.id}-copy-properties`,
-        },
-        {
-          id: "paste-properties",
-          label: "Paste Properties",
-          onSelect: handlePasteProperties,
-          disabled: !hasClipboardProperties,
-          testId: `object-panel-node-${node.id}-paste-properties`,
-        },
-        "separator",
-      ]
-
-      if (isUser) {
-        entries.push({
-          id: "delete",
-          label: `Delete ${node.label}`,
-          onSelect: handleDelete,
-          testId: `object-panel-node-${node.id}-delete`,
-        })
-      }
-
-      if (isUser) {
-        entries.push(
-          buildResetMenuEntry({
-            id: "reset-variant-instances",
-            label: "Reset Instances",
-            onSelect: handleResetVariantInstances,
-            disabled: !canResetVariantInstances,
-            testId: `object-panel-node-${node.id}-reset-instances`,
-          }),
-        )
-      }
-
-      // Authored roots are schema-free, so reset-to-catalog does not apply.
-      if (!isAuthored) {
-        entries.push(buildVariantResetAction())
-      }
-      return entries
-    }
-
-    return []
-  }
-
-  const actions: MenuEntry[] = isEcho ? [] : buildNodeActions()
-
-  const ownDisplayValue = properties?.display
-  // `display` also stores an inherit value at runtime, which its narrow
-  // `DisplayValue` type does not model, so read the tag as a plain string.
-  const ownDisplayType: string | undefined = ownDisplayValue?.type
-  const currentDisplayKey =
-    !ownDisplayValue || ownDisplayType === ValueType.EMPTY
-      ? "default"
-      : ownDisplayType === ValueType.INHERIT
-        ? "inherit"
-        : String(ownDisplayValue.value)
-
-  function setDisplay(value: Value) {
-    dispatch({
-      type: "set_node_properties",
-      payload: {
-        nodeId: node.id as VariantId,
-        properties: { display: value } as Properties,
-      },
-    })
-  }
-
-  function resetDisplay() {
-    dispatch({
-      type: "reset_node_property",
-      payload: { nodeId: node.id as VariantId, propertyKey: "display" },
-    })
-  }
-
-  // Selecting a display value from the row's picker. "default" clears the
-  // override, "inherit" stores an inherit value, and every other value stores
-  // the matching option. Mirrors the Display control in the properties sidebar.
-  function selectDisplay(value: string) {
-    if (value === "default") {
-      resetDisplay()
-    } else if (value === "inherit") {
-      setDisplay({ type: ValueType.INHERIT, value: null })
-    } else {
-      setDisplay({ type: ValueType.OPTION, value: value as Display })
-    }
-  }
-
-  // The row Display picker reuses the same floating `ComboboxListbox` as the
-  // properties Display control. Two sections: Default/Inherit, then the concrete
-  // states. Option values match `currentDisplayKey`.
-  const displayOptionGroups: ComboboxOptionItem[][] = isEcho
-    ? []
-    : [
-        [
-          { value: "default", name: "Default" },
-          { value: "inherit", name: "Inherit" },
-        ],
-        [
-          { value: Display.SHOW, name: "Show" },
-          { value: Display.HIDE, name: "Hide" },
-          { value: Display.STUB, name: "Stub" },
-          { value: Display.MOCK, name: "Mock" },
-          { value: Display.EXCLUDE, name: "Exclude" },
-        ],
-      ]
-
-  // Trigger glyph and every option glyph resolve to a Material icon from the
-  // shared property-icon catalog. Default and Inherit use the neutral display
-  // icon, so the trigger never swaps icon families (and apparent size) between
-  // states, matching the properties Display control.
-  function resolveDisplayGlyph(key: string): string {
-    if (key === "default" || key === "inherit") {
-      return DISPLAY_NEUTRAL_ICON
-    }
-    return PROPERTY_OPTION_ICONS.display[key] ?? DISPLAY_NEUTRAL_ICON
-  }
-
-  function resolveDisplayOptionIcon(option?: {
-    value: string
-    name: string
-  }): OptionIconRender {
-    return {
-      kind: "iconId",
-      icon: resolveDisplayGlyph(option?.value ?? "default"),
-    }
-  }
-
-  const displayIcon: IconProps = {
-    icon: resolveDisplayGlyph(currentDisplayKey) as IconProps["icon"],
-  }
-
-  // Collects the node's own display plus every display inherited from its
-  // instance-ancestor chain. The walk climbs while each parent is an instance
-  // and includes the first non-instance parent, so a variant root's state still
-  // reaches its instance children. Non-instance rows reflect only their own
-  // display.
-  function collectDisplayChainStates(): Display[] {
-    if (!nodeExistsInWorkspace) {
-      return []
-    }
-
-    const states: Display[] = []
-    const ownDisplay = properties?.display?.value
-    if (ownDisplay) states.push(ownDisplay)
-
-    if (!typeCheckingService.isInstance(node)) {
-      return states
-    }
-
-    let currentParent = nodeTraversalService.findParentNode(node.id, workspace)
-    while (currentParent) {
-      const parentDisplay = getNodeProperties(
-        currentParent as EntryNode,
-        workspace,
-      )?.display?.value
-      if (parentDisplay) states.push(parentDisplay)
-      if (typeCheckingService.isInstance(currentParent)) {
-        currentParent = nodeTraversalService.findParentNode(
-          currentParent.id,
-          workspace,
-        )
-      } else {
-        break
-      }
-    }
-
-    return states
-  }
-
-  // Row notation for the node's display, composed across its ancestor chain:
-  // dimmed for hide/stub/mock/exclude, italic for stub/exclude. Dimmed rows read
-  // as gray at 50% opacity. See `resolveRowDisplayDecoration`.
   const {
+    displayOptionGroups,
+    displayValue,
+    selectDisplay,
+    resolveDisplayOptionIcon,
+    displayIcon,
     isDimmed,
     dimStyle,
-    labelStyle: labelDecorationStyle,
-  } = resolveRowDisplayDecoration(collectDisplayChainStates())
+    labelDecorationStyle,
+  } = useRowNodeDisplay({
+    node,
+    workspace,
+    dispatch,
+    properties,
+    nodeExistsInWorkspace,
+    isEcho,
+  })
 
-  const labelStyle: CSSProperties | undefined = isEcho
-    ? { ...labelDecorationStyle, fontStyle: "italic", opacity: 0.7 }
-    : labelDecorationStyle
-
-  const label = {
-    children: getNodeLabel(),
-    style: labelStyle,
+  const label: TextLabelProps = {
+    children: getNodeLabel(node, workspace, {
+      showNodeIds,
+      showCodeNames,
+      nodeExistsInWorkspace,
+      properties,
+    }),
   }
 
   function setNodeLabel(newLabel: string) {
@@ -773,13 +235,13 @@ export function useRowNode(
   }
 
   return {
-    label: label as TextLabelProps,
+    label,
     buttonIconic,
     icon,
     icon2,
     actions,
     displayOptionGroups,
-    displayValue: currentDisplayKey,
+    displayValue,
     selectDisplay,
     resolveDisplayOptionIcon,
     displayIcon,

--- a/packages/editor/app/sidebars/objects/hooks/use-row-node.ts
+++ b/packages/editor/app/sidebars/objects/hooks/use-row-node.ts
@@ -4,11 +4,22 @@ import {
 } from "@lib/copy-schema/build-schema-snippet"
 import { serializeSchemaSnippet } from "@lib/copy-schema/serialize-schema-ts"
 import { removeNewLines } from "@lib/helpers/new-lines"
-import { MenuEntry } from "@lib/menus"
+import { ComboboxOptionItem, MenuEntry, OptionIconRender } from "@lib/menus"
 import { buildResetMenuEntry } from "@lib/menus/build-reset-menu-entry"
 import { getComponentName } from "@seldon/factory/export/react/discovery/get-component-name"
 import { CSSProperties } from "react"
-import { Display, InstanceId, Properties, VariantId } from "@seldon/core"
+import {
+  Display,
+  InstanceId,
+  Properties,
+  Value,
+  ValueType,
+  VariantId,
+} from "@seldon/core"
+import {
+  PROPERTY_ICONS,
+  PROPERTY_OPTION_ICONS,
+} from "@seldon/core/properties/schemas/data/property-icons"
 import { getComponentSchema } from "@seldon/core/components/catalog"
 import { ComponentId, isComponentId } from "@seldon/core/components/constants"
 import { isEmptyValue } from "@seldon/core/helpers/type-guards/value/is-empty-value"
@@ -53,6 +64,7 @@ import { useAddToast } from "@app/toaster/hooks/use-add-toast"
 import { useDraggable } from "./use-draggable"
 import { useEditState } from "./use-edit-state"
 import { useExpansion, useIsExpanded } from "./use-expansion"
+import { resolveRowDisplayDecoration } from "./row-display-style"
 import { useRowButton } from "./use-row-button"
 import { useRowClick } from "./use-row-click"
 import { useRowToggle } from "./use-row-toggle"
@@ -60,6 +72,10 @@ import {
   useIsAncestorOfSelection,
   useIsParentOfSelection,
 } from "./use-selection-relations"
+
+// Neutral Display glyph for the row picker trigger and the Default/Inherit
+// options, matching the properties Display control's property icon.
+const DISPLAY_NEUTRAL_ICON: string = PROPERTY_ICONS.display
 
 /**
  * Hook that provides all state and handlers for rendering a node row in the objects sidebar.
@@ -604,27 +620,116 @@ export function useRowNode(
 
   const actions: MenuEntry[] = isEcho ? [] : buildNodeActions()
 
-  function checkIfExcluded(): boolean {
+  const ownDisplayValue = properties?.display
+  // `display` also stores an inherit value at runtime, which its narrow
+  // `DisplayValue` type does not model, so read the tag as a plain string.
+  const ownDisplayType: string | undefined = ownDisplayValue?.type
+  const currentDisplayKey =
+    !ownDisplayValue || ownDisplayType === ValueType.EMPTY
+      ? "default"
+      : ownDisplayType === ValueType.INHERIT
+        ? "inherit"
+        : String(ownDisplayValue.value)
+
+  function setDisplay(value: Value) {
+    dispatch({
+      type: "set_node_properties",
+      payload: {
+        nodeId: node.id as VariantId,
+        properties: { display: value } as Properties,
+      },
+    })
+  }
+
+  function resetDisplay() {
+    dispatch({
+      type: "reset_node_property",
+      payload: { nodeId: node.id as VariantId, propertyKey: "display" },
+    })
+  }
+
+  // Selecting a display value from the row's picker. "default" clears the
+  // override, "inherit" stores an inherit value, and every other value stores
+  // the matching option. Mirrors the Display control in the properties sidebar.
+  function selectDisplay(value: string) {
+    if (value === "default") {
+      resetDisplay()
+    } else if (value === "inherit") {
+      setDisplay({ type: ValueType.INHERIT, value: null })
+    } else {
+      setDisplay({ type: ValueType.OPTION, value: value as Display })
+    }
+  }
+
+  // The row Display picker reuses the same floating `ComboboxListbox` as the
+  // properties Display control. Two sections: Default/Inherit, then the concrete
+  // states. Option values match `currentDisplayKey`.
+  const displayOptionGroups: ComboboxOptionItem[][] = isEcho
+    ? []
+    : [
+        [
+          { value: "default", name: "Default" },
+          { value: "inherit", name: "Inherit" },
+        ],
+        [
+          { value: Display.SHOW, name: "Show" },
+          { value: Display.HIDE, name: "Hide" },
+          { value: Display.STUB, name: "Stub" },
+          { value: Display.MOCK, name: "Mock" },
+          { value: Display.EXCLUDE, name: "Exclude" },
+        ],
+      ]
+
+  // Trigger glyph and every option glyph resolve to a Material icon from the
+  // shared property-icon catalog. Default and Inherit use the neutral display
+  // icon, so the trigger never swaps icon families (and apparent size) between
+  // states, matching the properties Display control.
+  function resolveDisplayGlyph(key: string): string {
+    if (key === "default" || key === "inherit") {
+      return DISPLAY_NEUTRAL_ICON
+    }
+    return PROPERTY_OPTION_ICONS.display[key] ?? DISPLAY_NEUTRAL_ICON
+  }
+
+  function resolveDisplayOptionIcon(option?: {
+    value: string
+    name: string
+  }): OptionIconRender {
+    return {
+      kind: "iconId",
+      icon: resolveDisplayGlyph(option?.value ?? "default"),
+    }
+  }
+
+  const displayIcon: IconProps = {
+    icon: resolveDisplayGlyph(currentDisplayKey) as IconProps["icon"],
+  }
+
+  // Collects the node's own display plus every display inherited from its
+  // instance-ancestor chain. The walk climbs while each parent is an instance
+  // and includes the first non-instance parent, so a variant root's state still
+  // reaches its instance children. Non-instance rows reflect only their own
+  // display.
+  function collectDisplayChainStates(): Display[] {
     if (!nodeExistsInWorkspace) {
-      return false
+      return []
     }
 
-    const isExcluded = properties?.display?.value === Display.EXCLUDE
-    if (isExcluded) return true
+    const states: Display[] = []
+    const ownDisplay = properties?.display?.value
+    if (ownDisplay) states.push(ownDisplay)
 
     if (!typeCheckingService.isInstance(node)) {
-      return false
+      return states
     }
 
     let currentParent = nodeTraversalService.findParentNode(node.id, workspace)
     while (currentParent) {
-      const parentProps = getNodeProperties(
+      const parentDisplay = getNodeProperties(
         currentParent as EntryNode,
         workspace,
-      )
-      if (parentProps?.display?.value === Display.EXCLUDE) {
-        return true
-      }
+      )?.display?.value
+      if (parentDisplay) states.push(parentDisplay)
       if (typeCheckingService.isInstance(currentParent)) {
         currentParent = nodeTraversalService.findParentNode(
           currentParent.id,
@@ -635,58 +740,21 @@ export function useRowNode(
       }
     }
 
-    return false
+    return states
   }
 
-  function checkIfStub(): boolean {
-    if (!nodeExistsInWorkspace) {
-      return false
-    }
+  // Row notation for the node's display, composed across its ancestor chain:
+  // dimmed for hide/stub/mock/exclude, italic for stub/exclude. Dimmed rows read
+  // as gray at 50% opacity. See `resolveRowDisplayDecoration`.
+  const {
+    isDimmed,
+    dimStyle,
+    labelStyle: labelDecorationStyle,
+  } = resolveRowDisplayDecoration(collectDisplayChainStates())
 
-    if (properties?.display?.value === Display.STUB) return true
-
-    if (!typeCheckingService.isInstance(node)) {
-      return false
-    }
-
-    let currentParent = nodeTraversalService.findParentNode(node.id, workspace)
-    while (currentParent) {
-      const parentProps = getNodeProperties(
-        currentParent as EntryNode,
-        workspace,
-      )
-      if (parentProps?.display?.value === Display.STUB) {
-        return true
-      }
-      if (typeCheckingService.isInstance(currentParent)) {
-        currentParent = nodeTraversalService.findParentNode(
-          currentParent.id,
-          workspace,
-        )
-      } else {
-        break
-      }
-    }
-
-    return false
-  }
-
-  // Excluded rows (own display or an excluded ancestor) read as italic with a
-  // strikethrough. Stub rows (own display or a stub ancestor) read as italic.
-  // Hidden rows use the node's own display only. All three drive the disabled
-  // look.
-  const isExcluded = checkIfExcluded()
-  const isHidden = properties?.display?.value === Display.HIDE
-  const isStub = checkIfStub()
-
-  const baseLabelStyle: CSSProperties | undefined = isExcluded
-    ? { fontStyle: "italic", textDecoration: "line-through" }
-    : isStub
-      ? { fontStyle: "italic" }
-      : undefined
   const labelStyle: CSSProperties | undefined = isEcho
-    ? { ...baseLabelStyle, fontStyle: "italic", opacity: 0.7 }
-    : baseLabelStyle
+    ? { ...labelDecorationStyle, fontStyle: "italic", opacity: 0.7 }
+    : labelDecorationStyle
 
   const label = {
     children: getNodeLabel(),
@@ -710,6 +778,11 @@ export function useRowNode(
     icon,
     icon2,
     actions,
+    displayOptionGroups,
+    displayValue: currentDisplayKey,
+    selectDisplay,
+    resolveDisplayOptionIcon,
+    displayIcon,
     onClick,
     onDoubleClick: handleDoubleClick,
     isExpanded: isExpandedState,
@@ -723,9 +796,9 @@ export function useRowNode(
     dragging,
     ref,
     properties,
-    isExcluded,
-    isHidden,
-    isStub,
+    isDimmed,
+    dimStyle,
+    labelDecorationStyle,
     isDuplicateLabel,
     nodeTypeColor,
     isPrimaryShared,

--- a/packages/editor/app/sidebars/objects/hooks/use-row-node.ts
+++ b/packages/editor/app/sidebars/objects/hooks/use-row-node.ts
@@ -22,14 +22,14 @@ import { hasNode } from "@lib/workspace/workspace-accessors"
 import { IconProps } from "@seldon/components/primitives/Icon"
 import { TextLabelProps } from "@seldon/components/primitives/TextLabel"
 import { useAddToast } from "@app/toaster/hooks/use-add-toast"
-import { useDraggable } from "./use-draggable"
-import { useEditState } from "./use-edit-state"
-import { useExpansion, useIsExpanded } from "./use-expansion"
 import {
   getComponentTypeIcon,
   getNodeLabel,
   getNodeTypeColor,
 } from "./row-node-label"
+import { useDraggable } from "./use-draggable"
+import { useEditState } from "./use-edit-state"
+import { useExpansion, useIsExpanded } from "./use-expansion"
 import { useRowButton } from "./use-row-button"
 import { useRowClick } from "./use-row-click"
 import { useRowNodeActions } from "./use-row-node-actions"

--- a/packages/editor/app/sidebars/properties/PropertiesSidebar.tsx
+++ b/packages/editor/app/sidebars/properties/PropertiesSidebar.tsx
@@ -23,13 +23,13 @@ import {
 import { PropertyDisplayCategory } from "@seldon/core/properties/schemas"
 import { isBoard } from "@seldon/core/workspace/helpers/components/is-board"
 import { useObjectProperties } from "@lib/workspace/hooks/use-object-properties"
+import { useBoardStateMenu } from "./hooks/use-board-state-menu"
 import {
   useBorderSideVisibility,
   useRevealedBorderSides,
 } from "./hooks/use-border-side-visibility"
 import { useFilterInput } from "./hooks/use-filter-input"
 import { useLayerDragMonitor } from "./hooks/use-layer-drag-monitor"
-import { useBoardStateMenu } from "./hooks/use-board-state-menu"
 import { usePropertiesSidebar } from "./hooks/use-properties-sidebar"
 import { PropertyEditNavigationProvider } from "./hooks/use-property-edit-navigation"
 import { useIsCategoryExpanded } from "./hooks/use-property-expansion"

--- a/packages/editor/app/sidebars/properties/PropertiesSidebar.tsx
+++ b/packages/editor/app/sidebars/properties/PropertiesSidebar.tsx
@@ -1,6 +1,14 @@
-import { MenuEntry } from "@lib/menus"
+import { MenuController, MenuEntry } from "@lib/menus"
 import { LayoutGroup } from "framer-motion"
-import { Fragment, useCallback, useDeferredValue, useMemo } from "react"
+import {
+  Fragment,
+  type MouseEvent as ReactMouseEvent,
+  useCallback,
+  useDeferredValue,
+  useMemo,
+  useRef,
+  useState,
+} from "react"
 import {
   Board,
   Instance,
@@ -21,6 +29,7 @@ import {
 } from "./hooks/use-border-side-visibility"
 import { useFilterInput } from "./hooks/use-filter-input"
 import { useLayerDragMonitor } from "./hooks/use-layer-drag-monitor"
+import { useBoardStateMenu } from "./hooks/use-board-state-menu"
 import { usePropertiesSidebar } from "./hooks/use-properties-sidebar"
 import { PropertyEditNavigationProvider } from "./hooks/use-property-edit-navigation"
 import { useIsCategoryExpanded } from "./hooks/use-property-expansion"
@@ -100,15 +109,51 @@ export function PropertiesSidebar() {
     [deferredState, filter.query],
   )
 
+  // The header State menu selects the active interaction state for the selected
+  // node's board tree. Its trigger is the generated `menuState` ButtonMenu; the
+  // dropdown anchors to it through the shared MenuController.
+  const stateMenu = useBoardStateMenu()
+  const [stateMenuOpen, setStateMenuOpen] = useState(false)
+  const stateMenuAnchor = useRef<HTMLElement | null>(null)
+  const openStateMenu = useCallback(
+    (event: ReactMouseEvent<HTMLButtonElement>) => {
+      stateMenuAnchor.current = event.currentTarget
+      setStateMenuOpen((open) => !open)
+    },
+    [],
+  )
+  const closeStateMenu = useCallback(() => setStateMenuOpen(false), [])
+
+  const menuStateSlot = {
+    onClick: openStateMenu,
+    disabled: stateMenu.disabled,
+    "data-testid": "board-state-trigger",
+  }
+  const stateLabelSlot = { children: stateMenu.label }
+  const stateMenuController = (
+    <MenuController
+      open={stateMenuOpen}
+      anchorRef={stateMenuAnchor}
+      onClose={closeStateMenu}
+      items={stateMenu.items}
+      align="end"
+    />
+  )
+
   if (deferredState.kind === "empty") {
     return (
-      <SidebarProperties
-        data-testid="properties-sidebar"
-        comboboxFieldFilter={filter.comboboxField}
-        input={filter.input}
-        buttonIconic={filter.buttonIconic}
-        style={styles.sidebar}
-      />
+      <>
+        <SidebarProperties
+          data-testid="properties-sidebar"
+          comboboxFieldFilter={filter.comboboxField}
+          input={filter.input}
+          buttonIconic={filter.buttonIconic}
+          buttonMenu={menuStateSlot}
+          textLabel={stateLabelSlot}
+          style={styles.sidebar}
+        />
+        {stateMenuController}
+      </>
     )
   }
 
@@ -122,14 +167,19 @@ export function PropertiesSidebar() {
   }
 
   return (
-    <SidebarProperties
-      data-testid="properties-sidebar"
-      comboboxFieldFilter={filter.comboboxField}
-      input={filter.input}
-      buttonIconic={filter.buttonIconic}
-      seldonRefs={seldonRefs}
-      style={styles.sidebar}
-    />
+    <>
+      <SidebarProperties
+        data-testid="properties-sidebar"
+        comboboxFieldFilter={filter.comboboxField}
+        input={filter.input}
+        buttonIconic={filter.buttonIconic}
+        buttonMenu={menuStateSlot}
+        textLabel={stateLabelSlot}
+        seldonRefs={seldonRefs}
+        style={styles.sidebar}
+      />
+      {stateMenuController}
+    </>
   )
 }
 

--- a/packages/editor/app/sidebars/properties/hooks/use-board-state-menu.ts
+++ b/packages/editor/app/sidebars/properties/hooks/use-board-state-menu.ts
@@ -1,7 +1,5 @@
-"use client"
-
-import { MenuController, MenuEntry, MenuItem } from "@lib/menus"
-import { CSSProperties, useMemo } from "react"
+import { MenuEntry, MenuItem } from "@lib/menus"
+import { useMemo } from "react"
 import {
   type CustomState,
   NORMAL_STATE,
@@ -11,36 +9,21 @@ import {
   type ReservedStateName,
 } from "@seldon/core/workspace/model/node-state"
 import { parseNodeLink } from "@seldon/core/workspace/model/template-ref"
+import { isBoard } from "@seldon/core/workspace/helpers/components/is-board"
+import { nodeRelationshipService } from "@seldon/core/workspace/services"
 import type { EntryNode } from "@seldon/core/workspace/types"
+import { getComponentKey } from "@lib/workspace/workspace-accessors"
+import { walkComponentTree } from "@lib/workspace/component-tree"
+import { useSelection } from "@lib/workspace/hooks/use-selection"
 import { useWorkspace } from "@lib/workspace/hooks/use-workspace"
-import { useEditorConfig } from "@lib/hooks/use-editor-config"
-import { useResolvedInterfaceMode } from "@lib/hooks/use-system-color-scheme"
 import {
   useActiveBoardState,
   useBoardStateStore,
-} from "../hooks/use-board-state-store"
-import { walkComponentTree } from "@lib/workspace/component-tree"
-import { ButtonMenu } from "@seldon/components/elements/ButtonMenu"
-import { Frame } from "@seldon/components/frames/Frame"
+} from "@app/canvas/hooks/use-board-state-store"
 
-// bespoke: marks board states whose override lives only on a child. Remove once
-// a generated View owns this canvas overlay treatment.
+// Marks board states whose override lives only on a child, matching the punch
+// accent the canvas switcher used.
 const CHILD_OVERRIDE_COLOR = "var(--sdn-swatch-punch)"
-
-interface BoardStateSwitcherProps {
-  boardKey: string
-}
-
-const wrapperStyle: CSSProperties = {
-  position: "absolute",
-  top: -28,
-  left: 0,
-  zIndex: 5,
-}
-
-function stopClickPropagation(event: React.MouseEvent) {
-  event.stopPropagation()
-}
 
 function stateLabel(state: NodeState, customStates: CustomState[]): string {
   if (state === NORMAL_STATE) return "Normal"
@@ -50,22 +33,37 @@ function stateLabel(state: NodeState, customStates: CustomState[]): string {
   return customStates.find((entry) => entry.key === state)?.label ?? state
 }
 
+export interface BoardStateMenu {
+  /** Menu rows for the shared `MenuController`. */
+  items: MenuEntry[]
+  /** Trigger label: the current active state name. */
+  label: string
+  /** True when the selection has no component board to hold state. */
+  disabled: boolean
+}
+
 /**
- * On-canvas interaction-state switcher. Sits just above the board and selects
- * the active state for the whole board tree. The dropdown chrome, positioning,
- * keyboard navigation, and dismissal come from the shared `MenuController`. Adding a
- * custom state creates it with a sticky default name through a core action.
- * Custom-state names are not editable yet.
+ * Interaction-state menu for the properties sidebar. Selects the active state
+ * for the selected node's whole board tree through the shared board-state store,
+ * the same store the canvas renders from and the `⌥1..0` hotkeys drive. The menu
+ * rows, override indicators, hotkey labels, and "Add custom state" match the
+ * former on-canvas switcher; only the location changed.
  */
-export function BoardStateSwitcher({ boardKey }: BoardStateSwitcherProps) {
+export function useBoardStateMenu(): BoardStateMenu {
   const { workspace, dispatch } = useWorkspace()
-  // The canvas root pins data-theme to the default chrome theme so board
-  // rendering reads authored swatch values. The switcher is chrome, so it
-  // re-scopes to the live chrome theme and mode, matching the topbar.
-  const { chromeTheme } = useEditorConfig()
-  const resolvedMode = useResolvedInterfaceMode()
-  const activeState = useActiveBoardState(boardKey)
+  const { selection } = useSelection()
   const setActiveState = useBoardStateStore((store) => store.setActiveState)
+
+  // Resolve the board key the same way `useNodeActiveState` does, so the menu
+  // writes to the key the canvas and sidebar read from.
+  const boardKey = useMemo<string | undefined>(() => {
+    if (!selection) return undefined
+    if (isBoard(selection)) return getComponentKey(selection)
+    const board = nodeRelationshipService.findBoardForNode(selection, workspace)
+    return board ? getComponentKey(board) : undefined
+  }, [selection, workspace])
+
+  const activeState = useActiveBoardState(boardKey ?? "")
 
   const customStates = useMemo(
     () => workspace.metadata.customStates ?? [],
@@ -94,7 +92,7 @@ export function BoardStateSwitcher({ boardKey }: BoardStateSwitcherProps) {
   const { ownOverrideStates, childOverrideStates } = useMemo(() => {
     const ownOverride = new Set<NodeState>()
     const childOverride = new Set<NodeState>()
-    const board = workspace.boards[boardKey]
+    const board = boardKey ? workspace.boards[boardKey] : undefined
     if (!board)
       return {
         ownOverrideStates: ownOverride,
@@ -126,7 +124,10 @@ export function BoardStateSwitcher({ boardKey }: BoardStateSwitcherProps) {
     }
   }, [workspace.boards, workspace.nodes, boardKey])
 
-  const select = (state: NodeState) => setActiveState(boardKey, state)
+  const select = (state: NodeState) => {
+    if (!boardKey) return
+    setActiveState(boardKey, state)
+  }
 
   // Creates a custom state with a sticky default name. Names are not editable
   // yet, so the next free `Custom N` label is assigned automatically.
@@ -185,27 +186,9 @@ export function BoardStateSwitcher({ boardKey }: BoardStateSwitcherProps) {
     testId: "board-state-add",
   })
 
-  // Chrome wrapper for the on-canvas state switcher. Re-scopes the switcher to
-  // the live chrome theme and mode via data-theme/data-mode.
-  return (
-    <Frame
-      style={wrapperStyle}
-      onClick={stopClickPropagation}
-      data-theme={chromeTheme}
-      data-mode={resolvedMode}
-    >
-      <MenuController
-        items={items}
-        renderTrigger={({ ref, triggerProps }) => (
-          <ButtonMenu
-            ref={ref}
-            type="button"
-            {...triggerProps}
-            textLabel={{ children: stateLabel(activeState, customStates) }}
-            data-testid="board-state-trigger"
-          />
-        )}
-      />
-    </Frame>
-  )
+  return {
+    items,
+    label: stateLabel(activeState, customStates),
+    disabled: !boardKey,
+  }
 }

--- a/packages/editor/app/sidebars/properties/hooks/use-board-state-menu.ts
+++ b/packages/editor/app/sidebars/properties/hooks/use-board-state-menu.ts
@@ -1,5 +1,6 @@
 import { MenuEntry, MenuItem } from "@lib/menus"
 import { useMemo } from "react"
+import { isBoard } from "@seldon/core/workspace/helpers/components/is-board"
 import {
   type CustomState,
   NORMAL_STATE,
@@ -9,13 +10,12 @@ import {
   type ReservedStateName,
 } from "@seldon/core/workspace/model/node-state"
 import { parseNodeLink } from "@seldon/core/workspace/model/template-ref"
-import { isBoard } from "@seldon/core/workspace/helpers/components/is-board"
 import { nodeRelationshipService } from "@seldon/core/workspace/services"
 import type { EntryNode } from "@seldon/core/workspace/types"
-import { getComponentKey } from "@lib/workspace/workspace-accessors"
-import { walkComponentTree } from "@lib/workspace/component-tree"
 import { useSelection } from "@lib/workspace/hooks/use-selection"
 import { useWorkspace } from "@lib/workspace/hooks/use-workspace"
+import { walkComponentTree } from "@lib/workspace/component-tree"
+import { getComponentKey } from "@lib/workspace/workspace-accessors"
 import {
   useActiveBoardState,
   useBoardStateStore,

--- a/packages/editor/app/sidebars/properties/hooks/use-property-combobox.ts
+++ b/packages/editor/app/sidebars/properties/hooks/use-property-combobox.ts
@@ -1,12 +1,12 @@
 import {
   type ComboboxOptionItem,
   type ComboboxOptionItems,
+  useComboboxPosition,
   useComboboxState,
 } from "@lib/menus"
 import { RefObject, useCallback, useEffect, useMemo, useRef } from "react"
 import type { PropertyPickerResult } from "../helpers/options-utils"
 import { FlatProperty } from "../helpers/properties-data"
-import { useComboboxPosition } from "./use-combobox-position"
 
 type ControlType = FlatProperty["controlType"]
 

--- a/packages/editor/lib/hooks/use-editor-config.ts
+++ b/packages/editor/lib/hooks/use-editor-config.ts
@@ -18,6 +18,14 @@ export type ComponentHighlightMode = "selection" | "leaves" | "branch" | "tree"
  */
 export type InterfaceMode = "system" | "light" | "dark"
 
+/**
+ * Objects sidebar content view. `"components"` lists Playground, Screens,
+ * Modules, Parts, Elements, and Primitives; `"resources"` lists Themes, Font
+ * Collections, and Icon Sets. Toggled from the sidebar header, defaulting to
+ * components.
+ */
+export type ObjectsView = "components" | "resources"
+
 interface EditorConfigState {
   // Canvas selection and hover overlay boxes in select mode
   showSelection: boolean
@@ -66,6 +74,10 @@ interface EditorConfigState {
   // Objects sidebar: show export component (code) names instead of labels
   showCodeNames: boolean
   setShowCodeNames: (enabled: boolean) => void
+
+  // Objects sidebar: components vs resources content view
+  objectsView: ObjectsView
+  setObjectsView: (view: ObjectsView) => void
 
   // Sidebar refactor settings
   useRefactoredSidebars: boolean
@@ -150,6 +162,11 @@ const useStore = create<EditorConfigState>()(
       setShowCodeNames: (enabled) =>
         set((state) => ({ ...state, showCodeNames: enabled })),
 
+      // Objects sidebar content view (components by default)
+      objectsView: "components",
+      setObjectsView: (view) =>
+        set((state) => ({ ...state, objectsView: view })),
+
       // Sidebar refactor settings
       useRefactoredSidebars: false,
       setUseRefactoredSidebars: (enabled) =>
@@ -180,6 +197,7 @@ const useStore = create<EditorConfigState>()(
         showUnusedIcons: state.showUnusedIcons,
         showPlayground: state.showPlayground,
         showCodeNames: state.showCodeNames,
+        objectsView: state.objectsView,
         useRefactoredSidebars: state.useRefactoredSidebars,
         chromeTheme: state.chromeTheme,
         interfaceMode: state.interfaceMode,
@@ -214,6 +232,8 @@ export function useEditorConfig() {
     setShowPlayground,
     showCodeNames,
     setShowCodeNames,
+    objectsView,
+    setObjectsView,
     useRefactoredSidebars,
     setUseRefactoredSidebars,
     chromeTheme,
@@ -246,6 +266,8 @@ export function useEditorConfig() {
       setShowPlayground: state.setShowPlayground,
       showCodeNames: state.showCodeNames,
       setShowCodeNames: state.setShowCodeNames,
+      objectsView: state.objectsView,
+      setObjectsView: state.setObjectsView,
       useRefactoredSidebars: state.useRefactoredSidebars,
       setUseRefactoredSidebars: state.setUseRefactoredSidebars,
       chromeTheme: state.chromeTheme,
@@ -356,6 +378,10 @@ export function useEditorConfig() {
     showCodeNames,
     setShowCodeNames,
     toggleShowCodeNames,
+
+    // Objects sidebar content view
+    objectsView,
+    setObjectsView,
 
     // Sidebar refactor methods
     useRefactoredSidebars,

--- a/packages/editor/lib/hooks/use-editor-shortcuts.ts
+++ b/packages/editor/lib/hooks/use-editor-shortcuts.ts
@@ -19,7 +19,7 @@ import { usePreview } from "./use-preview"
 import { useTool } from "./use-tool"
 
 /**
- * Reserved states in menu order, matching `BoardStateSwitcher`. Index 0 is
+ * Reserved states in menu order, matching `useBoardStateMenu`. Index 0 is
  * Normal and the rest follow `RESERVED_STATE_GROUPS`, so Option-1 through
  * Option-0 map top to bottom to Normal through Dragged.
  */

--- a/packages/editor/lib/menus/index.ts
+++ b/packages/editor/lib/menus/index.ts
@@ -7,6 +7,10 @@ export {
 export { ComboboxController } from "./ComboboxController"
 export { ComboboxListbox } from "./ComboboxListbox"
 export { useComboboxState } from "./use-combobox-state"
+export {
+  useComboboxPosition,
+  type ComboboxPosition,
+} from "./use-combobox-position"
 export type {
   MenuAlign,
   MenuEntry,

--- a/packages/editor/lib/menus/use-combobox-position.ts
+++ b/packages/editor/lib/menus/use-combobox-position.ts
@@ -1,28 +1,32 @@
 /**
- * Hook for calculating combobox options position
+ * Hook for calculating a floating list's position from an anchor element.
+ * Shared by the properties combobox and the objects-sidebar display picker.
  */
 import { RefObject, useEffect, useState } from "react"
 
-interface Position {
+export interface ComboboxPosition {
   x: number
   y: number
   w: number
-  positionAbove?: boolean // Flag to indicate menu should render above the control
+  /** True when the list should render above the anchor (anchor near viewport bottom). */
+  positionAbove?: boolean
 }
 
 interface UseComboboxPositionOptions {
   open: boolean
-  frameRef?: RefObject<HTMLDivElement | null>
+  frameRef?: RefObject<HTMLElement | null>
 }
 
 /**
- * Calculates and updates the position of combobox options dropdown
+ * Calculates and updates the position of a floating option list anchored to
+ * `frameRef`. Returns the anchor's left/width and a y below it, flipping to
+ * render above when the anchor sits in the bottom 40% of the viewport.
  */
 export function useComboboxPosition({
   open,
   frameRef,
-}: UseComboboxPositionOptions): Position {
-  const [optionsPosition, setOptionsPosition] = useState<Position>({
+}: UseComboboxPositionOptions): ComboboxPosition {
+  const [optionsPosition, setOptionsPosition] = useState<ComboboxPosition>({
     x: 0,
     y: 0,
     w: 0,

--- a/packages/editor/seldon/elements/ButtonToggle.tsx
+++ b/packages/editor/seldon/elements/ButtonToggle.tsx
@@ -76,6 +76,6 @@ const sdn: ButtonToggleProps = {
   icon: {
     icon: "seldon-component",
     "aria-hidden": "true",
-    className: "sdn-icon sdn-icon--ovkd",
+    className: "sdn-icon sdn-icon--vsau",
   },
 }

--- a/packages/editor/seldon/elements/ItemNode.tsx
+++ b/packages/editor/seldon/elements/ItemNode.tsx
@@ -241,7 +241,7 @@ const sdn: ItemNodeProps = {
   icon3: {
     icon: "seldon-display",
     "aria-hidden": "true",
-    className: "sdn-icon sdn-icon--vsau",
+    className: "sdn-icon sdn-icon--xi68",
   },
   buttonIconic3: {
     className: "sdn-button-iconic sdn-button-iconic--pgsr",
@@ -250,6 +250,6 @@ const sdn: ItemNodeProps = {
   icon4: {
     icon: "seldon-more",
     "aria-hidden": "true",
-    className: "sdn-icon sdn-icon--vsau",
+    className: "sdn-icon sdn-icon--xi68",
   },
 }

--- a/packages/editor/seldon/elements/ItemNode.tsx
+++ b/packages/editor/seldon/elements/ItemNode.tsx
@@ -30,6 +30,8 @@ export interface ItemNodeProps extends LiHTMLAttributes<HTMLLIElement> {
   input?: InputProps | null
   buttonIconic2?: ButtonIconicProps | null
   icon3?: IconProps | null
+  buttonIconic3?: ButtonIconicProps | null
+  icon4?: IconProps | null
 }
 
 /*****
@@ -56,6 +58,8 @@ export function ItemNode({
   input = sdn.input,
   buttonIconic2 = sdn.buttonIconic2,
   icon3 = sdn.icon3,
+  buttonIconic3,
+  icon4 = sdn.icon4,
   children,
   seldonRefs,
   ...props
@@ -140,6 +144,29 @@ export function ItemNode({
           className: combineClassNames(sdn.icon3?.className, icon3?.className),
         },
   )
+  const buttonIconic3Props = applyRef(
+    seldonRefs,
+    buttonIconic3 === null
+      ? null
+      : {
+          ...sdn.buttonIconic3,
+          ...buttonIconic3,
+          className: combineClassNames(
+            sdn.buttonIconic3?.className,
+            buttonIconic3?.className,
+          ),
+        },
+  )
+  const icon4Props = applyRef(
+    seldonRefs,
+    icon4 === null
+      ? null
+      : {
+          ...sdn.icon4,
+          ...icon4,
+          className: combineClassNames(sdn.icon4?.className, icon4?.className),
+        },
+  )
 
   return (
     <HTMLLi
@@ -163,6 +190,9 @@ export function ItemNode({
               buttonIconic={buttonIconic2Props}
               icon2={icon3Props}
             />
+          )}
+          {buttonIconic3 && buttonIconic3Props && (
+            <ButtonIconic {...buttonIconic3Props} icon={icon4Props} />
           )}
         </>
       )}
@@ -206,9 +236,18 @@ const sdn: ItemNodeProps = {
   },
   buttonIconic2: {
     className: "sdn-button-iconic sdn-button-iconic--pgsr",
-    "data-seldon-ref": "nodeActions",
+    "data-seldon-ref": "nodeDisplay",
   },
   icon3: {
+    icon: "seldon-display",
+    "aria-hidden": "true",
+    className: "sdn-icon sdn-icon--vsau",
+  },
+  buttonIconic3: {
+    className: "sdn-button-iconic sdn-button-iconic--pgsr",
+    "data-seldon-ref": "nodeActions",
+  },
+  icon4: {
     icon: "seldon-more",
     "aria-hidden": "true",
     className: "sdn-icon sdn-icon--vsau",

--- a/packages/editor/seldon/elements/ItemProperty.tsx
+++ b/packages/editor/seldon/elements/ItemProperty.tsx
@@ -295,7 +295,7 @@ const sdn: ItemPropertyProps = {
   icon3: {
     icon: "material-chevronDown",
     "aria-hidden": "true",
-    className: "sdn-icon sdn-icon--vsau",
+    className: "sdn-icon sdn-icon--xi68",
   },
   buttonIconic3: {
     className: "sdn-button-iconic sdn-button-iconic--pgsr",
@@ -304,6 +304,6 @@ const sdn: ItemPropertyProps = {
   icon4: {
     icon: "seldon-more",
     "aria-hidden": "true",
-    className: "sdn-icon sdn-icon--vsau",
+    className: "sdn-icon sdn-icon--xi68",
   },
 }

--- a/packages/editor/seldon/elements/ItemPropertyToggle.tsx
+++ b/packages/editor/seldon/elements/ItemPropertyToggle.tsx
@@ -258,6 +258,6 @@ const sdn: ItemPropertyToggleProps = {
   icon3: {
     icon: "seldon-more",
     "aria-hidden": "true",
-    className: "sdn-icon sdn-icon--vsau",
+    className: "sdn-icon sdn-icon--xi68",
   },
 }

--- a/packages/editor/seldon/elements/ItemSection.tsx
+++ b/packages/editor/seldon/elements/ItemSection.tsx
@@ -227,7 +227,7 @@ const sdn: ItemSectionProps = {
   icon2: {
     icon: "material-add",
     "aria-hidden": "true",
-    className: "sdn-icon sdn-icon--umgs",
+    className: "sdn-icon sdn-icon--0qvc",
   },
   buttonIconic3: {
     className: "sdn-button-iconic sdn-button-iconic--pgsr",
@@ -236,6 +236,6 @@ const sdn: ItemSectionProps = {
   icon3: {
     icon: "seldon-more",
     "aria-hidden": "true",
-    className: "sdn-icon sdn-icon--umgs",
+    className: "sdn-icon sdn-icon--0qvc",
   },
 }

--- a/packages/editor/seldon/modules/PanelHari.tsx
+++ b/packages/editor/seldon/modules/PanelHari.tsx
@@ -540,7 +540,7 @@ const sdn: PanelHariProps = {
   icon: {
     icon: "material-outputCircle",
     "aria-hidden": "true",
-    className: "sdn-icon sdn-icon--ovkd",
+    className: "sdn-icon sdn-icon--vsau",
   },
   buttonToggle2: {
     className: "sdn-button-toggle sdn-button-iconic--pgsr",
@@ -549,7 +549,7 @@ const sdn: PanelHariProps = {
   icon2: {
     icon: "material-buildCircle",
     "aria-hidden": "true",
-    className: "sdn-icon sdn-icon--ovkd",
+    className: "sdn-icon sdn-icon--vsau",
   },
   buttonToggle3: {
     className: "sdn-button-toggle sdn-button-iconic--pgsr",
@@ -558,7 +558,7 @@ const sdn: PanelHariProps = {
   icon3: {
     icon: "material-neurology",
     "aria-hidden": "true",
-    className: "sdn-icon sdn-icon--ovkd",
+    className: "sdn-icon sdn-icon--vsau",
   },
   buttonIconic: {
     className: "sdn-button-iconic sdn-button-iconic--pgsr",

--- a/packages/editor/seldon/modules/Sidebar.tsx
+++ b/packages/editor/seldon/modules/Sidebar.tsx
@@ -537,7 +537,7 @@ const sdn: SidebarProps = {
   },
   barButtons: {
     "aria-hidden": "false",
-    className: "sdn-bar-buttons sdn-bar-tabs-bar--qtpt",
+    className: "sdn-bar-buttons sdn-bar-buttons--ftcm",
   },
   frame2: {
     wrapperElement: "div",

--- a/packages/editor/seldon/modules/SidebarObjects.tsx
+++ b/packages/editor/seldon/modules/SidebarObjects.tsx
@@ -304,7 +304,7 @@ const sdn: SidebarObjectsProps = {
   icon3: {
     icon: "seldon-component",
     "aria-hidden": "true",
-    className: "sdn-icon sdn-icon--ovkd",
+    className: "sdn-icon sdn-icon--vsau",
   },
   buttonToggle2: {
     className: "sdn-button-toggle sdn-button-iconic--pgsr",
@@ -313,7 +313,7 @@ const sdn: SidebarObjectsProps = {
   icon4: {
     icon: "seldon-theme",
     "aria-hidden": "true",
-    className: "sdn-icon sdn-icon--ovkd",
+    className: "sdn-icon sdn-icon--vsau",
   },
   frame3: {
     wrapperElement: "div",

--- a/packages/editor/seldon/modules/SidebarObjects.tsx
+++ b/packages/editor/seldon/modules/SidebarObjects.tsx
@@ -11,7 +11,7 @@
  *
  *****/
 import { HTMLAttributes } from "react"
-import { ButtonIconic, ButtonIconicProps } from "../elements/ButtonIconic"
+import { ButtonIconicProps } from "../elements/ButtonIconic"
 import { ButtonToggle, ButtonToggleProps } from "../elements/ButtonToggle"
 import {
   ComboboxFieldProject,
@@ -19,8 +19,8 @@ import {
 } from "../elements/ComboboxFieldProject"
 import { Frame, FrameProps } from "../frames/Frame"
 import { HTMLDiv } from "../native-react/HTML.Div"
-import { Icon, IconProps } from "../primitives/Icon"
-import { Input, InputProps } from "../primitives/Input"
+import { IconProps } from "../primitives/Icon"
+import { InputProps } from "../primitives/Input"
 import { applyRef } from "../utils/apply-ref"
 import { combineClassNames } from "../utils/class-name"
 
@@ -28,17 +28,18 @@ export interface SidebarObjectsProps extends HTMLAttributes<HTMLElement> {
   className?: string
   "data-seldon-ref"?: string
   seldonRefs?: Record<string, Record<string, unknown>>
+  frame?: FrameProps | null
   comboboxFieldProject?: ComboboxFieldProjectProps | null
   icon?: IconProps | null
   input?: InputProps | null
   buttonIconic?: ButtonIconicProps | null
   icon2?: IconProps | null
-  frame?: FrameProps | null
+  frame2?: FrameProps | null
   buttonToggle?: ButtonToggleProps | null
   icon3?: IconProps | null
   buttonToggle2?: ButtonToggleProps | null
   icon4?: IconProps | null
-  frame2?: FrameProps | null
+  frame3?: FrameProps | null
 }
 
 /*****
@@ -58,17 +59,18 @@ export interface SidebarObjectsProps extends HTMLAttributes<HTMLElement> {
  *****/
 export function SidebarObjects({
   className = "",
+  frame = sdn.frame,
   comboboxFieldProject,
   icon = sdn.icon,
   input = sdn.input,
   buttonIconic = sdn.buttonIconic,
   icon2 = sdn.icon2,
-  frame = sdn.frame,
+  frame2 = sdn.frame2,
   buttonToggle,
   icon3 = sdn.icon3,
   buttonToggle2,
   icon4 = sdn.icon4,
-  frame2 = sdn.frame2,
+  frame3 = sdn.frame3,
   children,
   seldonRefs,
   ...props
@@ -76,6 +78,16 @@ export function SidebarObjects({
   const sidebarObjectsClassName = combineClassNames(
     "sdn-sidebar-objects",
     className,
+  )
+  const frameProps = applyRef(
+    seldonRefs,
+    frame === null
+      ? null
+      : {
+          ...sdn.frame,
+          ...frame,
+          className: combineClassNames(sdn.frame?.className, frame?.className),
+        },
   )
   const comboboxFieldProjectProps = applyRef(
     seldonRefs,
@@ -133,14 +145,17 @@ export function SidebarObjects({
           className: combineClassNames(sdn.icon2?.className, icon2?.className),
         },
   )
-  const frameProps = applyRef(
+  const frame2Props = applyRef(
     seldonRefs,
-    frame === null
+    frame2 === null
       ? null
       : {
-          ...sdn.frame,
-          ...frame,
-          className: combineClassNames(sdn.frame?.className, frame?.className),
+          ...sdn.frame2,
+          ...frame2,
+          className: combineClassNames(
+            sdn.frame2?.className,
+            frame2?.className,
+          ),
         },
   )
   const buttonToggleProps = applyRef(
@@ -189,16 +204,16 @@ export function SidebarObjects({
           className: combineClassNames(sdn.icon4?.className, icon4?.className),
         },
   )
-  const frame2Props = applyRef(
+  const frame3Props = applyRef(
     seldonRefs,
-    frame2 === null
+    frame3 === null
       ? null
       : {
-          ...sdn.frame2,
-          ...frame2,
+          ...sdn.frame3,
+          ...frame3,
           className: combineClassNames(
-            sdn.frame2?.className,
-            frame2?.className,
+            sdn.frame3?.className,
+            frame3?.className,
           ),
         },
   )
@@ -214,24 +229,26 @@ export function SidebarObjects({
         children
       ) : (
         <>
-          {comboboxFieldProject && comboboxFieldProjectProps && (
-            <ComboboxFieldProject {...comboboxFieldProjectProps}>
-              {icon && iconProps && <Icon {...iconProps} />}
-              {input && inputProps && <Input {...inputProps} />}
-              {buttonIconic && buttonIconicProps && (
-                <ButtonIconic {...buttonIconicProps} icon={icon2Props} />
+          <Frame {...frameProps}>
+            {comboboxFieldProject && comboboxFieldProjectProps && (
+              <ComboboxFieldProject
+                {...comboboxFieldProjectProps}
+                icon={iconProps}
+                input={inputProps}
+                buttonIconic={buttonIconicProps}
+                icon2={icon2Props}
+              />
+            )}
+            <Frame {...frame2Props}>
+              {buttonToggle && buttonToggleProps && (
+                <ButtonToggle {...buttonToggleProps} icon={icon3Props} />
               )}
-              <Frame {...frameProps}>
-                {buttonToggle && buttonToggleProps && (
-                  <ButtonToggle {...buttonToggleProps} icon={icon3Props} />
-                )}
-                {buttonToggle2 && buttonToggle2Props && (
-                  <ButtonToggle {...buttonToggle2Props} icon={icon4Props} />
-                )}
-              </Frame>
-            </ComboboxFieldProject>
-          )}
-          <Frame {...frame2Props}></Frame>
+              {buttonToggle2 && buttonToggle2Props && (
+                <ButtonToggle {...buttonToggle2Props} icon={icon4Props} />
+              )}
+            </Frame>
+          </Frame>
+          <Frame {...frame3Props}></Frame>
         </>
       )}
     </HTMLDiv>
@@ -245,6 +262,11 @@ const sdn: SidebarObjectsProps = {
   role: "complementary",
   "aria-hidden": "false",
   className: "sdn-sidebar-objects sdn-sidebar",
+  frame: {
+    wrapperElement: "div",
+    "aria-hidden": "false",
+    className: "sdn-frame sdn-frame--p4y0",
+  },
   comboboxFieldProject: {
     className: "sdn-combobox-field sdn-combobox-field-project--rzdy",
   },
@@ -270,7 +292,7 @@ const sdn: SidebarObjectsProps = {
     "aria-hidden": "true",
     className: "sdn-icon sdn-icon--vsau",
   },
-  frame: {
+  frame2: {
     wrapperElement: "div",
     "aria-hidden": "false",
     className: "sdn-frame sdn-frame--ma6i",
@@ -293,7 +315,7 @@ const sdn: SidebarObjectsProps = {
     "aria-hidden": "true",
     className: "sdn-icon sdn-icon--ovkd",
   },
-  frame2: {
+  frame3: {
     wrapperElement: "div",
     "aria-hidden": "false",
     className: "sdn-frame sdn-frame--enpy",

--- a/packages/editor/seldon/modules/SidebarObjects.tsx
+++ b/packages/editor/seldon/modules/SidebarObjects.tsx
@@ -11,15 +11,16 @@
  *
  *****/
 import { HTMLAttributes } from "react"
-import { ButtonIconicProps } from "../elements/ButtonIconic"
+import { ButtonIconic, ButtonIconicProps } from "../elements/ButtonIconic"
+import { ButtonToggle, ButtonToggleProps } from "../elements/ButtonToggle"
 import {
   ComboboxFieldProject,
   ComboboxFieldProjectProps,
 } from "../elements/ComboboxFieldProject"
 import { Frame, FrameProps } from "../frames/Frame"
 import { HTMLDiv } from "../native-react/HTML.Div"
-import { IconProps } from "../primitives/Icon"
-import { InputProps } from "../primitives/Input"
+import { Icon, IconProps } from "../primitives/Icon"
+import { Input, InputProps } from "../primitives/Input"
 import { applyRef } from "../utils/apply-ref"
 import { combineClassNames } from "../utils/class-name"
 
@@ -33,6 +34,11 @@ export interface SidebarObjectsProps extends HTMLAttributes<HTMLElement> {
   buttonIconic?: ButtonIconicProps | null
   icon2?: IconProps | null
   frame?: FrameProps | null
+  buttonToggle?: ButtonToggleProps | null
+  icon3?: IconProps | null
+  buttonToggle2?: ButtonToggleProps | null
+  icon4?: IconProps | null
+  frame2?: FrameProps | null
 }
 
 /*****
@@ -58,6 +64,11 @@ export function SidebarObjects({
   buttonIconic = sdn.buttonIconic,
   icon2 = sdn.icon2,
   frame = sdn.frame,
+  buttonToggle,
+  icon3 = sdn.icon3,
+  buttonToggle2,
+  icon4 = sdn.icon4,
+  frame2 = sdn.frame2,
   children,
   seldonRefs,
   ...props
@@ -132,6 +143,65 @@ export function SidebarObjects({
           className: combineClassNames(sdn.frame?.className, frame?.className),
         },
   )
+  const buttonToggleProps = applyRef(
+    seldonRefs,
+    buttonToggle === null
+      ? null
+      : {
+          ...sdn.buttonToggle,
+          ...buttonToggle,
+          className: combineClassNames(
+            sdn.buttonToggle?.className,
+            buttonToggle?.className,
+          ),
+        },
+  )
+  const icon3Props = applyRef(
+    seldonRefs,
+    icon3 === null
+      ? null
+      : {
+          ...sdn.icon3,
+          ...icon3,
+          className: combineClassNames(sdn.icon3?.className, icon3?.className),
+        },
+  )
+  const buttonToggle2Props = applyRef(
+    seldonRefs,
+    buttonToggle2 === null
+      ? null
+      : {
+          ...sdn.buttonToggle2,
+          ...buttonToggle2,
+          className: combineClassNames(
+            sdn.buttonToggle2?.className,
+            buttonToggle2?.className,
+          ),
+        },
+  )
+  const icon4Props = applyRef(
+    seldonRefs,
+    icon4 === null
+      ? null
+      : {
+          ...sdn.icon4,
+          ...icon4,
+          className: combineClassNames(sdn.icon4?.className, icon4?.className),
+        },
+  )
+  const frame2Props = applyRef(
+    seldonRefs,
+    frame2 === null
+      ? null
+      : {
+          ...sdn.frame2,
+          ...frame2,
+          className: combineClassNames(
+            sdn.frame2?.className,
+            frame2?.className,
+          ),
+        },
+  )
 
   return (
     <HTMLDiv
@@ -145,15 +215,23 @@ export function SidebarObjects({
       ) : (
         <>
           {comboboxFieldProject && comboboxFieldProjectProps && (
-            <ComboboxFieldProject
-              {...comboboxFieldProjectProps}
-              icon={iconProps}
-              input={inputProps}
-              buttonIconic={buttonIconicProps}
-              icon2={icon2Props}
-            />
+            <ComboboxFieldProject {...comboboxFieldProjectProps}>
+              {icon && iconProps && <Icon {...iconProps} />}
+              {input && inputProps && <Input {...inputProps} />}
+              {buttonIconic && buttonIconicProps && (
+                <ButtonIconic {...buttonIconicProps} icon={icon2Props} />
+              )}
+              <Frame {...frameProps}>
+                {buttonToggle && buttonToggleProps && (
+                  <ButtonToggle {...buttonToggleProps} icon={icon3Props} />
+                )}
+                {buttonToggle2 && buttonToggle2Props && (
+                  <ButtonToggle {...buttonToggle2Props} icon={icon4Props} />
+                )}
+              </Frame>
+            </ComboboxFieldProject>
           )}
-          <Frame {...frameProps}></Frame>
+          <Frame {...frame2Props}></Frame>
         </>
       )}
     </HTMLDiv>
@@ -168,7 +246,7 @@ const sdn: SidebarObjectsProps = {
   "aria-hidden": "false",
   className: "sdn-sidebar-objects sdn-sidebar",
   comboboxFieldProject: {
-    className: "sdn-combobox-field sdn-combobox-field--z3a0",
+    className: "sdn-combobox-field sdn-combobox-field-project--rzdy",
   },
   icon: {
     icon: "material-dataObject",
@@ -176,14 +254,16 @@ const sdn: SidebarObjectsProps = {
     className: "sdn-icon sdn-icon--xi68",
   },
   input: {
-    placeholder: "Project Name",
+    placeholder: "Workspace Name",
     type: "text",
     role: "combobox",
     "aria-haspopup": "listbox",
     className: "sdn-input sdn-input--twyx",
+    "data-seldon-ref": "workspaceName",
   },
   buttonIconic: {
     className: "sdn-button-iconic sdn-button-iconic--pgsr",
+    "data-seldon-ref": "workspaceSave",
   },
   icon2: {
     icon: "material-save",
@@ -191,6 +271,29 @@ const sdn: SidebarObjectsProps = {
     className: "sdn-icon sdn-icon--vsau",
   },
   frame: {
+    wrapperElement: "div",
+    "aria-hidden": "false",
+    className: "sdn-frame sdn-frame--ma6i",
+  },
+  buttonToggle: {
+    className: "sdn-button-toggle sdn-button-iconic--pgsr",
+    "data-seldon-ref": "sidebarComponents",
+  },
+  icon3: {
+    icon: "seldon-component",
+    "aria-hidden": "true",
+    className: "sdn-icon sdn-icon--ovkd",
+  },
+  buttonToggle2: {
+    className: "sdn-button-toggle sdn-button-iconic--pgsr",
+    "data-seldon-ref": "sidebarResources",
+  },
+  icon4: {
+    icon: "seldon-theme",
+    "aria-hidden": "true",
+    className: "sdn-icon sdn-icon--ovkd",
+  },
+  frame2: {
     wrapperElement: "div",
     "aria-hidden": "false",
     className: "sdn-frame sdn-frame--enpy",

--- a/packages/editor/seldon/modules/SidebarProperties.tsx
+++ b/packages/editor/seldon/modules/SidebarProperties.tsx
@@ -181,9 +181,11 @@ const sdn: SidebarPropertiesProps = {
     role: "combobox",
     "aria-haspopup": "listbox",
     className: "sdn-input sdn-input--twyx",
+    "data-seldon-ref": "propertyFilter",
   },
   buttonIconic: {
     className: "sdn-button-iconic sdn-button-iconic--pgsr",
+    "data-seldon-ref": "propertyFilterClear",
   },
   icon2: {
     icon: "material-close",
@@ -193,7 +195,7 @@ const sdn: SidebarPropertiesProps = {
   frame: {
     wrapperElement: "div",
     "aria-hidden": "false",
-    className: "sdn-frame sdn-frame--evmw",
+    className: "sdn-frame sdn-frame--enpy",
     "data-seldon-ref": "propertiesContainer",
   },
 }

--- a/packages/editor/seldon/modules/SidebarProperties.tsx
+++ b/packages/editor/seldon/modules/SidebarProperties.tsx
@@ -195,7 +195,7 @@ const sdn: SidebarPropertiesProps = {
   frame: {
     wrapperElement: "div",
     "aria-hidden": "false",
-    className: "sdn-frame sdn-frame--enpy",
+    className: "sdn-frame sdn-frame--evmw",
     "data-seldon-ref": "propertiesContainer",
   },
 }

--- a/packages/editor/seldon/modules/SidebarProperties.tsx
+++ b/packages/editor/seldon/modules/SidebarProperties.tsx
@@ -12,14 +12,16 @@
  *****/
 import { HTMLAttributes } from "react"
 import { ButtonIconicProps } from "../elements/ButtonIconic"
+import { ButtonMenu, ButtonMenuProps } from "../elements/ButtonMenu"
 import {
   ComboboxFieldFilter,
   ComboboxFieldFilterProps,
 } from "../elements/ComboboxFieldFilter"
 import { Frame, FrameProps } from "../frames/Frame"
 import { HTMLDiv } from "../native-react/HTML.Div"
-import { IconProps } from "../primitives/Icon"
+import { Icon, IconProps } from "../primitives/Icon"
 import { InputProps } from "../primitives/Input"
+import { TextLabel, TextLabelProps } from "../primitives/TextLabel"
 import { applyRef } from "../utils/apply-ref"
 import { combineClassNames } from "../utils/class-name"
 
@@ -27,12 +29,16 @@ export interface SidebarPropertiesProps extends HTMLAttributes<HTMLElement> {
   className?: string
   "data-seldon-ref"?: string
   seldonRefs?: Record<string, Record<string, unknown>>
+  frame?: FrameProps | null
   comboboxFieldFilter?: ComboboxFieldFilterProps | null
   icon?: IconProps | null
   input?: InputProps | null
   buttonIconic?: ButtonIconicProps | null
   icon2?: IconProps | null
-  frame?: FrameProps | null
+  buttonMenu?: ButtonMenuProps | null
+  textLabel?: TextLabelProps | null
+  icon3?: IconProps | null
+  frame2?: FrameProps | null
 }
 
 /*****
@@ -52,12 +58,16 @@ export interface SidebarPropertiesProps extends HTMLAttributes<HTMLElement> {
  *****/
 export function SidebarProperties({
   className = "",
+  frame = sdn.frame,
   comboboxFieldFilter,
   icon = sdn.icon,
   input = sdn.input,
   buttonIconic = sdn.buttonIconic,
   icon2 = sdn.icon2,
-  frame = sdn.frame,
+  buttonMenu,
+  textLabel,
+  icon3 = sdn.icon3,
+  frame2 = sdn.frame2,
   children,
   seldonRefs,
   ...props
@@ -65,6 +75,16 @@ export function SidebarProperties({
   const sidebarPropertiesClassName = combineClassNames(
     "sdn-sidebar-objects",
     className,
+  )
+  const frameProps = applyRef(
+    seldonRefs,
+    frame === null
+      ? null
+      : {
+          ...sdn.frame,
+          ...frame,
+          className: combineClassNames(sdn.frame?.className, frame?.className),
+        },
   )
   const comboboxFieldFilterProps = applyRef(
     seldonRefs,
@@ -122,14 +142,53 @@ export function SidebarProperties({
           className: combineClassNames(sdn.icon2?.className, icon2?.className),
         },
   )
-  const frameProps = applyRef(
+  const buttonMenuProps = applyRef(
     seldonRefs,
-    frame === null
+    buttonMenu === null
       ? null
       : {
-          ...sdn.frame,
-          ...frame,
-          className: combineClassNames(sdn.frame?.className, frame?.className),
+          ...sdn.buttonMenu,
+          ...buttonMenu,
+          className: combineClassNames(
+            sdn.buttonMenu?.className,
+            buttonMenu?.className,
+          ),
+        },
+  )
+  const textLabelProps = applyRef(
+    seldonRefs,
+    textLabel === null
+      ? null
+      : {
+          ...sdn.textLabel,
+          ...textLabel,
+          className: combineClassNames(
+            sdn.textLabel?.className,
+            textLabel?.className,
+          ),
+        },
+  )
+  const icon3Props = applyRef(
+    seldonRefs,
+    icon3 === null
+      ? null
+      : {
+          ...sdn.icon3,
+          ...icon3,
+          className: combineClassNames(sdn.icon3?.className, icon3?.className),
+        },
+  )
+  const frame2Props = applyRef(
+    seldonRefs,
+    frame2 === null
+      ? null
+      : {
+          ...sdn.frame2,
+          ...frame2,
+          className: combineClassNames(
+            sdn.frame2?.className,
+            frame2?.className,
+          ),
         },
   )
 
@@ -144,16 +203,26 @@ export function SidebarProperties({
         children
       ) : (
         <>
-          {comboboxFieldFilter && comboboxFieldFilterProps && (
-            <ComboboxFieldFilter
-              {...comboboxFieldFilterProps}
-              icon={iconProps}
-              input={inputProps}
-              buttonIconic={buttonIconicProps}
-              icon2={icon2Props}
-            />
-          )}
-          <Frame {...frameProps}></Frame>
+          <Frame {...frameProps}>
+            {comboboxFieldFilter && comboboxFieldFilterProps && (
+              <ComboboxFieldFilter
+                {...comboboxFieldFilterProps}
+                icon={iconProps}
+                input={inputProps}
+                buttonIconic={buttonIconicProps}
+                icon2={icon2Props}
+              />
+            )}
+            {buttonMenu && buttonMenuProps && (
+              <ButtonMenu {...buttonMenuProps}>
+                {textLabel && textLabelProps && (
+                  <TextLabel {...textLabelProps} />
+                )}
+                {icon3 && icon3Props && <Icon {...icon3Props} />}
+              </ButtonMenu>
+            )}
+          </Frame>
+          <Frame {...frame2Props}></Frame>
         </>
       )}
     </HTMLDiv>
@@ -167,8 +236,13 @@ const sdn: SidebarPropertiesProps = {
   role: "complementary",
   "aria-hidden": "false",
   className: "sdn-sidebar-objects sdn-sidebar",
+  frame: {
+    wrapperElement: "div",
+    "aria-hidden": "false",
+    className: "sdn-frame sdn-frame--uief",
+  },
   comboboxFieldFilter: {
-    className: "sdn-combobox-field sdn-combobox-field--z3a0",
+    className: "sdn-combobox-field sdn-combobox-field-project--rzdy",
   },
   icon: {
     icon: "material-filterList",
@@ -192,7 +266,19 @@ const sdn: SidebarPropertiesProps = {
     "aria-hidden": "true",
     className: "sdn-icon sdn-icon--vsau",
   },
-  frame: {
+  buttonMenu: {
+    className: "sdn-button-menu sdn-button-menu--t1a2",
+    "data-seldon-ref": "menuState",
+  },
+  textLabel: {
+    className: "sdn-text-label sdn-text-label--sa6t",
+  },
+  icon3: {
+    icon: "material-chevronDown",
+    "aria-hidden": "true",
+    className: "sdn-icon sdn-icon--y2ct",
+  },
+  frame2: {
     wrapperElement: "div",
     "aria-hidden": "false",
     className: "sdn-frame sdn-frame--evmw",

--- a/packages/editor/seldon/primitives/Icon.tsx
+++ b/packages/editor/seldon/primitives/Icon.tsx
@@ -64,6 +64,8 @@ export interface IconProps extends SVGAttributes<SVGElement> {
     | "material-notifications"
     | "seldon-frame"
     | "material-gridOn"
+    | "seldon-theme"
+    | "seldon-display"
     | "seldon-iconSocialFacebook"
     | "seldon-iconSocialReddit"
     | "seldon-iconSocialPinterest"
@@ -83,7 +85,6 @@ export interface IconProps extends SVGAttributes<SVGElement> {
     | "seldon-color"
     | "seldon-computed"
     | "seldon-custom"
-    | "seldon-display"
     | "seldon-empty"
     | "seldon-frameColumns"
     | "seldon-frameRows"
@@ -105,7 +106,6 @@ export interface IconProps extends SVGAttributes<SVGElement> {
     | "seldon-spread"
     | "seldon-step"
     | "seldon-stub"
-    | "seldon-theme"
     | "seldon-valuePx"
     | "seldon-valueRem"
     | "seldon-orientationHorizontal"
@@ -596,6 +596,8 @@ const iconMap = {
   "material-notifications": Icons.IconMaterialNotifications,
   "seldon-frame": Icons.IconSeldonFrame,
   "material-gridOn": Icons.IconMaterialGridOn,
+  "seldon-theme": Icons.IconSeldonTheme,
+  "seldon-display": Icons.IconSeldonDisplay,
   "seldon-iconSocialFacebook": Icons.IconSocialFacebook,
   "seldon-iconSocialReddit": Icons.IconSocialReddit,
   "seldon-iconSocialPinterest": Icons.IconSocialPinterest,
@@ -615,7 +617,6 @@ const iconMap = {
   "seldon-color": Icons.IconSeldonColor,
   "seldon-computed": Icons.IconSeldonComputed,
   "seldon-custom": Icons.IconSeldonCustom,
-  "seldon-display": Icons.IconSeldonDisplay,
   "seldon-empty": Icons.IconSeldonEmpty,
   "seldon-frameColumns": Icons.IconSeldonFrameColumns,
   "seldon-frameRows": Icons.IconSeldonFrameRows,
@@ -637,7 +638,6 @@ const iconMap = {
   "seldon-spread": Icons.IconSeldonSpread,
   "seldon-step": Icons.IconSeldonStep,
   "seldon-stub": Icons.IconSeldonStub,
-  "seldon-theme": Icons.IconSeldonTheme,
   "seldon-valuePx": Icons.IconSeldonValuePx,
   "seldon-valueRem": Icons.IconSeldonValueRem,
   "seldon-orientationHorizontal": Icons.IconSeldonOrientationHorizontal,

--- a/packages/editor/seldon/refs/index.ts
+++ b/packages/editor/seldon/refs/index.ts
@@ -50,6 +50,7 @@ export type SeldonRef =
   | "menuTheme"
   | "menuView"
   | "nodeActions"
+  | "nodeDisplay"
   | "nodeIcon"
   | "nodeLabel"
   | "nodeToggle"
@@ -62,6 +63,8 @@ export type SeldonRef =
   | "projectLabel"
   | "propertiesContainer"
   | "propertyActions"
+  | "propertyFilter"
+  | "propertyFilterClear"
   | "propertyLabel"
   | "propertyToggle"
   | "propertyToggleIcon"
@@ -73,6 +76,8 @@ export type SeldonRef =
   | "sectionLabel"
   | "sectionToggle"
   | "sectionToggleIcon"
+  | "sidebarComponents"
+  | "sidebarResources"
   | "toggleIcon"
   | "toggleValue"
   | "tool"
@@ -80,6 +85,8 @@ export type SeldonRef =
   | "valueIcon"
   | "valueLabel"
   | "valueOptionsMenu"
+  | "workspaceName"
+  | "workspaceSave"
 
 export interface SeldonRefEntry {
   component: string
@@ -278,6 +285,11 @@ export const SELDON_REFS: Record<SeldonRef, SeldonRefEntry> = {
     nodeId: "component-item-CeZRPCDC",
     className: "sdn-button-iconic sdn-button-iconic--pgsr",
   },
+  nodeDisplay: {
+    component: "ButtonIconic",
+    nodeId: "component-item-A2qQLKuh",
+    className: "sdn-button-iconic sdn-button-iconic--pgsr",
+  },
   nodeIcon: {
     component: "Icon",
     nodeId: "component-item-zdDEhaL4",
@@ -331,11 +343,21 @@ export const SELDON_REFS: Record<SeldonRef, SeldonRefEntry> = {
   propertiesContainer: {
     component: "Frame",
     nodeId: "component-sidebar-evMwxVOP",
-    className: "sdn-frame sdn-frame--evmw",
+    className: "sdn-frame sdn-frame--enpy",
   },
   propertyActions: {
     component: "ButtonIconic",
     nodeId: "component-button-CGRbb6mm",
+    className: "sdn-button-iconic sdn-button-iconic--pgsr",
+  },
+  propertyFilter: {
+    component: "Input",
+    nodeId: "component-comboboxField-Lg6E5jtv",
+    className: "sdn-input sdn-input--twyx",
+  },
+  propertyFilterClear: {
+    component: "ButtonIconic",
+    nodeId: "component-comboboxField-xvQW1VQq",
     className: "sdn-button-iconic sdn-button-iconic--pgsr",
   },
   propertyLabel: {
@@ -393,6 +415,16 @@ export const SELDON_REFS: Record<SeldonRef, SeldonRefEntry> = {
     nodeId: "component-item-7MKLAjub",
     className: "sdn-icon sdn-icon--umgs",
   },
+  sidebarComponents: {
+    component: "ButtonToggle",
+    nodeId: "component-button-f2yi4eeO",
+    className: "sdn-button-toggle sdn-button-iconic--pgsr",
+  },
+  sidebarResources: {
+    component: "ButtonToggle",
+    nodeId: "component-sidebar-9VESc1Om",
+    className: "sdn-button-toggle sdn-button-iconic--pgsr",
+  },
   toggleIcon: {
     component: "Icon",
     nodeId: "component-item-YzeMLx3R",
@@ -426,6 +458,16 @@ export const SELDON_REFS: Record<SeldonRef, SeldonRefEntry> = {
   valueOptionsMenu: {
     component: "ButtonIconic",
     nodeId: "component-button-HqmnST2I",
+    className: "sdn-button-iconic sdn-button-iconic--pgsr",
+  },
+  workspaceName: {
+    component: "Input",
+    nodeId: "component-comboboxField-spqmpmg5",
+    className: "sdn-input sdn-input--twyx",
+  },
+  workspaceSave: {
+    component: "ButtonIconic",
+    nodeId: "component-comboboxField-o9tr7uLV",
     className: "sdn-button-iconic sdn-button-iconic--pgsr",
   },
 }

--- a/packages/editor/seldon/refs/index.ts
+++ b/packages/editor/seldon/refs/index.ts
@@ -47,6 +47,7 @@ export type SeldonRef =
   | "menuFile"
   | "menuMode"
   | "menus"
+  | "menuState"
   | "menuTheme"
   | "menuView"
   | "nodeActions"
@@ -269,6 +270,11 @@ export const SELDON_REFS: Record<SeldonRef, SeldonRefEntry> = {
     component: "Frame",
     nodeId: "component-bar-DrSavE9B",
     className: "sdn-frame sdn-frame--drsa",
+  },
+  menuState: {
+    component: "ButtonMenu",
+    nodeId: "component-button-t1A2Kxjz",
+    className: "sdn-button-menu sdn-button-menu--t1a2",
   },
   menuTheme: {
     component: "ButtonMenu",

--- a/packages/editor/seldon/refs/index.ts
+++ b/packages/editor/seldon/refs/index.ts
@@ -343,7 +343,7 @@ export const SELDON_REFS: Record<SeldonRef, SeldonRefEntry> = {
   propertiesContainer: {
     component: "Frame",
     nodeId: "component-sidebar-evMwxVOP",
-    className: "sdn-frame sdn-frame--enpy",
+    className: "sdn-frame sdn-frame--evmw",
   },
   propertyActions: {
     component: "ButtonIconic",

--- a/packages/editor/seldon/styles.css
+++ b/packages/editor/seldon/styles.css
@@ -2311,7 +2311,15 @@ body {
 }
 
 .sdn-combobox-field-project--rzdy {
-  gap: var(--sdn-gaps-cozy);
+  align-self: unset;
+  flex-shrink: unset;
+  gap: var(--sdn-gaps-tight);
+  padding-top: 0;
+  padding-inline-end: 0;
+  padding-bottom: 0;
+  padding-inline-start: var(--sdn-paddings-tight);
+  flex: 1 0 0;
+  min-width: 0;
 }
 
 .sdn-combobox-field-search--9jd5 {
@@ -2546,6 +2554,18 @@ body {
 }
 
 .sdn-frame--enpy {
+  flex: unset;
+  overflow-x: hidden;
+  overflow-y: auto;
+  overflow: hidden;
+  height: fit-content;
+  flex-shrink: 0;
+  min-height: 0;
+  padding: 0;
+  margin: 0;
+}
+
+.sdn-frame--evmw {
   overflow-x: hidden;
   overflow-y: auto;
   overflow: hidden;
@@ -2648,11 +2668,13 @@ body {
     transparent
   );
   flex-direction: row;
+  align-items: center;
+  justify-content: end;
   gap: var(--sdn-gaps-tight);
   padding-top: 0;
   padding-inline-end: 0;
   padding-bottom: 0;
-  padding-inline-start: var(--sdn-paddings-cozy);
+  padding-inline-start: var(--sdn-paddings-compact);
   width: fit-content;
   flex-shrink: 0;
   height: 100%;
@@ -2696,6 +2718,19 @@ body {
   width: fit-content;
   flex-shrink: 0;
   height: 100%;
+}
+
+.sdn-frame--p4y0 {
+  flex: unset;
+  flex-direction: row;
+  gap: var(--sdn-gaps-compact);
+  padding-top: 0;
+  padding-inline-end: var(--sdn-paddings-tight);
+  padding-bottom: 0;
+  padding-inline-start: var(--sdn-paddings-tight);
+  height: fit-content;
+  flex-shrink: 0;
+  margin: 0;
 }
 
 .sdn-frame--q4nj {
@@ -5329,8 +5364,8 @@ body {
   border: var(--hairline) solid var(--sdn-swatch-punch);
 }
 
-.sdn-item-section:focus-visible .sdn-icon--umgs,
-.sdn-item-section:has(:focus-visible) .sdn-icon--umgs {
+.sdn-item-section:focus-visible .sdn-icon--0qvc,
+.sdn-item-section:has(:focus-visible) .sdn-icon--0qvc {
   color: var(--sdn-swatch-punch);
 }
 
@@ -5350,15 +5385,15 @@ body {
   border: var(--hairline) solid var(--sdn-hc-on-offWhite);
 }
 
+.sdn-item-section:focus-visible .sdn-icon--umgs,
+.sdn-item-section:has(:focus-visible) .sdn-icon--umgs {
+  color: var(--sdn-swatch-punch);
+}
+
 .sdn-item-section:focus-visible .sdn-input--shhi,
 .sdn-item-section:has(:focus-visible) .sdn-input--shhi {
   color: var(--sdn-swatch-punch);
   border-color: var(--sdn-swatch-punch);
-}
-
-.sdn-item-section:focus-visible .sdn-icon--0qvc,
-.sdn-item-section:has(:focus-visible) .sdn-icon--0qvc {
-  color: var(--sdn-swatch-punch);
 }
 
 .sdn-item-section:focus-visible .sdn-text-label--z34z,
@@ -5372,7 +5407,7 @@ body {
     color-mix(in srgb, var(--sdn-swatch-active) 80%, transparent);
 }
 
-.sdn-item-section[aria-selected="true"] .sdn-icon--umgs {
+.sdn-item-section[aria-selected="true"] .sdn-icon--0qvc {
   color: var(--sdn-swatch-active);
 }
 
@@ -5381,11 +5416,11 @@ body {
   border: var(--hairline) solid var(--sdn-swatch-active);
 }
 
-.sdn-item-section[aria-selected="true"] .sdn-input--shhi {
+.sdn-item-section[aria-selected="true"] .sdn-icon--umgs {
   color: var(--sdn-swatch-active);
 }
 
-.sdn-item-section[aria-selected="true"] .sdn-icon--0qvc {
+.sdn-item-section[aria-selected="true"] .sdn-input--shhi {
   color: var(--sdn-swatch-active);
 }
 
@@ -5404,8 +5439,8 @@ body {
   border: var(--hairline) solid var(--sdn-swatch-gray);
 }
 
-.sdn-item-section:disabled .sdn-icon--umgs,
-.sdn-item-section[aria-disabled="true"] .sdn-icon--umgs {
+.sdn-item-section:disabled .sdn-icon--0qvc,
+.sdn-item-section[aria-disabled="true"] .sdn-icon--0qvc {
   color: var(--sdn-swatch-gray);
 }
 
@@ -5421,13 +5456,13 @@ body {
   border: var(--hairline) solid var(--sdn-hc-on-offWhite);
 }
 
-.sdn-item-section:disabled .sdn-input--shhi,
-.sdn-item-section[aria-disabled="true"] .sdn-input--shhi {
+.sdn-item-section:disabled .sdn-icon--umgs,
+.sdn-item-section[aria-disabled="true"] .sdn-icon--umgs {
   color: var(--sdn-swatch-gray);
 }
 
-.sdn-item-section:disabled .sdn-icon--0qvc,
-.sdn-item-section[aria-disabled="true"] .sdn-icon--0qvc {
+.sdn-item-section:disabled .sdn-input--shhi,
+.sdn-item-section[aria-disabled="true"] .sdn-input--shhi {
   color: var(--sdn-swatch-gray);
 }
 
@@ -5454,7 +5489,7 @@ body {
   );
 }
 
-.sdn-item-section[aria-invalid="true"] .sdn-icon--umgs {
+.sdn-item-section[aria-invalid="true"] .sdn-icon--0qvc {
   color: var(--sdn-swatch-negative);
 }
 
@@ -5472,13 +5507,13 @@ body {
     color-mix(in srgb, var(--sdn-hc-on-offWhite) 50%, transparent);
 }
 
+.sdn-item-section[aria-invalid="true"] .sdn-icon--umgs {
+  color: var(--sdn-swatch-negative);
+}
+
 .sdn-item-section[aria-invalid="true"] .sdn-input--shhi {
   color: var(--sdn-swatch-negative);
   border-color: var(--sdn-swatch-negative);
-}
-
-.sdn-item-section[aria-invalid="true"] .sdn-icon--0qvc {
-  color: var(--sdn-swatch-negative);
 }
 
 .sdn-item-section[aria-invalid="true"] .sdn-text-label--z34z {
@@ -5491,7 +5526,7 @@ body {
     color-mix(in srgb, var(--sdn-swatch-active) 80%, transparent);
 }
 
-.sdn-item-section.sdn-state-activated .sdn-icon--umgs {
+.sdn-item-section.sdn-state-activated .sdn-icon--0qvc {
   color: var(--sdn-swatch-active);
 }
 
@@ -5500,13 +5535,13 @@ body {
   border: var(--hairline) solid var(--sdn-hc-on-offWhite);
 }
 
+.sdn-item-section.sdn-state-activated .sdn-icon--umgs {
+  color: var(--sdn-swatch-active);
+}
+
 .sdn-item-section.sdn-state-activated .sdn-input--shhi {
   color: var(--sdn-swatch-active);
   border-color: var(--sdn-swatch-primary);
-}
-
-.sdn-item-section.sdn-state-activated .sdn-icon--0qvc {
-  color: var(--sdn-swatch-active);
 }
 
 .sdn-item-section.sdn-state-activated .sdn-text-label--z34z {
@@ -5521,7 +5556,7 @@ body {
   );
 }
 
-.sdn-item-section:hover .sdn-icon--umgs {
+.sdn-item-section:hover .sdn-icon--0qvc {
   opacity: 0.8;
 }
 
@@ -5529,11 +5564,11 @@ body {
   border: var(--hairline) solid var(--sdn-swatch-primary-b60);
 }
 
-.sdn-item-section:hover .sdn-input--shhi {
+.sdn-item-section:hover .sdn-icon--umgs {
   opacity: 0.8;
 }
 
-.sdn-item-section:hover .sdn-icon--0qvc {
+.sdn-item-section:hover .sdn-input--shhi {
   opacity: 0.8;
 }
 
@@ -5549,7 +5584,7 @@ body {
   );
 }
 
-.sdn-item-section:active .sdn-icon--umgs {
+.sdn-item-section:active .sdn-icon--0qvc {
   opacity: 0.6;
 }
 
@@ -5558,11 +5593,11 @@ body {
     color-mix(in srgb, var(--sdn-swatch-primary) 40%, transparent);
 }
 
-.sdn-item-section:active .sdn-input--shhi {
+.sdn-item-section:active .sdn-icon--umgs {
   opacity: 0.6;
 }
 
-.sdn-item-section:active .sdn-icon--0qvc {
+.sdn-item-section:active .sdn-input--shhi {
   opacity: 0.6;
 }
 
@@ -5574,7 +5609,7 @@ body {
   background-color: var(--sdn-swatch-primary-bn20);
 }
 
-.sdn-item-section.sdn-state-dragged .sdn-icon--umgs {
+.sdn-item-section.sdn-state-dragged .sdn-icon--0qvc {
   color: var(--sdn-hc-on-primary-bn20);
 }
 
@@ -5583,11 +5618,11 @@ body {
   border: var(--hairline) solid var(--sdn-swatch-primary-bn20);
 }
 
-.sdn-item-section.sdn-state-dragged .sdn-input--shhi {
+.sdn-item-section.sdn-state-dragged .sdn-icon--umgs {
   color: var(--sdn-hc-on-primary-bn20);
 }
 
-.sdn-item-section.sdn-state-dragged .sdn-icon--0qvc {
+.sdn-item-section.sdn-state-dragged .sdn-input--shhi {
   color: var(--sdn-hc-on-primary-bn20);
 }
 

--- a/packages/editor/seldon/styles.css
+++ b/packages/editor/seldon/styles.css
@@ -1071,7 +1071,7 @@ body {
   margin-top: 0;
   margin-bottom: 0;
   padding-top: 0;
-  padding-inline-end: 0;
+  padding-inline-end: var(--sdn-paddings-tight);
   padding-bottom: 0;
   padding-inline-start: var(--sdn-paddings-tight);
   align-self: stretch;
@@ -2016,6 +2016,10 @@ body {
   padding: var(--sdn-paddings-compact);
 }
 
+.sdn-bar-buttons--ftcm {
+  border-radius: 0px;
+}
+
 .sdn-bar-buttons--ymyq {
   border-radius: unset;
   border-top-right-radius: 0px;
@@ -2306,6 +2310,10 @@ body {
   border: var(--hairline) solid var(--sdn-hc-on-primary);
 }
 
+.sdn-combobox-field-project--rzdy {
+  gap: var(--sdn-gaps-cozy);
+}
+
 .sdn-combobox-field-search--9jd5 {
   align-self: unset;
   flex-shrink: unset;
@@ -2540,15 +2548,7 @@ body {
 .sdn-frame--enpy {
   overflow-x: hidden;
   overflow-y: auto;
-  flex-wrap: wrap;
-  min-height: 0;
-  padding: 0;
-  margin: 0;
-}
-
-.sdn-frame--evmw {
-  overflow-x: hidden;
-  overflow-y: auto;
+  overflow: hidden;
   min-height: 0;
   padding: 0;
   margin: 0;
@@ -2635,6 +2635,28 @@ body {
   margin-top: var(--sdn-margins-cozy);
   height: fit-content;
   flex-shrink: 0;
+}
+
+.sdn-frame--ma6i {
+  align-self: unset;
+  flex: unset;
+  border-left-width: var(--hairline);
+  border-left-style: solid;
+  border-left-color: color-mix(
+    in srgb,
+    var(--sdn-swatch-primary) 50%,
+    transparent
+  );
+  flex-direction: row;
+  gap: var(--sdn-gaps-tight);
+  padding-top: 0;
+  padding-inline-end: 0;
+  padding-bottom: 0;
+  padding-inline-start: var(--sdn-paddings-cozy);
+  width: fit-content;
+  flex-shrink: 0;
+  height: 100%;
+  margin: 0;
 }
 
 .sdn-frame--mclm {

--- a/packages/editor/seldon/styles.css
+++ b/packages/editor/seldon/styles.css
@@ -2169,6 +2169,10 @@ body {
   min-width: 0;
 }
 
+.sdn-button-menu--t1a2 {
+  width: 30%;
+}
+
 .sdn-button-simple--dbgs {
   background-color: var(--sdn-swatch-offWhite);
   padding-top: var(--sdn-paddings-tight);
@@ -2824,6 +2828,21 @@ body {
   gap: var(--sdn-gaps-comfortable);
   height: fit-content;
   min-width: 0;
+}
+
+.sdn-frame--uief {
+  flex: unset;
+  flex-direction: row;
+  align-items: center;
+  justify-content: end;
+  gap: var(--sdn-gaps-compact);
+  padding-top: 0;
+  padding-inline-end: var(--sdn-paddings-tight);
+  padding-bottom: 0;
+  padding-inline-start: var(--sdn-paddings-tight);
+  height: fit-content;
+  flex-shrink: 0;
+  margin: 0;
 }
 
 .sdn-frame--vorn {

--- a/packages/editor/seldon/styles.css
+++ b/packages/editor/seldon/styles.css
@@ -570,7 +570,7 @@ body {
 }
 
 .sdn-button-toggle {
-  background-color: var(--sdn-swatch-primary-b75);
+  background-color: var(--sdn-swatch-offWhite);
   cursor: pointer;
   display: flex;
   flex-direction: row;
@@ -583,7 +583,7 @@ body {
   font-size: var(--sdn-font-size-medium);
   padding: var(--sdn-paddings-tight);
   border-radius: 99999px;
-  border: var(--hairline) solid var(--sdn-swatch-primary);
+  border: var(--hairline) solid var(--sdn-swatch-offBlack);
 }
 
 .sdn-button-tools {
@@ -2947,11 +2947,6 @@ body {
 .sdn-icon--nlt7 {
   font-size: var(--sdn-cmp-auto-fit-font-size-medium);
   color: var(--sdn-hc-on-white);
-}
-
-.sdn-icon--ovkd {
-  font-size: var(--sdn-cmp-auto-fit-font-size-medium);
-  color: var(--sdn-hc-on-primary-b75);
 }
 
 .sdn-icon--pbp5 {
@@ -6295,22 +6290,22 @@ body {
 .sdn-button-toggle:has(:focus-visible) {
   background-color: color-mix(
     in srgb,
-    var(--sdn-swatch-punch-b75) 20%,
+    var(--sdn-swatch-punch) 20%,
     transparent
   );
   border: var(--hairline) solid var(--sdn-swatch-punch);
 }
 
-.sdn-button-toggle:focus-visible .sdn-icon--ovkd,
-.sdn-button-toggle:has(:focus-visible) .sdn-icon--ovkd {
+.sdn-button-toggle:focus-visible .sdn-icon--vsau,
+.sdn-button-toggle:has(:focus-visible) .sdn-icon--vsau {
   color: var(--sdn-swatch-punch);
 }
 
 .sdn-button-toggle[aria-selected="true"] {
-  background-color: var(--sdn-swatch-offWhite-b75);
+  border: var(--hairline) solid var(--sdn-swatch-primary);
 }
 
-.sdn-button-toggle[aria-selected="true"] .sdn-icon--ovkd {
+.sdn-button-toggle[aria-selected="true"] .sdn-icon--vsau {
   color: var(--sdn-swatch-active);
 }
 
@@ -6320,66 +6315,60 @@ body {
   border: var(--hairline) solid var(--sdn-swatch-gray);
 }
 
-.sdn-button-toggle:disabled .sdn-icon--ovkd,
-.sdn-button-toggle[aria-disabled="true"] .sdn-icon--ovkd {
+.sdn-button-toggle:disabled .sdn-icon--vsau,
+.sdn-button-toggle[aria-disabled="true"] .sdn-icon--vsau {
   color: var(--sdn-swatch-gray);
 }
 
 .sdn-button-toggle[aria-invalid="true"] {
   background-color: color-mix(
     in srgb,
-    var(--sdn-swatch-negative-b75) 20%,
+    var(--sdn-swatch-negative) 20%,
     transparent
   );
   border: var(--hairline) solid var(--sdn-swatch-negative);
 }
 
-.sdn-button-toggle[aria-invalid="true"] .sdn-icon--ovkd {
+.sdn-button-toggle[aria-invalid="true"] .sdn-icon--vsau {
   color: var(--sdn-swatch-negative);
 }
 
 .sdn-button-toggle.sdn-state-activated {
-  background-color: var(--sdn-swatch-offWhite);
+  border: var(--hairline) solid var(--sdn-swatch-primary);
 }
 
-.sdn-button-toggle.sdn-state-activated .sdn-icon--ovkd {
+.sdn-button-toggle.sdn-state-activated .sdn-icon--vsau {
   color: var(--sdn-swatch-active);
 }
 
 .sdn-button-toggle:hover {
   background-color: color-mix(
     in srgb,
-    var(--sdn-swatch-primary-b75) 20%,
+    var(--sdn-swatch-offWhite) 80%,
     transparent
   );
-  border: var(--hairline) solid
-    color-mix(in srgb, var(--sdn-swatch-primary) 80%, transparent);
 }
 
-.sdn-button-toggle:hover .sdn-icon--ovkd {
+.sdn-button-toggle:hover .sdn-icon--vsau {
   opacity: 0.8;
-  color: var(--sdn-hc-on-offWhite);
 }
 
 .sdn-button-toggle:active {
   background-color: color-mix(
     in srgb,
-    var(--sdn-swatch-primary-b75) 40%,
+    var(--sdn-swatch-offWhite) 60%,
     transparent
   );
-  border: var(--hairline) solid
-    color-mix(in srgb, var(--sdn-swatch-primary) 60%, transparent);
 }
 
-.sdn-button-toggle:active .sdn-icon--ovkd {
+.sdn-button-toggle:active .sdn-icon--vsau {
   opacity: 0.6;
-  color: var(--sdn-hc-on-offWhite);
 }
 
 .sdn-button-toggle.sdn-state-dragged {
   background-color: var(--sdn-swatch-primary-bn20);
 }
 
-.sdn-button-toggle.sdn-state-dragged .sdn-icon--ovkd {
+.sdn-button-toggle.sdn-state-dragged .sdn-icon--vsau {
   color: var(--sdn-hc-on-primary-bn20);
 }

--- a/packages/editor/seldon/styles/adobe-spectrum.css
+++ b/packages/editor/seldon/styles/adobe-spectrum.css
@@ -73,9 +73,6 @@
   --sdn-swatch-punch-b50: hsl(326 59% 74.5%);
   --sdn-swatch-negative-b50: hsl(356 63% 74.5%);
   --sdn-swatch-swatch4-bn20: hsl(210 85% 86.4%);
-  --sdn-swatch-punch-b75: hsl(326 59% 87.25%);
-  --sdn-swatch-offWhite-b75: hsl(210 10% 99.25%);
-  --sdn-swatch-negative-b75: hsl(356 63% 87.25%);
   --sdn-swatch-gray-b50: hsl(210 4% 78%);
   /* Sizes */
   --sdn-sizes-tiny: 0.183rem;
@@ -182,9 +179,6 @@
   --sdn-hc-on-punch-b50: hsl(210 4% 12%);
   --sdn-hc-on-negative-b50: hsl(210 4% 12%);
   --sdn-hc-on-swatch4-bn20: hsl(210 4% 12%);
-  --sdn-hc-on-punch-b75: hsl(210 4% 12%);
-  --sdn-hc-on-offWhite-b75: hsl(210 4% 12%);
-  --sdn-hc-on-negative-b75: hsl(210 4% 12%);
   --sdn-hc-on-gray-b50: hsl(210 4% 12%);
   /* Auto Fit */
   --sdn-cmp-auto-fit-font-size-tiny: 0.454rem;
@@ -274,9 +268,6 @@
   --sdn-swatch-punch-b50: hsl(328 57% 77.5%);
   --sdn-swatch-negative-b50: hsl(360 61% 78%);
   --sdn-swatch-swatch4-bn20: hsl(240 0% 80%);
-  --sdn-swatch-punch-b75: hsl(328 57% 88.75%);
-  --sdn-swatch-offWhite-b75: hsl(0 0% 78.75%);
-  --sdn-swatch-negative-b75: hsl(360 61% 89%);
   --sdn-swatch-gray-b50: hsl(210 4% 69%);
   /* High Contrast */
   --sdn-hc-on-white: hsl(210 4% 98%);
@@ -315,8 +306,5 @@
   --sdn-hc-on-punch-b50: hsl(210 4% 12%);
   --sdn-hc-on-negative-b50: hsl(210 4% 12%);
   --sdn-hc-on-swatch4-bn20: hsl(210 4% 12%);
-  --sdn-hc-on-punch-b75: hsl(210 4% 12%);
-  --sdn-hc-on-offWhite-b75: hsl(210 4% 12%);
-  --sdn-hc-on-negative-b75: hsl(210 4% 12%);
   --sdn-hc-on-gray-b50: hsl(210 4% 12%);
 }

--- a/packages/editor/seldon/styles/earth.css
+++ b/packages/editor/seldon/styles/earth.css
@@ -76,9 +76,6 @@
   --sdn-swatch-punch-b50: hsl(95 23% 69.5%);
   --sdn-swatch-negative-b50: hsl(352 94% 72%);
   --sdn-swatch-swatch4-bn20: hsl(358 55% 37.6%);
-  --sdn-swatch-punch-b75: hsl(95 23% 84.75%);
-  --sdn-swatch-offWhite-b75: hsl(36 30% 99%);
-  --sdn-swatch-negative-b75: hsl(352 94% 86%);
   --sdn-swatch-gray-b50: hsl(16 12% 78%);
   /* Sizes */
   --sdn-sizes-tiny: 0.069rem;
@@ -185,9 +182,6 @@
   --sdn-hc-on-punch-b50: hsl(16 12% 8%);
   --sdn-hc-on-negative-b50: hsl(16 12% 98%);
   --sdn-hc-on-swatch4-bn20: hsl(16 12% 98%);
-  --sdn-hc-on-punch-b75: hsl(16 12% 8%);
-  --sdn-hc-on-offWhite-b75: hsl(16 12% 8%);
-  --sdn-hc-on-negative-b75: hsl(16 12% 8%);
   --sdn-hc-on-gray-b50: hsl(16 12% 8%);
   /* Auto Fit */
   --sdn-cmp-auto-fit-font-size-tiny: 0.327rem;
@@ -280,9 +274,6 @@
   --sdn-swatch-punch-b50: hsl(95 20% 71.5%);
   --sdn-swatch-negative-b50: hsl(359 76% 76.5%);
   --sdn-swatch-swatch4-bn20: hsl(360 51% 41.6%);
-  --sdn-swatch-punch-b75: hsl(95 20% 85.75%);
-  --sdn-swatch-offWhite-b75: hsl(24 18% 79%);
-  --sdn-swatch-negative-b75: hsl(359 76% 88.25%);
   --sdn-swatch-gray-b50: hsl(16 12% 69.5%);
   /* High Contrast */
   --sdn-hc-on-white: hsl(16 12% 98%);
@@ -321,8 +312,5 @@
   --sdn-hc-on-punch-b50: hsl(16 12% 8%);
   --sdn-hc-on-negative-b50: hsl(16 12% 8%);
   --sdn-hc-on-swatch4-bn20: hsl(16 12% 98%);
-  --sdn-hc-on-punch-b75: hsl(16 12% 8%);
-  --sdn-hc-on-offWhite-b75: hsl(16 12% 8%);
-  --sdn-hc-on-negative-b75: hsl(16 12% 8%);
   --sdn-hc-on-gray-b50: hsl(16 12% 8%);
 }

--- a/packages/editor/seldon/styles/google-material.css
+++ b/packages/editor/seldon/styles/google-material.css
@@ -75,9 +75,6 @@
   --sdn-swatch-punch-b50: hsl(25 68% 75.5%);
   --sdn-swatch-negative-b50: hsl(2 74% 69.5%);
   --sdn-swatch-swatch4-bn20: hsl(256 37% 68.8%);
-  --sdn-swatch-punch-b75: hsl(25 68% 87.75%);
-  --sdn-swatch-offWhite-b75: hsl(260 8% 99%);
-  --sdn-swatch-negative-b75: hsl(2 74% 84.75%);
   --sdn-swatch-gray-b50: hsl(256 10% 73.5%);
   /* Sizes */
   --sdn-sizes-tiny: 0.125rem;
@@ -184,9 +181,6 @@
   --sdn-hc-on-punch-b50: hsl(256 10% 1%);
   --sdn-hc-on-negative-b50: hsl(256 10% 100%);
   --sdn-hc-on-swatch4-bn20: hsl(256 10% 100%);
-  --sdn-hc-on-punch-b75: hsl(256 10% 1%);
-  --sdn-hc-on-offWhite-b75: hsl(256 10% 1%);
-  --sdn-hc-on-negative-b75: hsl(256 10% 1%);
   --sdn-hc-on-gray-b50: hsl(256 10% 1%);
   /* Auto Fit */
   --sdn-cmp-auto-fit-font-size-tiny: 0.4rem;
@@ -278,9 +272,6 @@
   --sdn-swatch-punch-b50: hsl(24 74% 79.5%);
   --sdn-swatch-negative-b50: hsl(6 60% 72.5%);
   --sdn-swatch-swatch4-bn20: hsl(256 61% 73.6%);
-  --sdn-swatch-punch-b75: hsl(24 74% 89.75%);
-  --sdn-swatch-offWhite-b75: hsl(260 10% 78%);
-  --sdn-swatch-negative-b75: hsl(6 60% 86.25%);
   --sdn-swatch-gray-b50: hsl(256 10% 76.5%);
   /* High Contrast */
   --sdn-hc-on-white: hsl(256 10% 100%);
@@ -319,8 +310,5 @@
   --sdn-hc-on-punch-b50: hsl(256 10% 1%);
   --sdn-hc-on-negative-b50: hsl(256 10% 1%);
   --sdn-hc-on-swatch4-bn20: hsl(256 10% 100%);
-  --sdn-hc-on-punch-b75: hsl(256 10% 1%);
-  --sdn-hc-on-offWhite-b75: hsl(256 10% 1%);
-  --sdn-hc-on-negative-b75: hsl(256 10% 1%);
   --sdn-hc-on-gray-b50: hsl(256 10% 1%);
 }

--- a/packages/editor/seldon/styles/high-contrast.css
+++ b/packages/editor/seldon/styles/high-contrast.css
@@ -73,9 +73,6 @@
   --sdn-swatch-punch-b50: hsl(20 95% 80%);
   --sdn-swatch-negative-b50: hsl(0 100% 82.5%);
   --sdn-swatch-swatch4-bn20: hsl(0 0% 64%);
-  --sdn-swatch-punch-b75: hsl(20 95% 90%);
-  --sdn-swatch-offWhite-b75: hsl(0 0% 99%);
-  --sdn-swatch-negative-b75: hsl(0 100% 91.25%);
   --sdn-swatch-gray-b50: hsl(0 0% 75%);
   /* Sizes */
   --sdn-sizes-tiny: 0.125rem;
@@ -182,9 +179,6 @@
   --sdn-hc-on-punch-b50: hsl(0 0% 0%);
   --sdn-hc-on-negative-b50: hsl(0 0% 0%);
   --sdn-hc-on-swatch4-bn20: hsl(0 0% 100%);
-  --sdn-hc-on-punch-b75: hsl(0 0% 0%);
-  --sdn-hc-on-offWhite-b75: hsl(0 0% 0%);
-  --sdn-hc-on-negative-b75: hsl(0 0% 0%);
   --sdn-hc-on-gray-b50: hsl(0 0% 0%);
   /* Auto Fit */
   --sdn-cmp-auto-fit-font-size-tiny: 0.4rem;
@@ -274,9 +268,6 @@
   --sdn-swatch-punch-b50: hsl(20 100% 82.5%);
   --sdn-swatch-negative-b50: hsl(3 100% 84.5%);
   --sdn-swatch-swatch4-bn20: hsl(156 0% 67.2%);
-  --sdn-swatch-punch-b75: hsl(20 100% 91.25%);
-  --sdn-swatch-offWhite-b75: hsl(0 0% 78.75%);
-  --sdn-swatch-negative-b75: hsl(3 100% 92.25%);
   --sdn-swatch-gray-b50: hsl(160 0% 71.5%);
   /* High Contrast */
   --sdn-hc-on-white: hsl(0 0% 100%);
@@ -315,8 +306,5 @@
   --sdn-hc-on-punch-b50: hsl(0 0% 0%);
   --sdn-hc-on-negative-b50: hsl(0 0% 0%);
   --sdn-hc-on-swatch4-bn20: hsl(0 0% 0%);
-  --sdn-hc-on-punch-b75: hsl(0 0% 0%);
-  --sdn-hc-on-offWhite-b75: hsl(0 0% 0%);
-  --sdn-hc-on-negative-b75: hsl(0 0% 0%);
   --sdn-hc-on-gray-b50: hsl(0 0% 0%);
 }

--- a/packages/editor/seldon/styles/ibm-carbon.css
+++ b/packages/editor/seldon/styles/ibm-carbon.css
@@ -73,9 +73,6 @@
   --sdn-swatch-punch-b50: hsl(202 100% 72%);
   --sdn-swatch-negative-b50: hsl(354 89% 72%);
   --sdn-swatch-swatch4-bn20: hsl(38 100% 70.4%);
-  --sdn-swatch-punch-b75: hsl(202 100% 86%);
-  --sdn-swatch-offWhite-b75: hsl(0 0% 99%);
-  --sdn-swatch-negative-b75: hsl(354 89% 86%);
   --sdn-swatch-gray-b50: hsl(218 12% 78%);
   /* Sizes */
   --sdn-sizes-tiny: 0.183rem;
@@ -182,9 +179,6 @@
   --sdn-hc-on-punch-b50: hsl(218 12% 8%);
   --sdn-hc-on-negative-b50: hsl(218 12% 98%);
   --sdn-hc-on-swatch4-bn20: hsl(218 12% 8%);
-  --sdn-hc-on-punch-b75: hsl(218 12% 8%);
-  --sdn-hc-on-offWhite-b75: hsl(218 12% 8%);
-  --sdn-hc-on-negative-b75: hsl(218 12% 8%);
   --sdn-hc-on-gray-b50: hsl(218 12% 8%);
   /* Auto Fit */
   --sdn-cmp-auto-fit-font-size-tiny: 0.454rem;
@@ -274,9 +268,6 @@
   --sdn-swatch-punch-b50: hsl(207 83% 79.5%);
   --sdn-swatch-negative-b50: hsl(1 76% 77%);
   --sdn-swatch-swatch4-bn20: hsl(36 96% 79.2%);
-  --sdn-swatch-punch-b75: hsl(207 83% 89.75%);
-  --sdn-swatch-offWhite-b75: hsl(0 0% 78.25%);
-  --sdn-swatch-negative-b75: hsl(1 76% 88.5%);
   --sdn-swatch-gray-b50: hsl(218 12% 70.5%);
   /* High Contrast */
   --sdn-hc-on-white: hsl(218 12% 98%);
@@ -315,8 +306,5 @@
   --sdn-hc-on-punch-b50: hsl(218 12% 8%);
   --sdn-hc-on-negative-b50: hsl(218 12% 98%);
   --sdn-hc-on-swatch4-bn20: hsl(218 12% 8%);
-  --sdn-hc-on-punch-b75: hsl(218 12% 8%);
-  --sdn-hc-on-offWhite-b75: hsl(218 12% 8%);
-  --sdn-hc-on-negative-b75: hsl(218 12% 8%);
   --sdn-hc-on-gray-b50: hsl(218 12% 98%);
 }

--- a/packages/editor/seldon/styles/industrial.css
+++ b/packages/editor/seldon/styles/industrial.css
@@ -73,9 +73,6 @@
   --sdn-swatch-punch-b50: hsl(151 92% 71%);
   --sdn-swatch-negative-b50: hsl(356 80% 75.5%);
   --sdn-swatch-swatch4-bn20: hsl(186 34% 57.6%);
-  --sdn-swatch-punch-b75: hsl(151 92% 85.5%);
-  --sdn-swatch-offWhite-b75: hsl(188 30% 77.5%);
-  --sdn-swatch-negative-b75: hsl(356 80% 87.75%);
   --sdn-swatch-gray-b50: hsl(186 40% 80%);
   /* Sizes */
   --sdn-sizes-tiny: 0.125rem;
@@ -182,9 +179,6 @@
   --sdn-hc-on-punch-b50: hsl(186 40% 20%);
   --sdn-hc-on-negative-b50: hsl(186 40% 20%);
   --sdn-hc-on-swatch4-bn20: hsl(186 40% 20%);
-  --sdn-hc-on-punch-b75: hsl(186 40% 20%);
-  --sdn-hc-on-offWhite-b75: hsl(186 40% 20%);
-  --sdn-hc-on-negative-b75: hsl(186 40% 20%);
   --sdn-hc-on-gray-b50: hsl(186 40% 20%);
   /* Auto Fit */
   --sdn-cmp-auto-fit-font-size-tiny: 0.4rem;
@@ -274,9 +268,6 @@
   --sdn-swatch-punch-b50: hsl(152 99% 69%);
   --sdn-swatch-negative-b50: hsl(351 100% 71%);
   --sdn-swatch-swatch4-bn20: hsl(186 31% 52.8%);
-  --sdn-swatch-punch-b75: hsl(152 99% 84.5%);
-  --sdn-swatch-offWhite-b75: hsl(186 22% 98.5%);
-  --sdn-swatch-negative-b75: hsl(351 100% 85.5%);
   --sdn-swatch-gray-b50: hsl(185 100% 58.5%);
   /* High Contrast */
   --sdn-hc-on-white: hsl(186 40% 20%);
@@ -315,8 +306,5 @@
   --sdn-hc-on-punch-b50: hsl(186 40% 20%);
   --sdn-hc-on-negative-b50: hsl(186 40% 90%);
   --sdn-hc-on-swatch4-bn20: hsl(186 40% 90%);
-  --sdn-hc-on-punch-b75: hsl(186 40% 20%);
-  --sdn-hc-on-offWhite-b75: hsl(186 40% 20%);
-  --sdn-hc-on-negative-b75: hsl(186 40% 20%);
   --sdn-hc-on-gray-b50: hsl(186 40% 20%);
 }

--- a/packages/editor/seldon/styles/pop-punk.css
+++ b/packages/editor/seldon/styles/pop-punk.css
@@ -73,9 +73,6 @@
   --sdn-swatch-punch-b50: hsl(170 100% 69.5%);
   --sdn-swatch-negative-b50: hsl(355 100% 73%);
   --sdn-swatch-swatch4-bn20: hsl(140 68% 56%);
-  --sdn-swatch-punch-b75: hsl(170 100% 84.75%);
-  --sdn-swatch-offWhite-b75: hsl(345 25% 99.25%);
-  --sdn-swatch-negative-b75: hsl(355 100% 86.5%);
   --sdn-swatch-gray-b50: hsl(344 12% 78%);
   /* Sizes */
   --sdn-sizes-tiny: 0.069rem;
@@ -182,9 +179,6 @@
   --sdn-hc-on-punch-b50: hsl(344 12% 8%);
   --sdn-hc-on-negative-b50: hsl(344 12% 98%);
   --sdn-hc-on-swatch4-bn20: hsl(344 12% 8%);
-  --sdn-hc-on-punch-b75: hsl(344 12% 8%);
-  --sdn-hc-on-offWhite-b75: hsl(344 12% 8%);
-  --sdn-hc-on-negative-b75: hsl(344 12% 8%);
   --sdn-hc-on-gray-b50: hsl(344 12% 8%);
   /* Auto Fit */
   --sdn-cmp-auto-fit-font-size-tiny: 0.327rem;
@@ -274,9 +268,6 @@
   --sdn-swatch-punch-b50: hsl(167 61% 78%);
   --sdn-swatch-negative-b50: hsl(5 88% 78%);
   --sdn-swatch-swatch4-bn20: hsl(139 80% 61.6%);
-  --sdn-swatch-punch-b75: hsl(167 61% 89%);
-  --sdn-swatch-offWhite-b75: hsl(345 8% 78%);
-  --sdn-swatch-negative-b75: hsl(5 88% 89%);
   --sdn-swatch-gray-b50: hsl(344 12% 71%);
   /* High Contrast */
   --sdn-hc-on-white: hsl(344 12% 98%);
@@ -315,8 +306,5 @@
   --sdn-hc-on-punch-b50: hsl(344 12% 8%);
   --sdn-hc-on-negative-b50: hsl(344 12% 8%);
   --sdn-hc-on-swatch4-bn20: hsl(344 12% 8%);
-  --sdn-hc-on-punch-b75: hsl(344 12% 8%);
-  --sdn-hc-on-offWhite-b75: hsl(344 12% 8%);
-  --sdn-hc-on-negative-b75: hsl(344 12% 8%);
   --sdn-hc-on-gray-b50: hsl(344 12% 8%);
 }

--- a/packages/editor/seldon/styles/seldon.css
+++ b/packages/editor/seldon/styles/seldon.css
@@ -73,9 +73,6 @@
   --sdn-swatch-punch-b50: hsl(20 84% 78%);
   --sdn-swatch-negative-b50: hsl(359 89% 80.5%);
   --sdn-swatch-swatch4-bn20: hsl(202 89% 63.2%);
-  --sdn-swatch-punch-b75: hsl(20 84% 89%);
-  --sdn-swatch-offWhite-b75: hsl(0 0% 99%);
-  --sdn-swatch-negative-b75: hsl(359 89% 90.25%);
   --sdn-swatch-gray-b50: hsl(202 0% 75%);
   /* Sizes */
   --sdn-sizes-tiny: 0.125rem;
@@ -182,9 +179,6 @@
   --sdn-hc-on-punch-b50: hsl(202 0% 8%);
   --sdn-hc-on-negative-b50: hsl(202 0% 8%);
   --sdn-hc-on-swatch4-bn20: hsl(202 0% 8%);
-  --sdn-hc-on-punch-b75: hsl(202 0% 8%);
-  --sdn-hc-on-offWhite-b75: hsl(202 0% 8%);
-  --sdn-hc-on-negative-b75: hsl(202 0% 8%);
   --sdn-hc-on-gray-b50: hsl(202 0% 8%);
   /* Auto Fit */
   --sdn-cmp-auto-fit-font-size-tiny: 0.4rem;
@@ -275,9 +269,6 @@
   --sdn-swatch-punch-b50: hsl(20 100% 80.5%);
   --sdn-swatch-negative-b50: hsl(1 100% 83.5%);
   --sdn-swatch-swatch4-bn20: hsl(203 99% 68%);
-  --sdn-swatch-punch-b75: hsl(20 100% 90.25%);
-  --sdn-swatch-offWhite-b75: hsl(0 0% 78.75%);
-  --sdn-swatch-negative-b75: hsl(1 100% 91.75%);
   --sdn-swatch-gray-b50: hsl(160 0% 71.5%);
   /* High Contrast */
   --sdn-hc-on-white: hsl(202 0% 98%);
@@ -316,8 +307,5 @@
   --sdn-hc-on-punch-b50: hsl(202 0% 8%);
   --sdn-hc-on-negative-b50: hsl(202 0% 8%);
   --sdn-hc-on-swatch4-bn20: hsl(202 0% 8%);
-  --sdn-hc-on-punch-b75: hsl(202 0% 8%);
-  --sdn-hc-on-offWhite-b75: hsl(202 0% 8%);
-  --sdn-hc-on-negative-b75: hsl(202 0% 8%);
   --sdn-hc-on-gray-b50: hsl(202 0% 8%);
 }

--- a/packages/editor/seldon/styles/sunset-blue.css
+++ b/packages/editor/seldon/styles/sunset-blue.css
@@ -73,9 +73,6 @@
   --sdn-swatch-punch-b50: hsl(10 79% 78%);
   --sdn-swatch-negative-b50: hsl(356 80% 76.5%);
   --sdn-swatch-swatch4-bn20: hsl(353 100% 45.6%);
-  --sdn-swatch-punch-b75: hsl(10 79% 89%);
-  --sdn-swatch-offWhite-b75: hsl(0 0% 98.25%);
-  --sdn-swatch-negative-b75: hsl(356 80% 88.25%);
   --sdn-swatch-gray-b50: hsl(198 12% 78%);
   /* Sizes */
   --sdn-sizes-tiny: 0.125rem;
@@ -182,9 +179,6 @@
   --sdn-hc-on-punch-b50: hsl(198 12% 8%);
   --sdn-hc-on-negative-b50: hsl(198 12% 98%);
   --sdn-hc-on-swatch4-bn20: hsl(198 12% 98%);
-  --sdn-hc-on-punch-b75: hsl(198 12% 8%);
-  --sdn-hc-on-offWhite-b75: hsl(198 12% 8%);
-  --sdn-hc-on-negative-b75: hsl(198 12% 8%);
   --sdn-hc-on-gray-b50: hsl(198 12% 8%);
   /* Auto Fit */
   --sdn-cmp-auto-fit-font-size-tiny: 0.4rem;
@@ -274,9 +268,6 @@
   --sdn-swatch-punch-b50: hsl(11 85% 80%);
   --sdn-swatch-negative-b50: hsl(359 85% 79.5%);
   --sdn-swatch-swatch4-bn20: hsl(359 100% 52%);
-  --sdn-swatch-punch-b75: hsl(11 85% 90%);
-  --sdn-swatch-offWhite-b75: hsl(210 28% 79%);
-  --sdn-swatch-negative-b75: hsl(359 85% 89.75%);
   --sdn-swatch-gray-b50: hsl(198 14% 68%);
   /* High Contrast */
   --sdn-hc-on-white: hsl(198 12% 98%);
@@ -315,8 +306,5 @@
   --sdn-hc-on-punch-b50: hsl(198 12% 8%);
   --sdn-hc-on-negative-b50: hsl(198 12% 98%);
   --sdn-hc-on-swatch4-bn20: hsl(198 12% 98%);
-  --sdn-hc-on-punch-b75: hsl(198 12% 8%);
-  --sdn-hc-on-offWhite-b75: hsl(198 12% 8%);
-  --sdn-hc-on-negative-b75: hsl(198 12% 8%);
   --sdn-hc-on-gray-b50: hsl(198 12% 98%);
 }

--- a/packages/editor/seldon/styles/wildberry.css
+++ b/packages/editor/seldon/styles/wildberry.css
@@ -73,9 +73,6 @@
   --sdn-swatch-punch-b50: hsl(185 100% 72%);
   --sdn-swatch-negative-b50: hsl(3 79% 78%);
   --sdn-swatch-swatch4-bn20: hsl(237 83% 45.6%);
-  --sdn-swatch-punch-b75: hsl(185 100% 86%);
-  --sdn-swatch-offWhite-b75: hsl(0 0% 98.25%);
-  --sdn-swatch-negative-b75: hsl(3 79% 89%);
   --sdn-swatch-gray-b50: hsl(327 12% 78%);
   /* Sizes */
   --sdn-sizes-tiny: 0.219rem;
@@ -182,9 +179,6 @@
   --sdn-hc-on-punch-b50: hsl(327 12% 8%);
   --sdn-hc-on-negative-b50: hsl(327 12% 98%);
   --sdn-hc-on-swatch4-bn20: hsl(327 12% 98%);
-  --sdn-hc-on-punch-b75: hsl(327 12% 8%);
-  --sdn-hc-on-offWhite-b75: hsl(327 12% 8%);
-  --sdn-hc-on-negative-b75: hsl(327 12% 8%);
   --sdn-hc-on-gray-b50: hsl(327 12% 8%);
   /* Auto Fit */
   --sdn-cmp-auto-fit-font-size-tiny: 0.51rem;
@@ -274,9 +268,6 @@
   --sdn-swatch-punch-b50: hsl(186 82% 79.5%);
   --sdn-swatch-negative-b50: hsl(5 88% 80.5%);
   --sdn-swatch-swatch4-bn20: hsl(242 88% 50.4%);
-  --sdn-swatch-punch-b75: hsl(186 82% 89.75%);
-  --sdn-swatch-offWhite-b75: hsl(0 0% 81.25%);
-  --sdn-swatch-negative-b75: hsl(5 88% 90.25%);
   --sdn-swatch-gray-b50: hsl(327 12% 71%);
   /* High Contrast */
   --sdn-hc-on-white: hsl(327 12% 98%);
@@ -315,8 +306,5 @@
   --sdn-hc-on-punch-b50: hsl(327 12% 8%);
   --sdn-hc-on-negative-b50: hsl(327 12% 8%);
   --sdn-hc-on-swatch4-bn20: hsl(327 12% 98%);
-  --sdn-hc-on-punch-b75: hsl(327 12% 8%);
-  --sdn-hc-on-offWhite-b75: hsl(327 12% 8%);
-  --sdn-hc-on-negative-b75: hsl(327 12% 8%);
   --sdn-hc-on-gray-b50: hsl(327 12% 98%);
 }

--- a/seldon-editor.json
+++ b/seldon-editor.json
@@ -1855,12 +1855,20 @@
                   "id": "component-item-pZCfJ3k6"
                 },
                 {
-                  "id": "component-item-CeZRPCDC",
+                  "id": "component-item-A2qQLKuh",
                   "children": [
                     {
-                      "id": "component-item-ZpsMrUME"
+                      "id": "component-item-vfutzRjn"
                     }
                   ]
+                }
+              ]
+            },
+            {
+              "id": "component-item-CeZRPCDC",
+              "children": [
+                {
+                  "id": "component-item-ZpsMrUME"
                 }
               ]
             }
@@ -3123,11 +3131,226 @@
                       "id": "component-comboboxField-iquyeQxk"
                     }
                   ]
+                },
+                {
+                  "id": "component-frame-mA6ivt6b",
+                  "children": [
+                    {
+                      "id": "component-button-f2yi4eeO",
+                      "children": [
+                        {
+                          "id": "component-button-4VOfbe9o"
+                        }
+                      ]
+                    },
+                    {
+                      "id": "component-sidebar-9VESc1Om",
+                      "children": [
+                        {
+                          "id": "component-sidebar-Zc8L5Z3e"
+                        }
+                      ]
+                    }
+                  ]
                 }
               ]
             },
             {
-              "id": "component-sidebar-ENPyLuzb"
+              "id": "component-sidebar-ENPyLuzb",
+              "children": [
+                {
+                  "id": "component-item-b1V5zHNC",
+                  "children": [
+                    {
+                      "id": "component-item-3uDeCFqI",
+                      "children": [
+                        {
+                          "id": "component-item-zkRTmMvs"
+                        }
+                      ]
+                    },
+                    {
+                      "id": "component-item-bZLp0uTX",
+                      "children": [
+                        {
+                          "id": "component-item-VlVrKVa9"
+                        },
+                        {
+                          "id": "component-item-evAOVW7m",
+                          "children": [
+                            {
+                              "id": "component-item-Ue5GakGO"
+                            },
+                            {
+                              "id": "component-item-bBB1bo4U"
+                            },
+                            {
+                              "id": "component-item-bD1t48vD",
+                              "children": [
+                                {
+                                  "id": "component-item-9iaYUrDq"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "id": "component-item-m0pKZcak",
+                      "children": [
+                        {
+                          "id": "component-item-RpGZs56q"
+                        }
+                      ]
+                    },
+                    {
+                      "id": "component-item-KZTQUWze",
+                      "children": [
+                        {
+                          "id": "component-item-9cFp2KiP"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "id": "component-item-v4KlFUSC",
+                  "children": [
+                    {
+                      "id": "component-item-bE0MzZf7",
+                      "children": [
+                        {
+                          "id": "component-item-aKs0x8nh"
+                        }
+                      ]
+                    },
+                    {
+                      "id": "component-item-kM0npFEE",
+                      "children": [
+                        {
+                          "id": "component-item-bzUsF0bh"
+                        },
+                        {
+                          "id": "component-item-MVKvGWgt"
+                        },
+                        {
+                          "id": "component-item-xtM8Jv36",
+                          "children": [
+                            {
+                              "id": "component-item-W8nnrW0C"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "id": "component-item-ef9iTpe3",
+                      "children": [
+                        {
+                          "id": "component-item-vHi7LWPt"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "id": "component-sidebar-JA0cb7AN",
+                  "children": [
+                    {
+                      "id": "component-sidebar-hwNZND96",
+                      "children": [
+                        {
+                          "id": "component-sidebar-6Cri5kRu"
+                        }
+                      ]
+                    },
+                    {
+                      "id": "component-sidebar-TfhOyss2",
+                      "children": [
+                        {
+                          "id": "component-sidebar-y4jZkllg"
+                        },
+                        {
+                          "id": "component-sidebar-WsWqzR44",
+                          "children": [
+                            {
+                              "id": "component-sidebar-z98EVoc0"
+                            },
+                            {
+                              "id": "component-sidebar-iW8WTAaz"
+                            },
+                            {
+                              "id": "component-sidebar-0hQiFwde",
+                              "children": [
+                                {
+                                  "id": "component-sidebar-zcujeg9q"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "id": "component-sidebar-S1S3FsY0",
+                      "children": [
+                        {
+                          "id": "component-sidebar-4YEPzpk0"
+                        }
+                      ]
+                    },
+                    {
+                      "id": "component-sidebar-WZRXutjM",
+                      "children": [
+                        {
+                          "id": "component-sidebar-czel5leu"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "id": "component-sidebar-MSYjRcHI",
+                  "children": [
+                    {
+                      "id": "component-sidebar-0balcrH4",
+                      "children": [
+                        {
+                          "id": "component-sidebar-69mi9aTF"
+                        }
+                      ]
+                    },
+                    {
+                      "id": "component-sidebar-EqUJmih2",
+                      "children": [
+                        {
+                          "id": "component-sidebar-37xyw8Qj"
+                        },
+                        {
+                          "id": "component-sidebar-hbiOoaHi"
+                        },
+                        {
+                          "id": "component-sidebar-tY21VVgA",
+                          "children": [
+                            {
+                              "id": "component-sidebar-08lOeHXm"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "id": "component-sidebar-R7vX91zP",
+                      "children": [
+                        {
+                          "id": "component-sidebar-GgC4jObF"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
             }
           ]
         },
@@ -3154,7 +3377,217 @@
               ]
             },
             {
-              "id": "component-sidebar-evMwxVOP"
+              "id": "component-sidebar-evMwxVOP",
+              "children": [
+                {
+                  "id": "component-item-B8RBVyHZ",
+                  "children": [
+                    {
+                      "id": "component-item-GkdUG8cw",
+                      "children": [
+                        {
+                          "id": "component-item-ojaLxpy0"
+                        }
+                      ]
+                    },
+                    {
+                      "id": "component-item-ZtCPosBL",
+                      "children": [
+                        {
+                          "id": "component-item-uwO2ynhb"
+                        },
+                        {
+                          "id": "component-item-oJ1gKB5O",
+                          "children": [
+                            {
+                              "id": "component-item-Y7FZOEsQ"
+                            },
+                            {
+                              "id": "component-item-taLEeaSp"
+                            },
+                            {
+                              "id": "component-item-5ZBBKqDF",
+                              "children": [
+                                {
+                                  "id": "component-item-LiVDdAqG"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "id": "component-item-naUTauiU",
+                      "children": [
+                        {
+                          "id": "component-item-s1trJIPc"
+                        }
+                      ]
+                    },
+                    {
+                      "id": "component-item-ifOuS9Th",
+                      "children": [
+                        {
+                          "id": "component-item-ocBfbzeB"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "id": "component-item-PGzJkIXO",
+                  "children": [
+                    {
+                      "id": "component-item-AbSWrsa8",
+                      "children": [
+                        {
+                          "id": "component-item-7hFHrht0"
+                        }
+                      ]
+                    },
+                    {
+                      "id": "component-item-e2HcTzxH",
+                      "children": [
+                        {
+                          "id": "component-item-THaHL5Id"
+                        },
+                        {
+                          "id": "component-item-5GirziHO",
+                          "children": [
+                            {
+                              "id": "component-item-1fM48fmG"
+                            },
+                            {
+                              "id": "component-item-GuDIdTRK"
+                            },
+                            {
+                              "id": "component-item-bpFUUbw3",
+                              "children": [
+                                {
+                                  "id": "component-item-5LMtRNu4"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "id": "component-item-p9tghfdO",
+                      "children": [
+                        {
+                          "id": "component-item-X7KjW3gx"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "id": "component-sidebar-Ej1nB3nm",
+                  "children": [
+                    {
+                      "id": "component-sidebar-w3EAGGeW",
+                      "children": [
+                        {
+                          "id": "component-sidebar-IsXAJFdJ"
+                        }
+                      ]
+                    },
+                    {
+                      "id": "component-sidebar-tcOK33bA",
+                      "children": [
+                        {
+                          "id": "component-sidebar-FMmaFaBm"
+                        },
+                        {
+                          "id": "component-sidebar-I74OjlO5",
+                          "children": [
+                            {
+                              "id": "component-sidebar-SS58OWpc"
+                            },
+                            {
+                              "id": "component-sidebar-uOs5RF1O"
+                            },
+                            {
+                              "id": "component-sidebar-1IoVBMtD",
+                              "children": [
+                                {
+                                  "id": "component-sidebar-bH9rtwWa"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "id": "component-sidebar-zYmKyfaj",
+                      "children": [
+                        {
+                          "id": "component-sidebar-qPXJqbrj"
+                        }
+                      ]
+                    },
+                    {
+                      "id": "component-sidebar-0W83UcNy",
+                      "children": [
+                        {
+                          "id": "component-sidebar-XLIbzniE"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "id": "component-sidebar-fP36DXiy",
+                  "children": [
+                    {
+                      "id": "component-sidebar-8ASr8hZB",
+                      "children": [
+                        {
+                          "id": "component-sidebar-6OwIYgWt"
+                        }
+                      ]
+                    },
+                    {
+                      "id": "component-sidebar-q2ZtEoiP",
+                      "children": [
+                        {
+                          "id": "component-sidebar-jnn1KpAH"
+                        },
+                        {
+                          "id": "component-sidebar-DIrG823L",
+                          "children": [
+                            {
+                              "id": "component-sidebar-7PcFsirP"
+                            },
+                            {
+                              "id": "component-sidebar-7ACASv5Y"
+                            },
+                            {
+                              "id": "component-sidebar-Vly9bSsT",
+                              "children": [
+                                {
+                                  "id": "component-sidebar-a94ywyeX"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "id": "component-sidebar-9aqniZBt",
+                      "children": [
+                        {
+                          "id": "component-sidebar-pjLC9d7r"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
             }
           ]
         }
@@ -6666,6 +7099,10 @@
             "type": "theme.ordinal",
             "value": "@padding.open"
           }
+        },
+        "gap": {
+          "type": "theme.ordinal",
+          "value": "@gap.open"
         }
       },
       "variants": [
@@ -17291,6 +17728,10 @@
         "symbol": {
           "type": "option",
           "value": "material-chevronDown"
+        },
+        "size": {
+          "type": "theme.ordinal",
+          "value": "@size.small"
         }
       },
       "origin": "schema",
@@ -17365,6 +17806,10 @@
         "symbol": {
           "type": "option",
           "value": "seldon-more"
+        },
+        "size": {
+          "type": "theme.ordinal",
+          "value": "@size.small"
         }
       },
       "origin": "schema",
@@ -17413,8 +17858,8 @@
             "value": "none"
           },
           "right": {
-            "type": "option",
-            "value": "none"
+            "type": "theme.ordinal",
+            "value": "@padding.tight"
           },
           "bottom": {
             "type": "option",
@@ -17848,6 +18293,10 @@
         "symbol": {
           "type": "option",
           "value": "seldon-more"
+        },
+        "size": {
+          "type": "theme.ordinal",
+          "value": "@size.small"
         }
       },
       "origin": "schema",
@@ -18882,6 +19331,10 @@
         "symbol": {
           "type": "option",
           "value": "material-add"
+        },
+        "size": {
+          "type": "theme.ordinal",
+          "value": "@size.small"
         }
       },
       "origin": "schema",
@@ -18956,6 +19409,10 @@
         "symbol": {
           "type": "option",
           "value": "seldon-more"
+        },
+        "size": {
+          "type": "theme.ordinal",
+          "value": "@size.small"
         }
       },
       "origin": "schema",
@@ -24718,6 +25175,24 @@
         "height": {
           "type": "option",
           "value": "fit"
+        },
+        "corners": {
+          "topLeft": {
+            "type": "option",
+            "value": "squared"
+          },
+          "topRight": {
+            "type": "option",
+            "value": "squared"
+          },
+          "bottomRight": {
+            "type": "option",
+            "value": "squared"
+          },
+          "bottomLeft": {
+            "type": "option",
+            "value": "squared"
+          }
         }
       },
       "origin": "schema",
@@ -24804,6 +25279,10 @@
             "type": "theme.ordinal",
             "value": "@padding.tight"
           }
+        },
+        "display": {
+          "type": "option",
+          "value": "show"
         }
       },
       "__editor": {
@@ -24859,9 +25338,13 @@
             "value": "none"
           }
         },
-        "wrapChildren": {
+        "clip": {
           "type": "option",
           "value": true
+        },
+        "display": {
+          "type": "option",
+          "value": "show"
         }
       },
       "origin": "schema",
@@ -24904,7 +25387,11 @@
               "value": null
             }
           }
-        ]
+        ],
+        "gap": {
+          "type": "theme.ordinal",
+          "value": "@gap.cozy"
+        }
       },
       "origin": "user"
     },
@@ -24933,6 +25420,7 @@
     },
     "component-comboboxField-spqmpmg5": {
       "id": "component-comboboxField-spqmpmg5",
+      "ref": "workspaceName",
       "type": "instance",
       "level": "primitive",
       "label": "Input",
@@ -24941,7 +25429,7 @@
       "overrides": {
         "placeholder": {
           "type": "exact",
-          "value": "Project Name"
+          "value": "Workspace Name"
         },
         "font": {
           "size": {
@@ -24980,6 +25468,7 @@
     },
     "component-comboboxField-o9tr7uLV": {
       "id": "component-comboboxField-o9tr7uLV",
+      "ref": "workspaceSave",
       "type": "instance",
       "level": "element",
       "label": "Iconic",
@@ -25142,6 +25631,10 @@
             "type": "option",
             "value": "none"
           }
+        },
+        "clip": {
+          "type": "option",
+          "value": true
         }
       },
       "origin": "schema",
@@ -25213,6 +25706,7 @@
     },
     "component-comboboxField-Lg6E5jtv": {
       "id": "component-comboboxField-Lg6E5jtv",
+      "ref": "propertyFilter",
       "type": "instance",
       "level": "primitive",
       "label": "Input",
@@ -25260,6 +25754,7 @@
     },
     "component-comboboxField-xvQW1VQq": {
       "id": "component-comboboxField-xvQW1VQq",
+      "ref": "propertyFilterClear",
       "type": "instance",
       "level": "element",
       "label": "Iconic",
@@ -49995,6 +50490,10 @@
         "symbol": {
           "type": "option",
           "value": "seldon-more"
+        },
+        "size": {
+          "type": "theme.ordinal",
+          "value": "@size.small"
         }
       },
       "origin": "schema",
@@ -58620,6 +59119,3740 @@
               "type": "theme.ordinal",
               "value": "@fontSize.small"
             }
+          }
+        }
+      }
+    },
+    "component-item-b1V5zHNC": {
+      "id": "component-item-b1V5zHNC",
+      "type": "instance",
+      "level": "element",
+      "label": "Section",
+      "theme": null,
+      "template": "node:component-item-qfPj12HJ",
+      "overrides": {
+        "display": {
+          "type": "option",
+          "value": "mock"
+        }
+      },
+      "origin": "user"
+    },
+    "component-item-3uDeCFqI": {
+      "id": "component-item-3uDeCFqI",
+      "type": "instance",
+      "level": "element",
+      "label": "Iconic",
+      "theme": null,
+      "template": "node:component-item-OCtkZUuF",
+      "overrides": {},
+      "origin": "user",
+      "__editor": {
+        "initialOverrides": {
+          "buttonSize": {
+            "type": "theme.ordinal",
+            "value": "@fontSize.small"
+          },
+          "padding": {
+            "top": {
+              "type": "theme.ordinal",
+              "value": "@padding.tight"
+            },
+            "right": {
+              "type": "theme.ordinal",
+              "value": "@padding.tight"
+            },
+            "bottom": {
+              "type": "theme.ordinal",
+              "value": "@padding.tight"
+            },
+            "left": {
+              "type": "theme.ordinal",
+              "value": "@padding.tight"
+            }
+          },
+          "background": [
+            {
+              "kind": {
+                "type": "option",
+                "value": "none"
+              }
+            }
+          ],
+          "border": {
+            "preset": {
+              "type": "theme.categorical",
+              "value": "@border.none"
+            }
+          }
+        }
+      }
+    },
+    "component-item-zkRTmMvs": {
+      "id": "component-item-zkRTmMvs",
+      "type": "instance",
+      "level": "primitive",
+      "label": "Icon",
+      "theme": null,
+      "template": "node:component-item-7MKLAjub",
+      "overrides": {},
+      "origin": "user",
+      "__editor": {
+        "initialOverrides": {
+          "symbol": {
+            "type": "option",
+            "value": "material-chevronDown"
+          },
+          "size": {
+            "type": "computed",
+            "value": "autoFit"
+          },
+          "color": {
+            "type": "computed",
+            "value": "highContrastColor"
+          }
+        }
+      }
+    },
+    "component-item-bZLp0uTX": {
+      "id": "component-item-bZLp0uTX",
+      "type": "instance",
+      "level": "element",
+      "label": "Combobox",
+      "theme": null,
+      "template": "node:component-item-GqRllIqj",
+      "overrides": {},
+      "origin": "user",
+      "__editor": {
+        "initialOverrides": {
+          "width": {
+            "type": "option",
+            "value": "fill"
+          }
+        }
+      }
+    },
+    "component-item-VlVrKVa9": {
+      "id": "component-item-VlVrKVa9",
+      "type": "instance",
+      "level": "primitive",
+      "label": "Label",
+      "theme": null,
+      "template": "node:component-item-Z34z7Dhr",
+      "overrides": {
+        "content": {
+          "type": "exact",
+          "value": "Level"
+        }
+      },
+      "origin": "user",
+      "__editor": {
+        "initialOverrides": {
+          "content": {
+            "type": "exact",
+            "value": "Label"
+          },
+          "width": {
+            "type": "exact",
+            "value": {
+              "unit": "%",
+              "value": 30
+            }
+          },
+          "font": {
+            "size": {
+              "type": "theme.ordinal",
+              "value": "@fontSize.xsmall"
+            }
+          }
+        }
+      }
+    },
+    "component-item-evAOVW7m": {
+      "id": "component-item-evAOVW7m",
+      "type": "instance",
+      "level": "element",
+      "label": "Combobox Field",
+      "theme": null,
+      "template": "node:component-item-O7CtNVBH",
+      "overrides": {},
+      "origin": "user",
+      "__editor": {
+        "initialOverrides": {}
+      }
+    },
+    "component-item-Ue5GakGO": {
+      "id": "component-item-Ue5GakGO",
+      "type": "instance",
+      "level": "primitive",
+      "label": "Icon",
+      "theme": null,
+      "template": "node:component-item-0qVCFngD",
+      "overrides": {},
+      "origin": "user",
+      "__editor": {
+        "initialOverrides": {
+          "symbol": {
+            "type": "option",
+            "value": "seldon-component"
+          },
+          "size": {
+            "type": "theme.ordinal",
+            "value": "@size.small"
+          },
+          "color": {
+            "type": "computed",
+            "value": "highContrastColor"
+          }
+        }
+      }
+    },
+    "component-item-bBB1bo4U": {
+      "id": "component-item-bBB1bo4U",
+      "type": "instance",
+      "level": "primitive",
+      "label": "Input",
+      "theme": null,
+      "template": "node:component-item-sHhIabuo",
+      "overrides": {},
+      "origin": "user",
+      "__editor": {
+        "initialOverrides": {
+          "width": {
+            "type": "option",
+            "value": "fill"
+          },
+          "padding": {
+            "top": {
+              "type": "exact",
+              "value": {
+                "unit": "px",
+                "value": 0
+              }
+            },
+            "right": {
+              "type": "exact",
+              "value": {
+                "unit": "px",
+                "value": 0
+              }
+            },
+            "bottom": {
+              "type": "exact",
+              "value": {
+                "unit": "px",
+                "value": 0
+              }
+            },
+            "left": {
+              "type": "exact",
+              "value": {
+                "unit": "px",
+                "value": 0
+              }
+            }
+          },
+          "background": [
+            {
+              "kind": {
+                "type": "option",
+                "value": "none"
+              }
+            }
+          ],
+          "border": {
+            "preset": {
+              "type": "theme.categorical",
+              "value": "@border.none"
+            }
+          },
+          "corners": {
+            "topLeft": {
+              "type": "empty",
+              "value": null
+            },
+            "topRight": {
+              "type": "empty",
+              "value": null
+            },
+            "bottomLeft": {
+              "type": "empty",
+              "value": null
+            },
+            "bottomRight": {
+              "type": "empty",
+              "value": null
+            }
+          },
+          "role": {
+            "type": "option",
+            "value": "combobox"
+          },
+          "ariaHasPopup": {
+            "type": "option",
+            "value": "listbox"
+          },
+          "font": {
+            "size": {
+              "type": "theme.ordinal",
+              "value": "@fontSize.xsmall"
+            }
+          }
+        }
+      }
+    },
+    "component-item-bD1t48vD": {
+      "id": "component-item-bD1t48vD",
+      "type": "instance",
+      "level": "element",
+      "label": "Iconic",
+      "theme": null,
+      "template": "node:component-item-8zOXA1We",
+      "overrides": {},
+      "origin": "user",
+      "__editor": {
+        "initialOverrides": {
+          "buttonSize": {
+            "type": "theme.ordinal",
+            "value": "@fontSize.small"
+          },
+          "background": [
+            {
+              "kind": {
+                "type": "option",
+                "value": "none"
+              }
+            }
+          ],
+          "border": {
+            "preset": {
+              "type": "theme.categorical",
+              "value": "@border.none"
+            }
+          }
+        }
+      }
+    },
+    "component-item-9iaYUrDq": {
+      "id": "component-item-9iaYUrDq",
+      "type": "instance",
+      "level": "primitive",
+      "label": "Icon",
+      "theme": null,
+      "template": "node:component-item-dE8vlG8d",
+      "overrides": {},
+      "origin": "user",
+      "__editor": {
+        "initialOverrides": {
+          "symbol": {
+            "type": "option",
+            "value": "material-chevronDown"
+          },
+          "size": {
+            "type": "computed",
+            "value": "autoFit"
+          },
+          "color": {
+            "type": "computed",
+            "value": "highContrastColor"
+          }
+        }
+      }
+    },
+    "component-item-m0pKZcak": {
+      "id": "component-item-m0pKZcak",
+      "type": "instance",
+      "level": "element",
+      "label": "Iconic",
+      "theme": null,
+      "template": "node:component-item-sDjvfAPl",
+      "overrides": {},
+      "origin": "user",
+      "__editor": {
+        "initialOverrides": {
+          "buttonSize": {
+            "type": "theme.ordinal",
+            "value": "@fontSize.small"
+          },
+          "padding": {
+            "top": {
+              "type": "theme.ordinal",
+              "value": "@padding.tight"
+            },
+            "right": {
+              "type": "theme.ordinal",
+              "value": "@padding.tight"
+            },
+            "bottom": {
+              "type": "theme.ordinal",
+              "value": "@padding.tight"
+            },
+            "left": {
+              "type": "theme.ordinal",
+              "value": "@padding.tight"
+            }
+          },
+          "border": {
+            "preset": {
+              "type": "theme.categorical",
+              "value": "@border.thin"
+            }
+          }
+        }
+      }
+    },
+    "component-item-RpGZs56q": {
+      "id": "component-item-RpGZs56q",
+      "type": "instance",
+      "level": "primitive",
+      "label": "Icon",
+      "theme": null,
+      "template": "node:component-item-CMEf5HDL",
+      "overrides": {},
+      "origin": "user",
+      "__editor": {
+        "initialOverrides": {
+          "symbol": {
+            "type": "option",
+            "value": "material-add"
+          },
+          "size": {
+            "type": "computed",
+            "value": "autoFit"
+          },
+          "color": {
+            "type": "computed",
+            "value": "highContrastColor"
+          }
+        }
+      }
+    },
+    "component-item-KZTQUWze": {
+      "id": "component-item-KZTQUWze",
+      "type": "instance",
+      "level": "element",
+      "label": "Iconic",
+      "theme": null,
+      "template": "node:component-item-m1G2OAIO",
+      "overrides": {},
+      "origin": "user",
+      "__editor": {
+        "initialOverrides": {
+          "buttonSize": {
+            "type": "theme.ordinal",
+            "value": "@fontSize.small"
+          },
+          "padding": {
+            "top": {
+              "type": "theme.ordinal",
+              "value": "@padding.tight"
+            },
+            "right": {
+              "type": "theme.ordinal",
+              "value": "@padding.tight"
+            },
+            "bottom": {
+              "type": "theme.ordinal",
+              "value": "@padding.tight"
+            },
+            "left": {
+              "type": "theme.ordinal",
+              "value": "@padding.tight"
+            }
+          },
+          "border": {
+            "preset": {
+              "type": "theme.categorical",
+              "value": "@border.thin"
+            }
+          }
+        }
+      }
+    },
+    "component-item-9cFp2KiP": {
+      "id": "component-item-9cFp2KiP",
+      "type": "instance",
+      "level": "primitive",
+      "label": "Icon",
+      "theme": null,
+      "template": "node:component-item-X0ybtMzs",
+      "overrides": {},
+      "origin": "user",
+      "__editor": {
+        "initialOverrides": {
+          "symbol": {
+            "type": "option",
+            "value": "material-moreHoriz"
+          },
+          "size": {
+            "type": "computed",
+            "value": "autoFit"
+          },
+          "color": {
+            "type": "computed",
+            "value": "highContrastColor"
+          }
+        }
+      }
+    },
+    "component-sidebar-JA0cb7AN": {
+      "id": "component-sidebar-JA0cb7AN",
+      "type": "instance",
+      "level": "element",
+      "label": "Section",
+      "theme": null,
+      "template": "node:component-item-qfPj12HJ",
+      "overrides": {
+        "display": {
+          "type": "option",
+          "value": "mock"
+        }
+      },
+      "origin": "user"
+    },
+    "component-sidebar-hwNZND96": {
+      "id": "component-sidebar-hwNZND96",
+      "type": "instance",
+      "level": "element",
+      "label": "Iconic",
+      "theme": null,
+      "template": "node:component-item-OCtkZUuF",
+      "overrides": {},
+      "origin": "user",
+      "__editor": {
+        "initialOverrides": {
+          "buttonSize": {
+            "type": "theme.ordinal",
+            "value": "@fontSize.small"
+          },
+          "padding": {
+            "top": {
+              "type": "theme.ordinal",
+              "value": "@padding.tight"
+            },
+            "right": {
+              "type": "theme.ordinal",
+              "value": "@padding.tight"
+            },
+            "bottom": {
+              "type": "theme.ordinal",
+              "value": "@padding.tight"
+            },
+            "left": {
+              "type": "theme.ordinal",
+              "value": "@padding.tight"
+            }
+          },
+          "background": [
+            {
+              "kind": {
+                "type": "option",
+                "value": "none"
+              }
+            }
+          ],
+          "border": {
+            "preset": {
+              "type": "theme.categorical",
+              "value": "@border.none"
+            }
+          }
+        }
+      }
+    },
+    "component-sidebar-6Cri5kRu": {
+      "id": "component-sidebar-6Cri5kRu",
+      "type": "instance",
+      "level": "primitive",
+      "label": "Icon",
+      "theme": null,
+      "template": "node:component-item-7MKLAjub",
+      "overrides": {},
+      "origin": "user",
+      "__editor": {
+        "initialOverrides": {
+          "symbol": {
+            "type": "option",
+            "value": "material-chevronDown"
+          },
+          "size": {
+            "type": "computed",
+            "value": "autoFit"
+          },
+          "color": {
+            "type": "computed",
+            "value": "highContrastColor"
+          }
+        }
+      }
+    },
+    "component-sidebar-TfhOyss2": {
+      "id": "component-sidebar-TfhOyss2",
+      "type": "instance",
+      "level": "element",
+      "label": "Combobox",
+      "theme": null,
+      "template": "node:component-item-GqRllIqj",
+      "overrides": {},
+      "origin": "user",
+      "__editor": {
+        "initialOverrides": {
+          "width": {
+            "type": "option",
+            "value": "fill"
+          }
+        }
+      }
+    },
+    "component-sidebar-y4jZkllg": {
+      "id": "component-sidebar-y4jZkllg",
+      "type": "instance",
+      "level": "primitive",
+      "label": "Label",
+      "theme": null,
+      "template": "node:component-item-Z34z7Dhr",
+      "overrides": {
+        "content": {
+          "type": "exact",
+          "value": "Level"
+        }
+      },
+      "origin": "user",
+      "__editor": {
+        "initialOverrides": {
+          "content": {
+            "type": "exact",
+            "value": "Label"
+          },
+          "width": {
+            "type": "exact",
+            "value": {
+              "unit": "%",
+              "value": 30
+            }
+          },
+          "font": {
+            "size": {
+              "type": "theme.ordinal",
+              "value": "@fontSize.xsmall"
+            }
+          }
+        }
+      }
+    },
+    "component-sidebar-WsWqzR44": {
+      "id": "component-sidebar-WsWqzR44",
+      "type": "instance",
+      "level": "element",
+      "label": "Combobox Field",
+      "theme": null,
+      "template": "node:component-item-O7CtNVBH",
+      "overrides": {},
+      "origin": "user",
+      "__editor": {
+        "initialOverrides": {}
+      }
+    },
+    "component-sidebar-z98EVoc0": {
+      "id": "component-sidebar-z98EVoc0",
+      "type": "instance",
+      "level": "primitive",
+      "label": "Icon",
+      "theme": null,
+      "template": "node:component-item-0qVCFngD",
+      "overrides": {},
+      "origin": "user",
+      "__editor": {
+        "initialOverrides": {
+          "symbol": {
+            "type": "option",
+            "value": "seldon-component"
+          },
+          "size": {
+            "type": "theme.ordinal",
+            "value": "@size.small"
+          },
+          "color": {
+            "type": "computed",
+            "value": "highContrastColor"
+          }
+        }
+      }
+    },
+    "component-sidebar-iW8WTAaz": {
+      "id": "component-sidebar-iW8WTAaz",
+      "type": "instance",
+      "level": "primitive",
+      "label": "Input",
+      "theme": null,
+      "template": "node:component-item-sHhIabuo",
+      "overrides": {},
+      "origin": "user",
+      "__editor": {
+        "initialOverrides": {
+          "width": {
+            "type": "option",
+            "value": "fill"
+          },
+          "padding": {
+            "top": {
+              "type": "exact",
+              "value": {
+                "unit": "px",
+                "value": 0
+              }
+            },
+            "right": {
+              "type": "exact",
+              "value": {
+                "unit": "px",
+                "value": 0
+              }
+            },
+            "bottom": {
+              "type": "exact",
+              "value": {
+                "unit": "px",
+                "value": 0
+              }
+            },
+            "left": {
+              "type": "exact",
+              "value": {
+                "unit": "px",
+                "value": 0
+              }
+            }
+          },
+          "background": [
+            {
+              "kind": {
+                "type": "option",
+                "value": "none"
+              }
+            }
+          ],
+          "border": {
+            "preset": {
+              "type": "theme.categorical",
+              "value": "@border.none"
+            }
+          },
+          "corners": {
+            "topLeft": {
+              "type": "empty",
+              "value": null
+            },
+            "topRight": {
+              "type": "empty",
+              "value": null
+            },
+            "bottomLeft": {
+              "type": "empty",
+              "value": null
+            },
+            "bottomRight": {
+              "type": "empty",
+              "value": null
+            }
+          },
+          "role": {
+            "type": "option",
+            "value": "combobox"
+          },
+          "ariaHasPopup": {
+            "type": "option",
+            "value": "listbox"
+          },
+          "font": {
+            "size": {
+              "type": "theme.ordinal",
+              "value": "@fontSize.xsmall"
+            }
+          }
+        }
+      }
+    },
+    "component-sidebar-0hQiFwde": {
+      "id": "component-sidebar-0hQiFwde",
+      "type": "instance",
+      "level": "element",
+      "label": "Iconic",
+      "theme": null,
+      "template": "node:component-item-8zOXA1We",
+      "overrides": {},
+      "origin": "user",
+      "__editor": {
+        "initialOverrides": {
+          "buttonSize": {
+            "type": "theme.ordinal",
+            "value": "@fontSize.small"
+          },
+          "background": [
+            {
+              "kind": {
+                "type": "option",
+                "value": "none"
+              }
+            }
+          ],
+          "border": {
+            "preset": {
+              "type": "theme.categorical",
+              "value": "@border.none"
+            }
+          }
+        }
+      }
+    },
+    "component-sidebar-zcujeg9q": {
+      "id": "component-sidebar-zcujeg9q",
+      "type": "instance",
+      "level": "primitive",
+      "label": "Icon",
+      "theme": null,
+      "template": "node:component-item-dE8vlG8d",
+      "overrides": {},
+      "origin": "user",
+      "__editor": {
+        "initialOverrides": {
+          "symbol": {
+            "type": "option",
+            "value": "material-chevronDown"
+          },
+          "size": {
+            "type": "computed",
+            "value": "autoFit"
+          },
+          "color": {
+            "type": "computed",
+            "value": "highContrastColor"
+          }
+        }
+      }
+    },
+    "component-sidebar-S1S3FsY0": {
+      "id": "component-sidebar-S1S3FsY0",
+      "type": "instance",
+      "level": "element",
+      "label": "Iconic",
+      "theme": null,
+      "template": "node:component-item-sDjvfAPl",
+      "overrides": {},
+      "origin": "user",
+      "__editor": {
+        "initialOverrides": {
+          "buttonSize": {
+            "type": "theme.ordinal",
+            "value": "@fontSize.small"
+          },
+          "padding": {
+            "top": {
+              "type": "theme.ordinal",
+              "value": "@padding.tight"
+            },
+            "right": {
+              "type": "theme.ordinal",
+              "value": "@padding.tight"
+            },
+            "bottom": {
+              "type": "theme.ordinal",
+              "value": "@padding.tight"
+            },
+            "left": {
+              "type": "theme.ordinal",
+              "value": "@padding.tight"
+            }
+          },
+          "border": {
+            "preset": {
+              "type": "theme.categorical",
+              "value": "@border.thin"
+            }
+          }
+        }
+      }
+    },
+    "component-sidebar-4YEPzpk0": {
+      "id": "component-sidebar-4YEPzpk0",
+      "type": "instance",
+      "level": "primitive",
+      "label": "Icon",
+      "theme": null,
+      "template": "node:component-item-CMEf5HDL",
+      "overrides": {},
+      "origin": "user",
+      "__editor": {
+        "initialOverrides": {
+          "symbol": {
+            "type": "option",
+            "value": "material-add"
+          },
+          "size": {
+            "type": "computed",
+            "value": "autoFit"
+          },
+          "color": {
+            "type": "computed",
+            "value": "highContrastColor"
+          }
+        }
+      }
+    },
+    "component-sidebar-WZRXutjM": {
+      "id": "component-sidebar-WZRXutjM",
+      "type": "instance",
+      "level": "element",
+      "label": "Iconic",
+      "theme": null,
+      "template": "node:component-item-m1G2OAIO",
+      "overrides": {},
+      "origin": "user",
+      "__editor": {
+        "initialOverrides": {
+          "buttonSize": {
+            "type": "theme.ordinal",
+            "value": "@fontSize.small"
+          },
+          "padding": {
+            "top": {
+              "type": "theme.ordinal",
+              "value": "@padding.tight"
+            },
+            "right": {
+              "type": "theme.ordinal",
+              "value": "@padding.tight"
+            },
+            "bottom": {
+              "type": "theme.ordinal",
+              "value": "@padding.tight"
+            },
+            "left": {
+              "type": "theme.ordinal",
+              "value": "@padding.tight"
+            }
+          },
+          "border": {
+            "preset": {
+              "type": "theme.categorical",
+              "value": "@border.thin"
+            }
+          }
+        }
+      }
+    },
+    "component-sidebar-czel5leu": {
+      "id": "component-sidebar-czel5leu",
+      "type": "instance",
+      "level": "primitive",
+      "label": "Icon",
+      "theme": null,
+      "template": "node:component-item-X0ybtMzs",
+      "overrides": {},
+      "origin": "user",
+      "__editor": {
+        "initialOverrides": {
+          "symbol": {
+            "type": "option",
+            "value": "material-moreHoriz"
+          },
+          "size": {
+            "type": "computed",
+            "value": "autoFit"
+          },
+          "color": {
+            "type": "computed",
+            "value": "highContrastColor"
+          }
+        }
+      }
+    },
+    "component-item-B8RBVyHZ": {
+      "id": "component-item-B8RBVyHZ",
+      "type": "instance",
+      "level": "element",
+      "label": "Section",
+      "theme": null,
+      "template": "node:component-item-qfPj12HJ",
+      "overrides": {
+        "display": {
+          "type": "option",
+          "value": "mock"
+        }
+      },
+      "origin": "user"
+    },
+    "component-item-GkdUG8cw": {
+      "id": "component-item-GkdUG8cw",
+      "type": "instance",
+      "level": "element",
+      "label": "Iconic",
+      "theme": null,
+      "template": "node:component-item-OCtkZUuF",
+      "overrides": {},
+      "origin": "user",
+      "__editor": {
+        "initialOverrides": {
+          "buttonSize": {
+            "type": "theme.ordinal",
+            "value": "@fontSize.small"
+          },
+          "padding": {
+            "top": {
+              "type": "theme.ordinal",
+              "value": "@padding.tight"
+            },
+            "right": {
+              "type": "theme.ordinal",
+              "value": "@padding.tight"
+            },
+            "bottom": {
+              "type": "theme.ordinal",
+              "value": "@padding.tight"
+            },
+            "left": {
+              "type": "theme.ordinal",
+              "value": "@padding.tight"
+            }
+          },
+          "background": [
+            {
+              "kind": {
+                "type": "option",
+                "value": "none"
+              }
+            }
+          ],
+          "border": {
+            "preset": {
+              "type": "theme.categorical",
+              "value": "@border.none"
+            }
+          }
+        }
+      }
+    },
+    "component-item-ojaLxpy0": {
+      "id": "component-item-ojaLxpy0",
+      "type": "instance",
+      "level": "primitive",
+      "label": "Icon",
+      "theme": null,
+      "template": "node:component-item-7MKLAjub",
+      "overrides": {},
+      "origin": "user",
+      "__editor": {
+        "initialOverrides": {
+          "symbol": {
+            "type": "option",
+            "value": "material-chevronDown"
+          },
+          "size": {
+            "type": "computed",
+            "value": "autoFit"
+          },
+          "color": {
+            "type": "computed",
+            "value": "highContrastColor"
+          }
+        }
+      }
+    },
+    "component-item-ZtCPosBL": {
+      "id": "component-item-ZtCPosBL",
+      "type": "instance",
+      "level": "element",
+      "label": "Combobox",
+      "theme": null,
+      "template": "node:component-item-GqRllIqj",
+      "overrides": {},
+      "origin": "user",
+      "__editor": {
+        "initialOverrides": {
+          "width": {
+            "type": "option",
+            "value": "fill"
+          }
+        }
+      }
+    },
+    "component-item-uwO2ynhb": {
+      "id": "component-item-uwO2ynhb",
+      "type": "instance",
+      "level": "primitive",
+      "label": "Label",
+      "theme": null,
+      "template": "node:component-item-Z34z7Dhr",
+      "overrides": {},
+      "origin": "user",
+      "__editor": {
+        "initialOverrides": {
+          "content": {
+            "type": "exact",
+            "value": "Label"
+          },
+          "width": {
+            "type": "exact",
+            "value": {
+              "unit": "%",
+              "value": 30
+            }
+          },
+          "font": {
+            "size": {
+              "type": "theme.ordinal",
+              "value": "@fontSize.xsmall"
+            }
+          }
+        }
+      }
+    },
+    "component-item-oJ1gKB5O": {
+      "id": "component-item-oJ1gKB5O",
+      "type": "instance",
+      "level": "element",
+      "label": "Combobox Field",
+      "theme": null,
+      "template": "node:component-item-O7CtNVBH",
+      "overrides": {},
+      "origin": "user",
+      "__editor": {
+        "initialOverrides": {}
+      }
+    },
+    "component-item-Y7FZOEsQ": {
+      "id": "component-item-Y7FZOEsQ",
+      "type": "instance",
+      "level": "primitive",
+      "label": "Icon",
+      "theme": null,
+      "template": "node:component-item-0qVCFngD",
+      "overrides": {},
+      "origin": "user",
+      "__editor": {
+        "initialOverrides": {
+          "symbol": {
+            "type": "option",
+            "value": "seldon-component"
+          },
+          "size": {
+            "type": "theme.ordinal",
+            "value": "@size.small"
+          },
+          "color": {
+            "type": "computed",
+            "value": "highContrastColor"
+          }
+        }
+      }
+    },
+    "component-item-taLEeaSp": {
+      "id": "component-item-taLEeaSp",
+      "type": "instance",
+      "level": "primitive",
+      "label": "Input",
+      "theme": null,
+      "template": "node:component-item-sHhIabuo",
+      "overrides": {},
+      "origin": "user",
+      "__editor": {
+        "initialOverrides": {
+          "width": {
+            "type": "option",
+            "value": "fill"
+          },
+          "padding": {
+            "top": {
+              "type": "exact",
+              "value": {
+                "unit": "px",
+                "value": 0
+              }
+            },
+            "right": {
+              "type": "exact",
+              "value": {
+                "unit": "px",
+                "value": 0
+              }
+            },
+            "bottom": {
+              "type": "exact",
+              "value": {
+                "unit": "px",
+                "value": 0
+              }
+            },
+            "left": {
+              "type": "exact",
+              "value": {
+                "unit": "px",
+                "value": 0
+              }
+            }
+          },
+          "background": [
+            {
+              "kind": {
+                "type": "option",
+                "value": "none"
+              }
+            }
+          ],
+          "border": {
+            "preset": {
+              "type": "theme.categorical",
+              "value": "@border.none"
+            }
+          },
+          "corners": {
+            "topLeft": {
+              "type": "empty",
+              "value": null
+            },
+            "topRight": {
+              "type": "empty",
+              "value": null
+            },
+            "bottomLeft": {
+              "type": "empty",
+              "value": null
+            },
+            "bottomRight": {
+              "type": "empty",
+              "value": null
+            }
+          },
+          "role": {
+            "type": "option",
+            "value": "combobox"
+          },
+          "ariaHasPopup": {
+            "type": "option",
+            "value": "listbox"
+          },
+          "font": {
+            "size": {
+              "type": "theme.ordinal",
+              "value": "@fontSize.xsmall"
+            }
+          }
+        }
+      }
+    },
+    "component-item-5ZBBKqDF": {
+      "id": "component-item-5ZBBKqDF",
+      "type": "instance",
+      "level": "element",
+      "label": "Iconic",
+      "theme": null,
+      "template": "node:component-item-8zOXA1We",
+      "overrides": {},
+      "origin": "user",
+      "__editor": {
+        "initialOverrides": {
+          "buttonSize": {
+            "type": "theme.ordinal",
+            "value": "@fontSize.small"
+          },
+          "background": [
+            {
+              "kind": {
+                "type": "option",
+                "value": "none"
+              }
+            }
+          ],
+          "border": {
+            "preset": {
+              "type": "theme.categorical",
+              "value": "@border.none"
+            }
+          }
+        }
+      }
+    },
+    "component-item-LiVDdAqG": {
+      "id": "component-item-LiVDdAqG",
+      "type": "instance",
+      "level": "primitive",
+      "label": "Icon",
+      "theme": null,
+      "template": "node:component-item-dE8vlG8d",
+      "overrides": {},
+      "origin": "user",
+      "__editor": {
+        "initialOverrides": {
+          "symbol": {
+            "type": "option",
+            "value": "material-chevronDown"
+          },
+          "size": {
+            "type": "computed",
+            "value": "autoFit"
+          },
+          "color": {
+            "type": "computed",
+            "value": "highContrastColor"
+          }
+        }
+      }
+    },
+    "component-item-naUTauiU": {
+      "id": "component-item-naUTauiU",
+      "type": "instance",
+      "level": "element",
+      "label": "Iconic",
+      "theme": null,
+      "template": "node:component-item-sDjvfAPl",
+      "overrides": {},
+      "origin": "user",
+      "__editor": {
+        "initialOverrides": {
+          "buttonSize": {
+            "type": "theme.ordinal",
+            "value": "@fontSize.small"
+          },
+          "padding": {
+            "top": {
+              "type": "theme.ordinal",
+              "value": "@padding.tight"
+            },
+            "right": {
+              "type": "theme.ordinal",
+              "value": "@padding.tight"
+            },
+            "bottom": {
+              "type": "theme.ordinal",
+              "value": "@padding.tight"
+            },
+            "left": {
+              "type": "theme.ordinal",
+              "value": "@padding.tight"
+            }
+          },
+          "border": {
+            "preset": {
+              "type": "theme.categorical",
+              "value": "@border.thin"
+            }
+          }
+        }
+      }
+    },
+    "component-item-s1trJIPc": {
+      "id": "component-item-s1trJIPc",
+      "type": "instance",
+      "level": "primitive",
+      "label": "Icon",
+      "theme": null,
+      "template": "node:component-item-CMEf5HDL",
+      "overrides": {},
+      "origin": "user",
+      "__editor": {
+        "initialOverrides": {
+          "symbol": {
+            "type": "option",
+            "value": "material-add"
+          },
+          "size": {
+            "type": "computed",
+            "value": "autoFit"
+          },
+          "color": {
+            "type": "computed",
+            "value": "highContrastColor"
+          }
+        }
+      }
+    },
+    "component-item-ifOuS9Th": {
+      "id": "component-item-ifOuS9Th",
+      "type": "instance",
+      "level": "element",
+      "label": "Iconic",
+      "theme": null,
+      "template": "node:component-item-m1G2OAIO",
+      "overrides": {},
+      "origin": "user",
+      "__editor": {
+        "initialOverrides": {
+          "buttonSize": {
+            "type": "theme.ordinal",
+            "value": "@fontSize.small"
+          },
+          "padding": {
+            "top": {
+              "type": "theme.ordinal",
+              "value": "@padding.tight"
+            },
+            "right": {
+              "type": "theme.ordinal",
+              "value": "@padding.tight"
+            },
+            "bottom": {
+              "type": "theme.ordinal",
+              "value": "@padding.tight"
+            },
+            "left": {
+              "type": "theme.ordinal",
+              "value": "@padding.tight"
+            }
+          },
+          "border": {
+            "preset": {
+              "type": "theme.categorical",
+              "value": "@border.thin"
+            }
+          }
+        }
+      }
+    },
+    "component-item-ocBfbzeB": {
+      "id": "component-item-ocBfbzeB",
+      "type": "instance",
+      "level": "primitive",
+      "label": "Icon",
+      "theme": null,
+      "template": "node:component-item-X0ybtMzs",
+      "overrides": {},
+      "origin": "user",
+      "__editor": {
+        "initialOverrides": {
+          "symbol": {
+            "type": "option",
+            "value": "material-moreHoriz"
+          },
+          "size": {
+            "type": "computed",
+            "value": "autoFit"
+          },
+          "color": {
+            "type": "computed",
+            "value": "highContrastColor"
+          }
+        }
+      }
+    },
+    "component-item-PGzJkIXO": {
+      "id": "component-item-PGzJkIXO",
+      "type": "instance",
+      "level": "element",
+      "label": "Property",
+      "theme": null,
+      "template": "node:component-item-input",
+      "overrides": {
+        "display": {
+          "type": "option",
+          "value": "mock"
+        }
+      },
+      "origin": "user",
+      "__editor": {
+        "repeat": {
+          "count": 3
+        }
+      }
+    },
+    "component-item-AbSWrsa8": {
+      "id": "component-item-AbSWrsa8",
+      "type": "instance",
+      "level": "element",
+      "label": "Iconic",
+      "theme": null,
+      "template": "node:component-button-iVVLVSBT",
+      "overrides": {},
+      "origin": "user",
+      "__editor": {
+        "initialOverrides": {
+          "buttonSize": {
+            "type": "theme.ordinal",
+            "value": "@fontSize.small"
+          },
+          "padding": {
+            "top": {
+              "type": "theme.ordinal",
+              "value": "@padding.tight"
+            },
+            "right": {
+              "type": "theme.ordinal",
+              "value": "@padding.tight"
+            },
+            "bottom": {
+              "type": "theme.ordinal",
+              "value": "@padding.tight"
+            },
+            "left": {
+              "type": "theme.ordinal",
+              "value": "@padding.tight"
+            }
+          },
+          "background": [
+            {
+              "kind": {
+                "type": "option",
+                "value": "none"
+              }
+            }
+          ],
+          "border": {
+            "preset": {
+              "type": "theme.categorical",
+              "value": "@border.none"
+            }
+          }
+        }
+      }
+    },
+    "component-item-7hFHrht0": {
+      "id": "component-item-7hFHrht0",
+      "type": "instance",
+      "level": "primitive",
+      "label": "Icon",
+      "theme": null,
+      "template": "node:component-icon-Aa4AD1wO",
+      "overrides": {
+        "symbol": {
+          "type": "option",
+          "value": "material-chevronRight"
+        }
+      },
+      "origin": "user",
+      "__editor": {
+        "initialOverrides": {
+          "symbol": {
+            "type": "option",
+            "value": "material-chevronDown"
+          },
+          "size": {
+            "type": "computed",
+            "value": "autoFit"
+          },
+          "color": {
+            "type": "computed",
+            "value": "highContrastColor"
+          }
+        }
+      }
+    },
+    "component-item-e2HcTzxH": {
+      "id": "component-item-e2HcTzxH",
+      "type": "instance",
+      "level": "element",
+      "label": "Combobox",
+      "theme": null,
+      "template": "node:component-formControl-qMoPhhJ6",
+      "overrides": {},
+      "origin": "user",
+      "__editor": {
+        "initialOverrides": {
+          "width": {
+            "type": "option",
+            "value": "fill"
+          }
+        }
+      }
+    },
+    "component-item-THaHL5Id": {
+      "id": "component-item-THaHL5Id",
+      "type": "instance",
+      "level": "primitive",
+      "label": "Input",
+      "theme": null,
+      "template": "node:component-item-JvSW6JpE",
+      "overrides": {},
+      "origin": "user",
+      "__editor": {
+        "initialOverrides": {
+          "width": {
+            "type": "option",
+            "value": "fill"
+          },
+          "padding": {
+            "top": {
+              "type": "exact",
+              "value": {
+                "unit": "px",
+                "value": 0
+              }
+            },
+            "right": {
+              "type": "exact",
+              "value": {
+                "unit": "px",
+                "value": 0
+              }
+            },
+            "bottom": {
+              "type": "exact",
+              "value": {
+                "unit": "px",
+                "value": 0
+              }
+            },
+            "left": {
+              "type": "exact",
+              "value": {
+                "unit": "px",
+                "value": 0
+              }
+            }
+          },
+          "background": [
+            {
+              "kind": {
+                "type": "option",
+                "value": "none"
+              }
+            }
+          ],
+          "border": {
+            "preset": {
+              "type": "theme.categorical",
+              "value": "@border.none"
+            }
+          },
+          "corners": {
+            "topLeft": {
+              "type": "empty",
+              "value": null
+            },
+            "topRight": {
+              "type": "empty",
+              "value": null
+            },
+            "bottomLeft": {
+              "type": "empty",
+              "value": null
+            },
+            "bottomRight": {
+              "type": "empty",
+              "value": null
+            }
+          },
+          "role": {
+            "type": "option",
+            "value": "combobox"
+          },
+          "ariaHasPopup": {
+            "type": "option",
+            "value": "listbox"
+          },
+          "font": {
+            "size": {
+              "type": "theme.ordinal",
+              "value": "@fontSize.xsmall"
+            }
+          }
+        }
+      }
+    },
+    "component-item-5GirziHO": {
+      "id": "component-item-5GirziHO",
+      "type": "instance",
+      "level": "element",
+      "label": "Combobox Field",
+      "theme": null,
+      "template": "node:component-comboboxField-cMKwpdAk",
+      "overrides": {},
+      "origin": "user",
+      "__editor": {
+        "initialOverrides": {}
+      }
+    },
+    "component-item-1fM48fmG": {
+      "id": "component-item-1fM48fmG",
+      "type": "instance",
+      "level": "primitive",
+      "label": "Icon",
+      "theme": null,
+      "template": "node:component-icon-V1g4W5fN",
+      "overrides": {},
+      "origin": "user",
+      "__editor": {
+        "initialOverrides": {
+          "symbol": {
+            "type": "option",
+            "value": "seldon-component"
+          },
+          "size": {
+            "type": "theme.ordinal",
+            "value": "@size.small"
+          },
+          "color": {
+            "type": "computed",
+            "value": "highContrastColor"
+          }
+        }
+      }
+    },
+    "component-item-GuDIdTRK": {
+      "id": "component-item-GuDIdTRK",
+      "type": "instance",
+      "level": "primitive",
+      "label": "Input",
+      "theme": null,
+      "template": "node:component-input-IeGTgo7S",
+      "overrides": {},
+      "origin": "user",
+      "__editor": {
+        "initialOverrides": {
+          "width": {
+            "type": "option",
+            "value": "fill"
+          },
+          "padding": {
+            "top": {
+              "type": "exact",
+              "value": {
+                "unit": "px",
+                "value": 0
+              }
+            },
+            "right": {
+              "type": "exact",
+              "value": {
+                "unit": "px",
+                "value": 0
+              }
+            },
+            "bottom": {
+              "type": "exact",
+              "value": {
+                "unit": "px",
+                "value": 0
+              }
+            },
+            "left": {
+              "type": "exact",
+              "value": {
+                "unit": "px",
+                "value": 0
+              }
+            }
+          },
+          "background": [
+            {
+              "kind": {
+                "type": "option",
+                "value": "none"
+              }
+            }
+          ],
+          "border": {
+            "preset": {
+              "type": "theme.categorical",
+              "value": "@border.none"
+            }
+          },
+          "corners": {
+            "topLeft": {
+              "type": "empty",
+              "value": null
+            },
+            "topRight": {
+              "type": "empty",
+              "value": null
+            },
+            "bottomLeft": {
+              "type": "empty",
+              "value": null
+            },
+            "bottomRight": {
+              "type": "empty",
+              "value": null
+            }
+          },
+          "role": {
+            "type": "option",
+            "value": "combobox"
+          },
+          "ariaHasPopup": {
+            "type": "option",
+            "value": "listbox"
+          },
+          "font": {
+            "size": {
+              "type": "theme.ordinal",
+              "value": "@fontSize.xsmall"
+            }
+          }
+        }
+      }
+    },
+    "component-item-bpFUUbw3": {
+      "id": "component-item-bpFUUbw3",
+      "type": "instance",
+      "level": "element",
+      "label": "Iconic",
+      "theme": null,
+      "template": "node:component-button-HqmnST2I",
+      "overrides": {},
+      "origin": "user",
+      "__editor": {
+        "initialOverrides": {
+          "buttonSize": {
+            "type": "theme.ordinal",
+            "value": "@fontSize.small"
+          },
+          "background": [
+            {
+              "kind": {
+                "type": "option",
+                "value": "none"
+              }
+            }
+          ],
+          "border": {
+            "preset": {
+              "type": "theme.categorical",
+              "value": "@border.none"
+            }
+          }
+        }
+      }
+    },
+    "component-item-5LMtRNu4": {
+      "id": "component-item-5LMtRNu4",
+      "type": "instance",
+      "level": "primitive",
+      "label": "Icon",
+      "theme": null,
+      "template": "node:component-icon-vzp64Ki8",
+      "overrides": {},
+      "origin": "user",
+      "__editor": {
+        "initialOverrides": {
+          "symbol": {
+            "type": "option",
+            "value": "material-chevronDown"
+          },
+          "size": {
+            "type": "computed",
+            "value": "autoFit"
+          },
+          "color": {
+            "type": "computed",
+            "value": "highContrastColor"
+          }
+        }
+      }
+    },
+    "component-item-p9tghfdO": {
+      "id": "component-item-p9tghfdO",
+      "type": "instance",
+      "level": "element",
+      "label": "Iconic",
+      "theme": null,
+      "template": "node:component-button-CGRbb6mm",
+      "overrides": {},
+      "origin": "user",
+      "__editor": {
+        "initialOverrides": {
+          "buttonSize": {
+            "type": "theme.ordinal",
+            "value": "@fontSize.small"
+          },
+          "padding": {
+            "top": {
+              "type": "theme.ordinal",
+              "value": "@padding.tight"
+            },
+            "right": {
+              "type": "theme.ordinal",
+              "value": "@padding.tight"
+            },
+            "bottom": {
+              "type": "theme.ordinal",
+              "value": "@padding.tight"
+            },
+            "left": {
+              "type": "theme.ordinal",
+              "value": "@padding.tight"
+            }
+          },
+          "border": {
+            "preset": {
+              "type": "theme.categorical",
+              "value": "@border.thin"
+            }
+          }
+        }
+      }
+    },
+    "component-item-X7KjW3gx": {
+      "id": "component-item-X7KjW3gx",
+      "type": "instance",
+      "level": "primitive",
+      "label": "Icon",
+      "theme": null,
+      "template": "node:component-icon-5Coex6SW",
+      "overrides": {},
+      "origin": "user",
+      "__editor": {
+        "initialOverrides": {
+          "symbol": {
+            "type": "option",
+            "value": "material-moreHoriz"
+          },
+          "size": {
+            "type": "computed",
+            "value": "autoFit"
+          },
+          "color": {
+            "type": "computed",
+            "value": "highContrastColor"
+          }
+        }
+      }
+    },
+    "component-sidebar-Ej1nB3nm": {
+      "id": "component-sidebar-Ej1nB3nm",
+      "type": "instance",
+      "level": "element",
+      "label": "Section",
+      "theme": null,
+      "template": "node:component-item-qfPj12HJ",
+      "overrides": {
+        "display": {
+          "type": "option",
+          "value": "mock"
+        }
+      },
+      "origin": "user"
+    },
+    "component-sidebar-w3EAGGeW": {
+      "id": "component-sidebar-w3EAGGeW",
+      "type": "instance",
+      "level": "element",
+      "label": "Iconic",
+      "theme": null,
+      "template": "node:component-item-OCtkZUuF",
+      "overrides": {},
+      "origin": "user",
+      "__editor": {
+        "initialOverrides": {
+          "buttonSize": {
+            "type": "theme.ordinal",
+            "value": "@fontSize.small"
+          },
+          "padding": {
+            "top": {
+              "type": "theme.ordinal",
+              "value": "@padding.tight"
+            },
+            "right": {
+              "type": "theme.ordinal",
+              "value": "@padding.tight"
+            },
+            "bottom": {
+              "type": "theme.ordinal",
+              "value": "@padding.tight"
+            },
+            "left": {
+              "type": "theme.ordinal",
+              "value": "@padding.tight"
+            }
+          },
+          "background": [
+            {
+              "kind": {
+                "type": "option",
+                "value": "none"
+              }
+            }
+          ],
+          "border": {
+            "preset": {
+              "type": "theme.categorical",
+              "value": "@border.none"
+            }
+          }
+        }
+      }
+    },
+    "component-sidebar-IsXAJFdJ": {
+      "id": "component-sidebar-IsXAJFdJ",
+      "type": "instance",
+      "level": "primitive",
+      "label": "Icon",
+      "theme": null,
+      "template": "node:component-item-7MKLAjub",
+      "overrides": {},
+      "origin": "user",
+      "__editor": {
+        "initialOverrides": {
+          "symbol": {
+            "type": "option",
+            "value": "material-chevronDown"
+          },
+          "size": {
+            "type": "computed",
+            "value": "autoFit"
+          },
+          "color": {
+            "type": "computed",
+            "value": "highContrastColor"
+          }
+        }
+      }
+    },
+    "component-sidebar-tcOK33bA": {
+      "id": "component-sidebar-tcOK33bA",
+      "type": "instance",
+      "level": "element",
+      "label": "Combobox",
+      "theme": null,
+      "template": "node:component-item-GqRllIqj",
+      "overrides": {},
+      "origin": "user",
+      "__editor": {
+        "initialOverrides": {
+          "width": {
+            "type": "option",
+            "value": "fill"
+          }
+        }
+      }
+    },
+    "component-sidebar-FMmaFaBm": {
+      "id": "component-sidebar-FMmaFaBm",
+      "type": "instance",
+      "level": "primitive",
+      "label": "Label",
+      "theme": null,
+      "template": "node:component-item-Z34z7Dhr",
+      "overrides": {},
+      "origin": "user",
+      "__editor": {
+        "initialOverrides": {
+          "content": {
+            "type": "exact",
+            "value": "Label"
+          },
+          "width": {
+            "type": "exact",
+            "value": {
+              "unit": "%",
+              "value": 30
+            }
+          },
+          "font": {
+            "size": {
+              "type": "theme.ordinal",
+              "value": "@fontSize.xsmall"
+            }
+          }
+        }
+      }
+    },
+    "component-sidebar-I74OjlO5": {
+      "id": "component-sidebar-I74OjlO5",
+      "type": "instance",
+      "level": "element",
+      "label": "Combobox Field",
+      "theme": null,
+      "template": "node:component-item-O7CtNVBH",
+      "overrides": {},
+      "origin": "user",
+      "__editor": {
+        "initialOverrides": {}
+      }
+    },
+    "component-sidebar-SS58OWpc": {
+      "id": "component-sidebar-SS58OWpc",
+      "type": "instance",
+      "level": "primitive",
+      "label": "Icon",
+      "theme": null,
+      "template": "node:component-item-0qVCFngD",
+      "overrides": {},
+      "origin": "user",
+      "__editor": {
+        "initialOverrides": {
+          "symbol": {
+            "type": "option",
+            "value": "seldon-component"
+          },
+          "size": {
+            "type": "theme.ordinal",
+            "value": "@size.small"
+          },
+          "color": {
+            "type": "computed",
+            "value": "highContrastColor"
+          }
+        }
+      }
+    },
+    "component-sidebar-uOs5RF1O": {
+      "id": "component-sidebar-uOs5RF1O",
+      "type": "instance",
+      "level": "primitive",
+      "label": "Input",
+      "theme": null,
+      "template": "node:component-item-sHhIabuo",
+      "overrides": {},
+      "origin": "user",
+      "__editor": {
+        "initialOverrides": {
+          "width": {
+            "type": "option",
+            "value": "fill"
+          },
+          "padding": {
+            "top": {
+              "type": "exact",
+              "value": {
+                "unit": "px",
+                "value": 0
+              }
+            },
+            "right": {
+              "type": "exact",
+              "value": {
+                "unit": "px",
+                "value": 0
+              }
+            },
+            "bottom": {
+              "type": "exact",
+              "value": {
+                "unit": "px",
+                "value": 0
+              }
+            },
+            "left": {
+              "type": "exact",
+              "value": {
+                "unit": "px",
+                "value": 0
+              }
+            }
+          },
+          "background": [
+            {
+              "kind": {
+                "type": "option",
+                "value": "none"
+              }
+            }
+          ],
+          "border": {
+            "preset": {
+              "type": "theme.categorical",
+              "value": "@border.none"
+            }
+          },
+          "corners": {
+            "topLeft": {
+              "type": "empty",
+              "value": null
+            },
+            "topRight": {
+              "type": "empty",
+              "value": null
+            },
+            "bottomLeft": {
+              "type": "empty",
+              "value": null
+            },
+            "bottomRight": {
+              "type": "empty",
+              "value": null
+            }
+          },
+          "role": {
+            "type": "option",
+            "value": "combobox"
+          },
+          "ariaHasPopup": {
+            "type": "option",
+            "value": "listbox"
+          },
+          "font": {
+            "size": {
+              "type": "theme.ordinal",
+              "value": "@fontSize.xsmall"
+            }
+          }
+        }
+      }
+    },
+    "component-sidebar-1IoVBMtD": {
+      "id": "component-sidebar-1IoVBMtD",
+      "type": "instance",
+      "level": "element",
+      "label": "Iconic",
+      "theme": null,
+      "template": "node:component-item-8zOXA1We",
+      "overrides": {},
+      "origin": "user",
+      "__editor": {
+        "initialOverrides": {
+          "buttonSize": {
+            "type": "theme.ordinal",
+            "value": "@fontSize.small"
+          },
+          "background": [
+            {
+              "kind": {
+                "type": "option",
+                "value": "none"
+              }
+            }
+          ],
+          "border": {
+            "preset": {
+              "type": "theme.categorical",
+              "value": "@border.none"
+            }
+          }
+        }
+      }
+    },
+    "component-sidebar-bH9rtwWa": {
+      "id": "component-sidebar-bH9rtwWa",
+      "type": "instance",
+      "level": "primitive",
+      "label": "Icon",
+      "theme": null,
+      "template": "node:component-item-dE8vlG8d",
+      "overrides": {},
+      "origin": "user",
+      "__editor": {
+        "initialOverrides": {
+          "symbol": {
+            "type": "option",
+            "value": "material-chevronDown"
+          },
+          "size": {
+            "type": "computed",
+            "value": "autoFit"
+          },
+          "color": {
+            "type": "computed",
+            "value": "highContrastColor"
+          }
+        }
+      }
+    },
+    "component-sidebar-zYmKyfaj": {
+      "id": "component-sidebar-zYmKyfaj",
+      "type": "instance",
+      "level": "element",
+      "label": "Iconic",
+      "theme": null,
+      "template": "node:component-item-sDjvfAPl",
+      "overrides": {},
+      "origin": "user",
+      "__editor": {
+        "initialOverrides": {
+          "buttonSize": {
+            "type": "theme.ordinal",
+            "value": "@fontSize.small"
+          },
+          "padding": {
+            "top": {
+              "type": "theme.ordinal",
+              "value": "@padding.tight"
+            },
+            "right": {
+              "type": "theme.ordinal",
+              "value": "@padding.tight"
+            },
+            "bottom": {
+              "type": "theme.ordinal",
+              "value": "@padding.tight"
+            },
+            "left": {
+              "type": "theme.ordinal",
+              "value": "@padding.tight"
+            }
+          },
+          "border": {
+            "preset": {
+              "type": "theme.categorical",
+              "value": "@border.thin"
+            }
+          }
+        }
+      }
+    },
+    "component-sidebar-qPXJqbrj": {
+      "id": "component-sidebar-qPXJqbrj",
+      "type": "instance",
+      "level": "primitive",
+      "label": "Icon",
+      "theme": null,
+      "template": "node:component-item-CMEf5HDL",
+      "overrides": {},
+      "origin": "user",
+      "__editor": {
+        "initialOverrides": {
+          "symbol": {
+            "type": "option",
+            "value": "material-add"
+          },
+          "size": {
+            "type": "computed",
+            "value": "autoFit"
+          },
+          "color": {
+            "type": "computed",
+            "value": "highContrastColor"
+          }
+        }
+      }
+    },
+    "component-sidebar-0W83UcNy": {
+      "id": "component-sidebar-0W83UcNy",
+      "type": "instance",
+      "level": "element",
+      "label": "Iconic",
+      "theme": null,
+      "template": "node:component-item-m1G2OAIO",
+      "overrides": {},
+      "origin": "user",
+      "__editor": {
+        "initialOverrides": {
+          "buttonSize": {
+            "type": "theme.ordinal",
+            "value": "@fontSize.small"
+          },
+          "padding": {
+            "top": {
+              "type": "theme.ordinal",
+              "value": "@padding.tight"
+            },
+            "right": {
+              "type": "theme.ordinal",
+              "value": "@padding.tight"
+            },
+            "bottom": {
+              "type": "theme.ordinal",
+              "value": "@padding.tight"
+            },
+            "left": {
+              "type": "theme.ordinal",
+              "value": "@padding.tight"
+            }
+          },
+          "border": {
+            "preset": {
+              "type": "theme.categorical",
+              "value": "@border.thin"
+            }
+          }
+        }
+      }
+    },
+    "component-sidebar-XLIbzniE": {
+      "id": "component-sidebar-XLIbzniE",
+      "type": "instance",
+      "level": "primitive",
+      "label": "Icon",
+      "theme": null,
+      "template": "node:component-item-X0ybtMzs",
+      "overrides": {},
+      "origin": "user",
+      "__editor": {
+        "initialOverrides": {
+          "symbol": {
+            "type": "option",
+            "value": "material-moreHoriz"
+          },
+          "size": {
+            "type": "computed",
+            "value": "autoFit"
+          },
+          "color": {
+            "type": "computed",
+            "value": "highContrastColor"
+          }
+        }
+      }
+    },
+    "component-sidebar-fP36DXiy": {
+      "id": "component-sidebar-fP36DXiy",
+      "type": "instance",
+      "level": "element",
+      "label": "Property",
+      "theme": null,
+      "template": "node:component-item-input",
+      "overrides": {
+        "display": {
+          "type": "option",
+          "value": "mock"
+        }
+      },
+      "origin": "user",
+      "__editor": {
+        "repeat": {
+          "count": 5
+        }
+      }
+    },
+    "component-sidebar-8ASr8hZB": {
+      "id": "component-sidebar-8ASr8hZB",
+      "type": "instance",
+      "level": "element",
+      "label": "Iconic",
+      "theme": null,
+      "template": "node:component-button-iVVLVSBT",
+      "overrides": {},
+      "origin": "user",
+      "__editor": {
+        "initialOverrides": {
+          "buttonSize": {
+            "type": "theme.ordinal",
+            "value": "@fontSize.small"
+          },
+          "padding": {
+            "top": {
+              "type": "theme.ordinal",
+              "value": "@padding.tight"
+            },
+            "right": {
+              "type": "theme.ordinal",
+              "value": "@padding.tight"
+            },
+            "bottom": {
+              "type": "theme.ordinal",
+              "value": "@padding.tight"
+            },
+            "left": {
+              "type": "theme.ordinal",
+              "value": "@padding.tight"
+            }
+          },
+          "background": [
+            {
+              "kind": {
+                "type": "option",
+                "value": "none"
+              }
+            }
+          ],
+          "border": {
+            "preset": {
+              "type": "theme.categorical",
+              "value": "@border.none"
+            }
+          }
+        }
+      }
+    },
+    "component-sidebar-6OwIYgWt": {
+      "id": "component-sidebar-6OwIYgWt",
+      "type": "instance",
+      "level": "primitive",
+      "label": "Icon",
+      "theme": null,
+      "template": "node:component-icon-Aa4AD1wO",
+      "overrides": {},
+      "origin": "user",
+      "__editor": {
+        "initialOverrides": {
+          "symbol": {
+            "type": "option",
+            "value": "material-chevronDown"
+          },
+          "size": {
+            "type": "computed",
+            "value": "autoFit"
+          },
+          "color": {
+            "type": "computed",
+            "value": "highContrastColor"
+          }
+        }
+      }
+    },
+    "component-sidebar-q2ZtEoiP": {
+      "id": "component-sidebar-q2ZtEoiP",
+      "type": "instance",
+      "level": "element",
+      "label": "Combobox",
+      "theme": null,
+      "template": "node:component-formControl-qMoPhhJ6",
+      "overrides": {},
+      "origin": "user",
+      "__editor": {
+        "initialOverrides": {
+          "width": {
+            "type": "option",
+            "value": "fill"
+          }
+        }
+      }
+    },
+    "component-sidebar-jnn1KpAH": {
+      "id": "component-sidebar-jnn1KpAH",
+      "type": "instance",
+      "level": "primitive",
+      "label": "Input",
+      "theme": null,
+      "template": "node:component-item-JvSW6JpE",
+      "overrides": {},
+      "origin": "user",
+      "__editor": {
+        "initialOverrides": {
+          "width": {
+            "type": "option",
+            "value": "fill"
+          },
+          "padding": {
+            "top": {
+              "type": "exact",
+              "value": {
+                "unit": "px",
+                "value": 0
+              }
+            },
+            "right": {
+              "type": "exact",
+              "value": {
+                "unit": "px",
+                "value": 0
+              }
+            },
+            "bottom": {
+              "type": "exact",
+              "value": {
+                "unit": "px",
+                "value": 0
+              }
+            },
+            "left": {
+              "type": "exact",
+              "value": {
+                "unit": "px",
+                "value": 0
+              }
+            }
+          },
+          "background": [
+            {
+              "kind": {
+                "type": "option",
+                "value": "none"
+              }
+            }
+          ],
+          "border": {
+            "preset": {
+              "type": "theme.categorical",
+              "value": "@border.none"
+            }
+          },
+          "corners": {
+            "topLeft": {
+              "type": "empty",
+              "value": null
+            },
+            "topRight": {
+              "type": "empty",
+              "value": null
+            },
+            "bottomLeft": {
+              "type": "empty",
+              "value": null
+            },
+            "bottomRight": {
+              "type": "empty",
+              "value": null
+            }
+          },
+          "role": {
+            "type": "option",
+            "value": "combobox"
+          },
+          "ariaHasPopup": {
+            "type": "option",
+            "value": "listbox"
+          },
+          "font": {
+            "size": {
+              "type": "theme.ordinal",
+              "value": "@fontSize.xsmall"
+            }
+          }
+        }
+      }
+    },
+    "component-sidebar-DIrG823L": {
+      "id": "component-sidebar-DIrG823L",
+      "type": "instance",
+      "level": "element",
+      "label": "Combobox Field",
+      "theme": null,
+      "template": "node:component-comboboxField-cMKwpdAk",
+      "overrides": {},
+      "origin": "user",
+      "__editor": {
+        "initialOverrides": {}
+      }
+    },
+    "component-sidebar-7PcFsirP": {
+      "id": "component-sidebar-7PcFsirP",
+      "type": "instance",
+      "level": "primitive",
+      "label": "Icon",
+      "theme": null,
+      "template": "node:component-icon-V1g4W5fN",
+      "overrides": {},
+      "origin": "user",
+      "__editor": {
+        "initialOverrides": {
+          "symbol": {
+            "type": "option",
+            "value": "seldon-component"
+          },
+          "size": {
+            "type": "theme.ordinal",
+            "value": "@size.small"
+          },
+          "color": {
+            "type": "computed",
+            "value": "highContrastColor"
+          }
+        }
+      }
+    },
+    "component-sidebar-7ACASv5Y": {
+      "id": "component-sidebar-7ACASv5Y",
+      "type": "instance",
+      "level": "primitive",
+      "label": "Input",
+      "theme": null,
+      "template": "node:component-input-IeGTgo7S",
+      "overrides": {},
+      "origin": "user",
+      "__editor": {
+        "initialOverrides": {
+          "width": {
+            "type": "option",
+            "value": "fill"
+          },
+          "padding": {
+            "top": {
+              "type": "exact",
+              "value": {
+                "unit": "px",
+                "value": 0
+              }
+            },
+            "right": {
+              "type": "exact",
+              "value": {
+                "unit": "px",
+                "value": 0
+              }
+            },
+            "bottom": {
+              "type": "exact",
+              "value": {
+                "unit": "px",
+                "value": 0
+              }
+            },
+            "left": {
+              "type": "exact",
+              "value": {
+                "unit": "px",
+                "value": 0
+              }
+            }
+          },
+          "background": [
+            {
+              "kind": {
+                "type": "option",
+                "value": "none"
+              }
+            }
+          ],
+          "border": {
+            "preset": {
+              "type": "theme.categorical",
+              "value": "@border.none"
+            }
+          },
+          "corners": {
+            "topLeft": {
+              "type": "empty",
+              "value": null
+            },
+            "topRight": {
+              "type": "empty",
+              "value": null
+            },
+            "bottomLeft": {
+              "type": "empty",
+              "value": null
+            },
+            "bottomRight": {
+              "type": "empty",
+              "value": null
+            }
+          },
+          "role": {
+            "type": "option",
+            "value": "combobox"
+          },
+          "ariaHasPopup": {
+            "type": "option",
+            "value": "listbox"
+          },
+          "font": {
+            "size": {
+              "type": "theme.ordinal",
+              "value": "@fontSize.xsmall"
+            }
+          }
+        }
+      }
+    },
+    "component-sidebar-Vly9bSsT": {
+      "id": "component-sidebar-Vly9bSsT",
+      "type": "instance",
+      "level": "element",
+      "label": "Iconic",
+      "theme": null,
+      "template": "node:component-button-HqmnST2I",
+      "overrides": {},
+      "origin": "user",
+      "__editor": {
+        "initialOverrides": {
+          "buttonSize": {
+            "type": "theme.ordinal",
+            "value": "@fontSize.small"
+          },
+          "background": [
+            {
+              "kind": {
+                "type": "option",
+                "value": "none"
+              }
+            }
+          ],
+          "border": {
+            "preset": {
+              "type": "theme.categorical",
+              "value": "@border.none"
+            }
+          }
+        }
+      }
+    },
+    "component-sidebar-a94ywyeX": {
+      "id": "component-sidebar-a94ywyeX",
+      "type": "instance",
+      "level": "primitive",
+      "label": "Icon",
+      "theme": null,
+      "template": "node:component-icon-vzp64Ki8",
+      "overrides": {},
+      "origin": "user",
+      "__editor": {
+        "initialOverrides": {
+          "symbol": {
+            "type": "option",
+            "value": "material-chevronDown"
+          },
+          "size": {
+            "type": "computed",
+            "value": "autoFit"
+          },
+          "color": {
+            "type": "computed",
+            "value": "highContrastColor"
+          }
+        }
+      }
+    },
+    "component-sidebar-9aqniZBt": {
+      "id": "component-sidebar-9aqniZBt",
+      "type": "instance",
+      "level": "element",
+      "label": "Iconic",
+      "theme": null,
+      "template": "node:component-button-CGRbb6mm",
+      "overrides": {},
+      "origin": "user",
+      "__editor": {
+        "initialOverrides": {
+          "buttonSize": {
+            "type": "theme.ordinal",
+            "value": "@fontSize.small"
+          },
+          "padding": {
+            "top": {
+              "type": "theme.ordinal",
+              "value": "@padding.tight"
+            },
+            "right": {
+              "type": "theme.ordinal",
+              "value": "@padding.tight"
+            },
+            "bottom": {
+              "type": "theme.ordinal",
+              "value": "@padding.tight"
+            },
+            "left": {
+              "type": "theme.ordinal",
+              "value": "@padding.tight"
+            }
+          },
+          "border": {
+            "preset": {
+              "type": "theme.categorical",
+              "value": "@border.thin"
+            }
+          }
+        }
+      }
+    },
+    "component-sidebar-pjLC9d7r": {
+      "id": "component-sidebar-pjLC9d7r",
+      "type": "instance",
+      "level": "primitive",
+      "label": "Icon",
+      "theme": null,
+      "template": "node:component-icon-5Coex6SW",
+      "overrides": {},
+      "origin": "user",
+      "__editor": {
+        "initialOverrides": {
+          "symbol": {
+            "type": "option",
+            "value": "material-moreHoriz"
+          },
+          "size": {
+            "type": "computed",
+            "value": "autoFit"
+          },
+          "color": {
+            "type": "computed",
+            "value": "highContrastColor"
+          }
+        }
+      }
+    },
+    "component-button-f2yi4eeO": {
+      "id": "component-button-f2yi4eeO",
+      "ref": "sidebarComponents",
+      "type": "instance",
+      "level": "element",
+      "label": "Toggle",
+      "theme": null,
+      "template": "node:component-button-JxkeXZK8",
+      "overrides": {},
+      "origin": "user"
+    },
+    "component-button-4VOfbe9o": {
+      "id": "component-button-4VOfbe9o",
+      "type": "instance",
+      "level": "primitive",
+      "label": "Icon",
+      "theme": null,
+      "template": "node:component-button-oVKDSm9s",
+      "overrides": {},
+      "origin": "user",
+      "__editor": {
+        "initialOverrides": {
+          "symbol": {
+            "type": "option",
+            "value": "seldon-component"
+          },
+          "size": {
+            "type": "computed",
+            "value": "autoFit"
+          },
+          "color": {
+            "type": "computed",
+            "value": "highContrastColor"
+          }
+        }
+      }
+    },
+    "component-sidebar-9VESc1Om": {
+      "id": "component-sidebar-9VESc1Om",
+      "ref": "sidebarResources",
+      "type": "instance",
+      "level": "element",
+      "label": "Toggle",
+      "theme": null,
+      "template": "node:component-button-JxkeXZK8",
+      "overrides": {},
+      "origin": "user"
+    },
+    "component-sidebar-Zc8L5Z3e": {
+      "id": "component-sidebar-Zc8L5Z3e",
+      "type": "instance",
+      "level": "primitive",
+      "label": "Icon",
+      "theme": null,
+      "template": "node:component-button-oVKDSm9s",
+      "overrides": {
+        "symbol": {
+          "type": "option",
+          "value": "seldon-theme"
+        }
+      },
+      "origin": "user",
+      "__editor": {
+        "initialOverrides": {
+          "symbol": {
+            "type": "option",
+            "value": "seldon-component"
+          },
+          "size": {
+            "type": "computed",
+            "value": "autoFit"
+          },
+          "color": {
+            "type": "computed",
+            "value": "highContrastColor"
+          }
+        }
+      }
+    },
+    "component-frame-mA6ivt6b": {
+      "id": "component-frame-mA6ivt6b",
+      "type": "instance",
+      "level": "frame",
+      "label": "Frame",
+      "theme": null,
+      "template": "node:component-frame-default",
+      "overrides": {
+        "orientation": {
+          "type": "option",
+          "value": "horizontal"
+        },
+        "margin": {
+          "top": {
+            "type": "option",
+            "value": "none"
+          },
+          "right": {
+            "type": "option",
+            "value": "none"
+          },
+          "bottom": {
+            "type": "option",
+            "value": "none"
+          },
+          "left": {
+            "type": "option",
+            "value": "none"
+          }
+        },
+        "padding": {
+          "top": {
+            "type": "option",
+            "value": "none"
+          },
+          "right": {
+            "type": "option",
+            "value": "none"
+          },
+          "bottom": {
+            "type": "option",
+            "value": "none"
+          },
+          "left": {
+            "type": "theme.ordinal",
+            "value": "@padding.cozy"
+          }
+        },
+        "gap": {
+          "type": "theme.ordinal",
+          "value": "@gap.tight"
+        },
+        "width": {
+          "type": "option",
+          "value": "fit"
+        },
+        "borderLeft": {
+          "preset": {
+            "type": "theme.categorical",
+            "value": "@border.hairline"
+          },
+          "brightness": {
+            "type": "empty",
+            "value": null
+          },
+          "opacity": {
+            "type": "exact",
+            "value": {
+              "unit": "%",
+              "value": 50
+            }
+          }
+        }
+      },
+      "origin": "user"
+    },
+    "component-item-A2qQLKuh": {
+      "id": "component-item-A2qQLKuh",
+      "ref": "nodeDisplay",
+      "type": "instance",
+      "level": "element",
+      "label": "Iconic",
+      "theme": null,
+      "template": "node:component-button-iconic",
+      "overrides": {},
+      "origin": "schema",
+      "__editor": {
+        "initialOverrides": {
+          "buttonSize": {
+            "type": "theme.ordinal",
+            "value": "@fontSize.small"
+          },
+          "background": [
+            {
+              "kind": {
+                "type": "option",
+                "value": "none"
+              }
+            }
+          ],
+          "border": {
+            "preset": {
+              "type": "theme.categorical",
+              "value": "@border.none"
+            }
+          }
+        }
+      }
+    },
+    "component-item-vfutzRjn": {
+      "id": "component-item-vfutzRjn",
+      "type": "instance",
+      "level": "primitive",
+      "label": "Icon",
+      "theme": null,
+      "template": "node:component-icon-VSAubWrH",
+      "overrides": {
+        "symbol": {
+          "type": "option",
+          "value": "seldon-display"
+        },
+        "display": {
+          "type": "option",
+          "value": "show"
+        },
+        "size": {
+          "type": "theme.ordinal",
+          "value": "@size.small"
+        }
+      },
+      "origin": "schema",
+      "__editor": {
+        "initialOverrides": {
+          "symbol": {
+            "type": "option",
+            "value": "material-chevronDown"
+          },
+          "size": {
+            "type": "computed",
+            "value": "autoFit"
+          },
+          "color": {
+            "type": "computed",
+            "value": "highContrastColor"
+          }
+        }
+      }
+    },
+    "component-item-v4KlFUSC": {
+      "id": "component-item-v4KlFUSC",
+      "type": "instance",
+      "level": "element",
+      "label": "Node",
+      "theme": null,
+      "template": "node:component-item-TnD6GN06",
+      "overrides": {
+        "display": {
+          "type": "option",
+          "value": "mock"
+        }
+      },
+      "origin": "user",
+      "__editor": {
+        "repeat": {
+          "count": 3
+        }
+      }
+    },
+    "component-item-bE0MzZf7": {
+      "id": "component-item-bE0MzZf7",
+      "type": "instance",
+      "level": "element",
+      "label": "Iconic",
+      "theme": null,
+      "template": "node:component-item-HSgjhz6b",
+      "overrides": {},
+      "origin": "user",
+      "__editor": {
+        "initialOverrides": {
+          "buttonSize": {
+            "type": "theme.ordinal",
+            "value": "@fontSize.small"
+          },
+          "padding": {
+            "top": {
+              "type": "theme.ordinal",
+              "value": "@padding.tight"
+            },
+            "right": {
+              "type": "theme.ordinal",
+              "value": "@padding.tight"
+            },
+            "bottom": {
+              "type": "theme.ordinal",
+              "value": "@padding.tight"
+            },
+            "left": {
+              "type": "theme.ordinal",
+              "value": "@padding.tight"
+            }
+          },
+          "background": [
+            {
+              "kind": {
+                "type": "option",
+                "value": "none"
+              }
+            }
+          ],
+          "border": {
+            "preset": {
+              "type": "theme.categorical",
+              "value": "@border.none"
+            }
+          }
+        }
+      }
+    },
+    "component-item-aKs0x8nh": {
+      "id": "component-item-aKs0x8nh",
+      "type": "instance",
+      "level": "primitive",
+      "label": "Icon",
+      "theme": null,
+      "template": "node:component-item-zn8GFZsT",
+      "overrides": {},
+      "origin": "user",
+      "__editor": {
+        "initialOverrides": {
+          "symbol": {
+            "type": "option",
+            "value": "material-chevronDown"
+          },
+          "size": {
+            "type": "computed",
+            "value": "autoFit"
+          },
+          "color": {
+            "type": "computed",
+            "value": "highContrastColor"
+          }
+        }
+      }
+    },
+    "component-item-kM0npFEE": {
+      "id": "component-item-kM0npFEE",
+      "type": "instance",
+      "level": "element",
+      "label": "Combobox Field",
+      "theme": null,
+      "template": "node:component-item-LMjE9ivP",
+      "overrides": {},
+      "origin": "user",
+      "__editor": {
+        "initialOverrides": {}
+      }
+    },
+    "component-item-bzUsF0bh": {
+      "id": "component-item-bzUsF0bh",
+      "type": "instance",
+      "level": "primitive",
+      "label": "Icon",
+      "theme": null,
+      "template": "node:component-item-zdDEhaL4",
+      "overrides": {},
+      "origin": "user",
+      "__editor": {
+        "initialOverrides": {
+          "symbol": {
+            "type": "option",
+            "value": "seldon-component"
+          },
+          "size": {
+            "type": "theme.ordinal",
+            "value": "@size.small"
+          },
+          "color": {
+            "type": "computed",
+            "value": "highContrastColor"
+          }
+        }
+      }
+    },
+    "component-item-MVKvGWgt": {
+      "id": "component-item-MVKvGWgt",
+      "type": "instance",
+      "level": "primitive",
+      "label": "Input",
+      "theme": null,
+      "template": "node:component-item-pZCfJ3k6",
+      "overrides": {},
+      "origin": "user",
+      "__editor": {
+        "initialOverrides": {
+          "width": {
+            "type": "option",
+            "value": "fill"
+          },
+          "padding": {
+            "top": {
+              "type": "exact",
+              "value": {
+                "unit": "px",
+                "value": 0
+              }
+            },
+            "right": {
+              "type": "exact",
+              "value": {
+                "unit": "px",
+                "value": 0
+              }
+            },
+            "bottom": {
+              "type": "exact",
+              "value": {
+                "unit": "px",
+                "value": 0
+              }
+            },
+            "left": {
+              "type": "exact",
+              "value": {
+                "unit": "px",
+                "value": 0
+              }
+            }
+          },
+          "background": [
+            {
+              "kind": {
+                "type": "option",
+                "value": "none"
+              }
+            }
+          ],
+          "border": {
+            "preset": {
+              "type": "theme.categorical",
+              "value": "@border.none"
+            }
+          },
+          "corners": {
+            "topLeft": {
+              "type": "empty",
+              "value": null
+            },
+            "topRight": {
+              "type": "empty",
+              "value": null
+            },
+            "bottomLeft": {
+              "type": "empty",
+              "value": null
+            },
+            "bottomRight": {
+              "type": "empty",
+              "value": null
+            }
+          },
+          "role": {
+            "type": "option",
+            "value": "combobox"
+          },
+          "ariaHasPopup": {
+            "type": "option",
+            "value": "listbox"
+          },
+          "font": {
+            "size": {
+              "type": "theme.ordinal",
+              "value": "@fontSize.xsmall"
+            }
+          }
+        }
+      }
+    },
+    "component-item-xtM8Jv36": {
+      "id": "component-item-xtM8Jv36",
+      "type": "instance",
+      "level": "element",
+      "label": "Iconic",
+      "theme": null,
+      "template": "node:component-item-A2qQLKuh",
+      "overrides": {},
+      "origin": "user",
+      "__editor": {
+        "initialOverrides": {
+          "buttonSize": {
+            "type": "theme.ordinal",
+            "value": "@fontSize.small"
+          },
+          "background": [
+            {
+              "kind": {
+                "type": "option",
+                "value": "none"
+              }
+            }
+          ],
+          "border": {
+            "preset": {
+              "type": "theme.categorical",
+              "value": "@border.none"
+            }
+          }
+        }
+      }
+    },
+    "component-item-W8nnrW0C": {
+      "id": "component-item-W8nnrW0C",
+      "type": "instance",
+      "level": "primitive",
+      "label": "Icon",
+      "theme": null,
+      "template": "node:component-item-vfutzRjn",
+      "overrides": {},
+      "origin": "user",
+      "__editor": {
+        "initialOverrides": {
+          "symbol": {
+            "type": "option",
+            "value": "material-chevronDown"
+          },
+          "size": {
+            "type": "computed",
+            "value": "autoFit"
+          },
+          "color": {
+            "type": "computed",
+            "value": "highContrastColor"
+          }
+        }
+      }
+    },
+    "component-item-ef9iTpe3": {
+      "id": "component-item-ef9iTpe3",
+      "type": "instance",
+      "level": "element",
+      "label": "Iconic",
+      "theme": null,
+      "template": "node:component-item-CeZRPCDC",
+      "overrides": {},
+      "origin": "user",
+      "__editor": {
+        "initialOverrides": {
+          "buttonSize": {
+            "type": "theme.ordinal",
+            "value": "@fontSize.small"
+          },
+          "background": [
+            {
+              "kind": {
+                "type": "option",
+                "value": "none"
+              }
+            }
+          ],
+          "border": {
+            "preset": {
+              "type": "theme.categorical",
+              "value": "@border.none"
+            }
+          }
+        }
+      }
+    },
+    "component-item-vHi7LWPt": {
+      "id": "component-item-vHi7LWPt",
+      "type": "instance",
+      "level": "primitive",
+      "label": "Icon",
+      "theme": null,
+      "template": "node:component-item-ZpsMrUME",
+      "overrides": {},
+      "origin": "user",
+      "__editor": {
+        "initialOverrides": {
+          "symbol": {
+            "type": "option",
+            "value": "material-chevronDown"
+          },
+          "size": {
+            "type": "computed",
+            "value": "autoFit"
+          },
+          "color": {
+            "type": "computed",
+            "value": "highContrastColor"
+          }
+        }
+      }
+    },
+    "component-sidebar-MSYjRcHI": {
+      "id": "component-sidebar-MSYjRcHI",
+      "type": "instance",
+      "level": "element",
+      "label": "Node",
+      "theme": null,
+      "template": "node:component-item-TnD6GN06",
+      "overrides": {
+        "display": {
+          "type": "option",
+          "value": "mock"
+        }
+      },
+      "origin": "user",
+      "__editor": {
+        "repeat": {
+          "count": 5
+        }
+      }
+    },
+    "component-sidebar-0balcrH4": {
+      "id": "component-sidebar-0balcrH4",
+      "type": "instance",
+      "level": "element",
+      "label": "Iconic",
+      "theme": null,
+      "template": "node:component-item-HSgjhz6b",
+      "overrides": {},
+      "origin": "user",
+      "__editor": {
+        "initialOverrides": {
+          "buttonSize": {
+            "type": "theme.ordinal",
+            "value": "@fontSize.small"
+          },
+          "padding": {
+            "top": {
+              "type": "theme.ordinal",
+              "value": "@padding.tight"
+            },
+            "right": {
+              "type": "theme.ordinal",
+              "value": "@padding.tight"
+            },
+            "bottom": {
+              "type": "theme.ordinal",
+              "value": "@padding.tight"
+            },
+            "left": {
+              "type": "theme.ordinal",
+              "value": "@padding.tight"
+            }
+          },
+          "background": [
+            {
+              "kind": {
+                "type": "option",
+                "value": "none"
+              }
+            }
+          ],
+          "border": {
+            "preset": {
+              "type": "theme.categorical",
+              "value": "@border.none"
+            }
+          }
+        }
+      }
+    },
+    "component-sidebar-69mi9aTF": {
+      "id": "component-sidebar-69mi9aTF",
+      "type": "instance",
+      "level": "primitive",
+      "label": "Icon",
+      "theme": null,
+      "template": "node:component-item-zn8GFZsT",
+      "overrides": {},
+      "origin": "user",
+      "__editor": {
+        "initialOverrides": {
+          "symbol": {
+            "type": "option",
+            "value": "material-chevronDown"
+          },
+          "size": {
+            "type": "computed",
+            "value": "autoFit"
+          },
+          "color": {
+            "type": "computed",
+            "value": "highContrastColor"
+          }
+        }
+      }
+    },
+    "component-sidebar-EqUJmih2": {
+      "id": "component-sidebar-EqUJmih2",
+      "type": "instance",
+      "level": "element",
+      "label": "Combobox Field",
+      "theme": null,
+      "template": "node:component-item-LMjE9ivP",
+      "overrides": {},
+      "origin": "user",
+      "__editor": {
+        "initialOverrides": {}
+      }
+    },
+    "component-sidebar-37xyw8Qj": {
+      "id": "component-sidebar-37xyw8Qj",
+      "type": "instance",
+      "level": "primitive",
+      "label": "Icon",
+      "theme": null,
+      "template": "node:component-item-zdDEhaL4",
+      "overrides": {},
+      "origin": "user",
+      "__editor": {
+        "initialOverrides": {
+          "symbol": {
+            "type": "option",
+            "value": "seldon-component"
+          },
+          "size": {
+            "type": "theme.ordinal",
+            "value": "@size.small"
+          },
+          "color": {
+            "type": "computed",
+            "value": "highContrastColor"
+          }
+        }
+      }
+    },
+    "component-sidebar-hbiOoaHi": {
+      "id": "component-sidebar-hbiOoaHi",
+      "type": "instance",
+      "level": "primitive",
+      "label": "Input",
+      "theme": null,
+      "template": "node:component-item-pZCfJ3k6",
+      "overrides": {},
+      "origin": "user",
+      "__editor": {
+        "initialOverrides": {
+          "width": {
+            "type": "option",
+            "value": "fill"
+          },
+          "padding": {
+            "top": {
+              "type": "exact",
+              "value": {
+                "unit": "px",
+                "value": 0
+              }
+            },
+            "right": {
+              "type": "exact",
+              "value": {
+                "unit": "px",
+                "value": 0
+              }
+            },
+            "bottom": {
+              "type": "exact",
+              "value": {
+                "unit": "px",
+                "value": 0
+              }
+            },
+            "left": {
+              "type": "exact",
+              "value": {
+                "unit": "px",
+                "value": 0
+              }
+            }
+          },
+          "background": [
+            {
+              "kind": {
+                "type": "option",
+                "value": "none"
+              }
+            }
+          ],
+          "border": {
+            "preset": {
+              "type": "theme.categorical",
+              "value": "@border.none"
+            }
+          },
+          "corners": {
+            "topLeft": {
+              "type": "empty",
+              "value": null
+            },
+            "topRight": {
+              "type": "empty",
+              "value": null
+            },
+            "bottomLeft": {
+              "type": "empty",
+              "value": null
+            },
+            "bottomRight": {
+              "type": "empty",
+              "value": null
+            }
+          },
+          "role": {
+            "type": "option",
+            "value": "combobox"
+          },
+          "ariaHasPopup": {
+            "type": "option",
+            "value": "listbox"
+          },
+          "font": {
+            "size": {
+              "type": "theme.ordinal",
+              "value": "@fontSize.xsmall"
+            }
+          }
+        }
+      }
+    },
+    "component-sidebar-tY21VVgA": {
+      "id": "component-sidebar-tY21VVgA",
+      "type": "instance",
+      "level": "element",
+      "label": "Iconic",
+      "theme": null,
+      "template": "node:component-item-A2qQLKuh",
+      "overrides": {},
+      "origin": "user",
+      "__editor": {
+        "initialOverrides": {
+          "buttonSize": {
+            "type": "theme.ordinal",
+            "value": "@fontSize.small"
+          },
+          "background": [
+            {
+              "kind": {
+                "type": "option",
+                "value": "none"
+              }
+            }
+          ],
+          "border": {
+            "preset": {
+              "type": "theme.categorical",
+              "value": "@border.none"
+            }
+          }
+        }
+      }
+    },
+    "component-sidebar-08lOeHXm": {
+      "id": "component-sidebar-08lOeHXm",
+      "type": "instance",
+      "level": "primitive",
+      "label": "Icon",
+      "theme": null,
+      "template": "node:component-item-vfutzRjn",
+      "overrides": {},
+      "origin": "user",
+      "__editor": {
+        "initialOverrides": {
+          "symbol": {
+            "type": "option",
+            "value": "material-chevronDown"
+          },
+          "size": {
+            "type": "computed",
+            "value": "autoFit"
+          },
+          "color": {
+            "type": "computed",
+            "value": "highContrastColor"
+          }
+        }
+      }
+    },
+    "component-sidebar-R7vX91zP": {
+      "id": "component-sidebar-R7vX91zP",
+      "type": "instance",
+      "level": "element",
+      "label": "Iconic",
+      "theme": null,
+      "template": "node:component-item-CeZRPCDC",
+      "overrides": {},
+      "origin": "user",
+      "__editor": {
+        "initialOverrides": {
+          "buttonSize": {
+            "type": "theme.ordinal",
+            "value": "@fontSize.small"
+          },
+          "background": [
+            {
+              "kind": {
+                "type": "option",
+                "value": "none"
+              }
+            }
+          ],
+          "border": {
+            "preset": {
+              "type": "theme.categorical",
+              "value": "@border.none"
+            }
+          }
+        }
+      }
+    },
+    "component-sidebar-GgC4jObF": {
+      "id": "component-sidebar-GgC4jObF",
+      "type": "instance",
+      "level": "primitive",
+      "label": "Icon",
+      "theme": null,
+      "template": "node:component-item-ZpsMrUME",
+      "overrides": {},
+      "origin": "user",
+      "__editor": {
+        "initialOverrides": {
+          "symbol": {
+            "type": "option",
+            "value": "material-chevronDown"
+          },
+          "size": {
+            "type": "computed",
+            "value": "autoFit"
+          },
+          "color": {
+            "type": "computed",
+            "value": "highContrastColor"
           }
         }
       }

--- a/seldon-editor.json
+++ b/seldon-editor.json
@@ -54308,17 +54308,14 @@
         "border": {
           "color": {
             "type": "theme.categorical",
-            "value": "@swatch.primary"
+            "value": "@swatch.offBlack"
           }
         },
         "background": [
           {
-            "brightness": {
-              "type": "exact",
-              "value": {
-                "unit": "%",
-                "value": 75
-              }
+            "color": {
+              "type": "theme.categorical",
+              "value": "@swatch.offWhite"
             }
           }
         ]
@@ -54347,55 +54344,14 @@
       },
       "states": {
         "active": {
-          "border": {
-            "opacity": {
-              "type": "exact",
-              "value": {
-                "unit": "%",
-                "value": 60
-              }
-            }
-          },
+          "border": {},
           "background": [
-            {
-              "color": {
-                "type": "theme.categorical",
-                "value": "@swatch.primary"
-              },
-              "opacity": {
-                "type": "exact",
-                "value": {
-                  "unit": "%",
-                  "value": 40
-                }
-              }
-            }
+            {}
           ]
         },
         "hover": {
-          "border": {
-            "opacity": {
-              "type": "exact",
-              "value": {
-                "unit": "%",
-                "value": 80
-              }
-            }
-          },
           "background": [
-            {
-              "color": {
-                "type": "theme.categorical",
-                "value": "@swatch.primary"
-              },
-              "opacity": {
-                "type": "exact",
-                "value": {
-                  "unit": "%",
-                  "value": 20
-                }
-              }
-            }
+            {}
           ]
         },
         "disabled": {
@@ -54445,13 +54401,6 @@
               "color": {
                 "type": "theme.categorical",
                 "value": "@swatch.offWhite"
-              },
-              "brightness": {
-                "type": "exact",
-                "value": {
-                  "unit": "%",
-                  "value": 0
-                }
               }
             }
           ]
@@ -54463,6 +54412,16 @@
               "value": "@swatch.negative"
             }
           }
+        },
+        "dragged": {
+          "background": [
+            {
+              "color": {
+                "type": "theme.categorical",
+                "value": "@swatch.primary"
+              }
+            }
+          ]
         }
       }
     },

--- a/seldon-editor.json
+++ b/seldon-editor.json
@@ -3116,19 +3116,24 @@
           "id": "component-sidebar-JPgwrmRn",
           "children": [
             {
-              "id": "component-comboboxField-rZdYB5xB",
+              "id": "component-frame-p4y0JeD3",
               "children": [
                 {
-                  "id": "component-comboboxField-McgE030b"
-                },
-                {
-                  "id": "component-comboboxField-spqmpmg5"
-                },
-                {
-                  "id": "component-comboboxField-o9tr7uLV",
+                  "id": "component-comboboxField-rZdYB5xB",
                   "children": [
                     {
-                      "id": "component-comboboxField-iquyeQxk"
+                      "id": "component-comboboxField-McgE030b"
+                    },
+                    {
+                      "id": "component-comboboxField-spqmpmg5"
+                    },
+                    {
+                      "id": "component-comboboxField-o9tr7uLV",
+                      "children": [
+                        {
+                          "id": "component-comboboxField-iquyeQxk"
+                        }
+                      ]
                     }
                   ]
                 },
@@ -6426,6 +6431,33 @@
                   "children": [
                     {
                       "id": "component-message-H9AYMh8C"
+                    }
+                  ]
+                },
+                {
+                  "id": "component-message-nawXvQfN",
+                  "children": [
+                    {
+                      "id": "component-message-pA0QXIMj",
+                      "children": [
+                        {
+                          "id": "component-message-OAnuFd88",
+                          "children": [
+                            {
+                              "id": "component-message-syyvOPAO"
+                            }
+                          ]
+                        },
+                        {
+                          "id": "component-message-W046MhPP"
+                        },
+                        {
+                          "id": "component-message-9TPHNjXN"
+                        }
+                      ]
+                    },
+                    {
+                      "id": "component-message-xd64xwRz"
                     }
                   ]
                 },
@@ -25345,6 +25377,10 @@
         "display": {
           "type": "option",
           "value": "show"
+        },
+        "height": {
+          "type": "option",
+          "value": "fit"
         }
       },
       "origin": "schema",
@@ -25390,7 +25426,29 @@
         ],
         "gap": {
           "type": "theme.ordinal",
-          "value": "@gap.cozy"
+          "value": "@gap.tight"
+        },
+        "display": {
+          "type": "option",
+          "value": "show"
+        },
+        "padding": {
+          "top": {
+            "type": "option",
+            "value": "none"
+          },
+          "right": {
+            "type": "option",
+            "value": "none"
+          },
+          "bottom": {
+            "type": "option",
+            "value": "none"
+          },
+          "left": {
+            "type": "theme.ordinal",
+            "value": "@padding.tight"
+          }
         }
       },
       "origin": "user"
@@ -62064,7 +62122,7 @@
           },
           "left": {
             "type": "theme.ordinal",
-            "value": "@padding.cozy"
+            "value": "@padding.compact"
           }
         },
         "gap": {
@@ -62091,6 +62149,10 @@
               "value": 50
             }
           }
+        },
+        "align": {
+          "type": "option",
+          "value": "right"
         }
       },
       "origin": "user"
@@ -62139,10 +62201,6 @@
         "symbol": {
           "type": "option",
           "value": "seldon-display"
-        },
-        "display": {
-          "type": "option",
-          "value": "show"
         },
         "size": {
           "type": "theme.ordinal",
@@ -62856,6 +62914,297 @@
           }
         }
       }
+    },
+    "component-message-nawXvQfN": {
+      "id": "component-message-nawXvQfN",
+      "type": "instance",
+      "level": "element",
+      "label": "Thinking",
+      "theme": null,
+      "template": "node:component-message-thinking",
+      "overrides": {
+        "display": {
+          "type": "option",
+          "value": "mock"
+        }
+      },
+      "origin": "user"
+    },
+    "component-message-pA0QXIMj": {
+      "id": "component-message-pA0QXIMj",
+      "type": "instance",
+      "level": "frame",
+      "label": "Frame",
+      "theme": null,
+      "template": "node:component-frame-IEewTaDU",
+      "overrides": {},
+      "origin": "user",
+      "__editor": {
+        "initialOverrides": {
+          "orientation": {
+            "type": "option",
+            "value": "horizontal"
+          },
+          "align": {
+            "type": "option",
+            "value": "left"
+          },
+          "width": {
+            "type": "option",
+            "value": "fill"
+          },
+          "gap": {
+            "type": "theme.ordinal",
+            "value": "@gap.tight"
+          }
+        }
+      }
+    },
+    "component-message-OAnuFd88": {
+      "id": "component-message-OAnuFd88",
+      "type": "instance",
+      "level": "element",
+      "label": "Iconic",
+      "theme": null,
+      "template": "node:component-button-iKLUV4uP",
+      "overrides": {},
+      "origin": "user",
+      "__editor": {
+        "initialOverrides": {
+          "buttonSize": {
+            "type": "theme.ordinal",
+            "value": "@fontSize.xsmall"
+          },
+          "padding": {
+            "top": {
+              "type": "theme.ordinal",
+              "value": "@padding.tight"
+            },
+            "right": {
+              "type": "theme.ordinal",
+              "value": "@padding.tight"
+            },
+            "bottom": {
+              "type": "theme.ordinal",
+              "value": "@padding.tight"
+            },
+            "left": {
+              "type": "theme.ordinal",
+              "value": "@padding.tight"
+            }
+          },
+          "background": [
+            {
+              "kind": {
+                "type": "option",
+                "value": "color"
+              },
+              "color": {
+                "type": "option",
+                "value": "transparent"
+              }
+            }
+          ]
+        }
+      }
+    },
+    "component-message-syyvOPAO": {
+      "id": "component-message-syyvOPAO",
+      "type": "instance",
+      "level": "primitive",
+      "label": "Icon",
+      "theme": null,
+      "template": "node:component-icon-KzY9lbAe",
+      "overrides": {},
+      "origin": "user",
+      "__editor": {
+        "initialOverrides": {
+          "symbol": {
+            "type": "option",
+            "value": "material-chevronDown"
+          },
+          "size": {
+            "type": "computed",
+            "value": "autoFit"
+          },
+          "color": {
+            "type": "computed",
+            "value": "highContrastColor"
+          }
+        }
+      }
+    },
+    "component-message-W046MhPP": {
+      "id": "component-message-W046MhPP",
+      "type": "instance",
+      "level": "primitive",
+      "label": "Description",
+      "theme": null,
+      "template": "node:component-text-0r1JFBYH",
+      "overrides": {
+        "content": {
+          "type": "exact",
+          "value": "Thought for 23s · gpt-oss20:b · minimal"
+        }
+      },
+      "origin": "user",
+      "__editor": {
+        "initialOverrides": {
+          "content": {
+            "type": "exact",
+            "value": "Thinking..."
+          },
+          "width": {
+            "type": "option",
+            "value": "fill"
+          },
+          "color": {
+            "type": "computed",
+            "value": "highContrastColor"
+          },
+          "font": {
+            "preset": {
+              "type": "theme.categorical",
+              "value": "@font.label"
+            },
+            "size": {
+              "type": "theme.ordinal",
+              "value": "@fontSize.xsmall"
+            }
+          }
+        }
+      }
+    },
+    "component-message-9TPHNjXN": {
+      "id": "component-message-9TPHNjXN",
+      "type": "instance",
+      "level": "primitive",
+      "label": "Description",
+      "theme": null,
+      "template": "node:component-message-aeeOGbms",
+      "overrides": {},
+      "origin": "user",
+      "__editor": {
+        "initialOverrides": {
+          "content": {
+            "type": "exact",
+            "value": "Thinking..."
+          },
+          "width": {
+            "type": "option",
+            "value": "fill"
+          },
+          "color": {
+            "type": "computed",
+            "value": "highContrastColor"
+          },
+          "font": {
+            "preset": {
+              "type": "theme.categorical",
+              "value": "@font.label"
+            },
+            "size": {
+              "type": "theme.ordinal",
+              "value": "@fontSize.xsmall"
+            }
+          }
+        }
+      }
+    },
+    "component-message-xd64xwRz": {
+      "id": "component-message-xd64xwRz",
+      "type": "instance",
+      "level": "primitive",
+      "label": "Description",
+      "theme": null,
+      "template": "node:component-text-cHoacyQ2",
+      "overrides": {},
+      "origin": "user",
+      "__editor": {
+        "initialOverrides": {
+          "content": {
+            "type": "exact",
+            "value": "Reasoning..."
+          },
+          "width": {
+            "type": "option",
+            "value": "fill"
+          },
+          "color": {
+            "type": "computed",
+            "value": "highContrastColor"
+          },
+          "font": {
+            "preset": {
+              "type": "theme.categorical",
+              "value": "@font.body"
+            },
+            "size": {
+              "type": "theme.ordinal",
+              "value": "@fontSize.xsmall"
+            }
+          }
+        }
+      }
+    },
+    "component-frame-p4y0JeD3": {
+      "id": "component-frame-p4y0JeD3",
+      "type": "instance",
+      "level": "frame",
+      "label": "Frame",
+      "theme": null,
+      "template": "node:component-frame-default",
+      "overrides": {
+        "margin": {
+          "top": {
+            "type": "option",
+            "value": "none"
+          },
+          "right": {
+            "type": "option",
+            "value": "none"
+          },
+          "bottom": {
+            "type": "option",
+            "value": "none"
+          },
+          "left": {
+            "type": "option",
+            "value": "none"
+          }
+        },
+        "padding": {
+          "top": {
+            "type": "option",
+            "value": "none"
+          },
+          "right": {
+            "type": "theme.ordinal",
+            "value": "@padding.tight"
+          },
+          "bottom": {
+            "type": "option",
+            "value": "none"
+          },
+          "left": {
+            "type": "theme.ordinal",
+            "value": "@padding.tight"
+          }
+        },
+        "height": {
+          "type": "option",
+          "value": "fit"
+        },
+        "orientation": {
+          "type": "option",
+          "value": "horizontal"
+        },
+        "gap": {
+          "type": "theme.ordinal",
+          "value": "@gap.compact"
+        }
+      },
+      "origin": "user"
     }
   },
   "themes": {

--- a/seldon-editor.json
+++ b/seldon-editor.json
@@ -54388,14 +54388,10 @@
       "states": {
         "active": {
           "border": {},
-          "background": [
-            {}
-          ]
+          "background": [{}]
         },
         "hover": {
-          "background": [
-            {}
-          ]
+          "background": [{}]
         },
         "disabled": {
           "border": {},

--- a/seldon-editor.json
+++ b/seldon-editor.json
@@ -3363,19 +3363,35 @@
           "id": "component-sidebar-DrwVziuy",
           "children": [
             {
-              "id": "component-comboboxField-LSIWPWiC",
+              "id": "component-frame-uiEFvsSQ",
               "children": [
                 {
-                  "id": "component-comboboxField-0NyAQIRn"
-                },
-                {
-                  "id": "component-comboboxField-Lg6E5jtv"
-                },
-                {
-                  "id": "component-comboboxField-xvQW1VQq",
+                  "id": "component-comboboxField-LSIWPWiC",
                   "children": [
                     {
-                      "id": "component-comboboxField-yANWz3qm"
+                      "id": "component-comboboxField-0NyAQIRn"
+                    },
+                    {
+                      "id": "component-comboboxField-Lg6E5jtv"
+                    },
+                    {
+                      "id": "component-comboboxField-xvQW1VQq",
+                      "children": [
+                        {
+                          "id": "component-comboboxField-yANWz3qm"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "id": "component-button-t1A2Kxjz",
+                  "children": [
+                    {
+                      "id": "component-button-ky1rrrZT"
+                    },
+                    {
+                      "id": "component-button-dYCRThCF"
                     }
                   ]
                 }
@@ -24947,7 +24963,12 @@
       "label": "Sidebar",
       "theme": null,
       "template": "catalog:sidebar",
-      "overrides": {},
+      "overrides": {
+        "display": {
+          "type": "option",
+          "value": "show"
+        }
+      },
       "__editor": {
         "initialOverrides": {}
       }
@@ -25735,7 +25756,29 @@
               "value": null
             }
           }
-        ]
+        ],
+        "padding": {
+          "top": {
+            "type": "option",
+            "value": "none"
+          },
+          "right": {
+            "type": "option",
+            "value": "none"
+          },
+          "bottom": {
+            "type": "option",
+            "value": "none"
+          },
+          "left": {
+            "type": "theme.ordinal",
+            "value": "@padding.tight"
+          }
+        },
+        "gap": {
+          "type": "theme.ordinal",
+          "value": "@gap.tight"
+        }
       },
       "origin": "user"
     },
@@ -63164,6 +63207,159 @@
         }
       },
       "origin": "user"
+    },
+    "component-frame-uiEFvsSQ": {
+      "id": "component-frame-uiEFvsSQ",
+      "type": "instance",
+      "level": "frame",
+      "label": "Frame",
+      "theme": null,
+      "template": "node:component-frame-default",
+      "overrides": {
+        "padding": {
+          "top": {
+            "type": "option",
+            "value": "none"
+          },
+          "right": {
+            "type": "theme.ordinal",
+            "value": "@padding.tight"
+          },
+          "bottom": {
+            "type": "option",
+            "value": "none"
+          },
+          "left": {
+            "type": "theme.ordinal",
+            "value": "@padding.tight"
+          }
+        },
+        "margin": {
+          "top": {
+            "type": "option",
+            "value": "none"
+          },
+          "right": {
+            "type": "option",
+            "value": "none"
+          },
+          "bottom": {
+            "type": "option",
+            "value": "none"
+          },
+          "left": {
+            "type": "option",
+            "value": "none"
+          }
+        },
+        "orientation": {
+          "type": "option",
+          "value": "horizontal"
+        },
+        "height": {
+          "type": "option",
+          "value": "fit"
+        },
+        "gap": {
+          "type": "theme.ordinal",
+          "value": "@gap.compact"
+        },
+        "align": {
+          "type": "option",
+          "value": "right"
+        }
+      },
+      "origin": "user"
+    },
+    "component-button-t1A2Kxjz": {
+      "id": "component-button-t1A2Kxjz",
+      "ref": "menuState",
+      "type": "instance",
+      "level": "element",
+      "label": "Menu",
+      "theme": null,
+      "template": "node:component-button-menu",
+      "overrides": {
+        "width": {
+          "type": "exact",
+          "value": {
+            "unit": "%",
+            "value": 30
+          }
+        }
+      },
+      "origin": "user"
+    },
+    "component-button-ky1rrrZT": {
+      "id": "component-button-ky1rrrZT",
+      "type": "instance",
+      "level": "primitive",
+      "label": "Label",
+      "theme": null,
+      "template": "node:component-text-Sa6TDqI5",
+      "overrides": {
+        "content": {
+          "type": "exact",
+          "value": "State"
+        }
+      },
+      "origin": "user",
+      "__editor": {
+        "initialOverrides": {
+          "content": {
+            "type": "exact",
+            "value": "Button Menu"
+          },
+          "cursor": {
+            "type": "option",
+            "value": "pointer"
+          },
+          "color": {
+            "type": "computed",
+            "value": "highContrastColor"
+          },
+          "font": {
+            "preset": {
+              "type": "theme.categorical",
+              "value": "@font.label"
+            },
+            "size": {
+              "type": "computed",
+              "value": "autoFit"
+            }
+          }
+        }
+      }
+    },
+    "component-button-dYCRThCF": {
+      "id": "component-button-dYCRThCF",
+      "type": "instance",
+      "level": "primitive",
+      "label": "Icon",
+      "theme": null,
+      "template": "node:component-icon-y2cT3qUf",
+      "overrides": {},
+      "origin": "user",
+      "__editor": {
+        "initialOverrides": {
+          "symbol": {
+            "type": "option",
+            "value": "material-chevronDown"
+          },
+          "size": {
+            "type": "computed",
+            "value": "autoFit"
+          },
+          "color": {
+            "type": "computed",
+            "value": "highContrastColor"
+          },
+          "cursor": {
+            "type": "option",
+            "value": "pointer"
+          }
+        }
+      }
     }
   },
   "themes": {


### PR DESCRIPTION
## 📝 Description

Reworks the editor sidebars and relocates the board state menu.

- **Objects sidebar**: adds a Components/Resources toggle in the header (persisted via `useEditorConfig`, Components default), an always-visible per-row Display picker that reuses the properties `ComboboxListbox`, and a single facet-based model for display-state row styling (`row-display-style.ts`: dimmed for hide/stub/mock/exclude, italic for stub/exclude, faded gray for mock/exclude), applied to a node and its instance-ancestor chain.
- **`use-row-node.ts` refactor**: split the 800-line hook into focused units — `use-row-node-actions.ts` (row actions menu), `use-row-node-display.ts` (Display picker + decoration), and pure `row-node-label.ts` helpers — leaving a thin orchestrator. Board and resource rows now correctly show the actions menu instead of the display icon.
- **Properties sidebar**: moves the interaction-state menu off the canvas into the sidebar header. New `useBoardStateMenu` hook drives the same board-state store (identical options, override indicators, `⌥1..0` hotkeys, custom states); the generated `menuState` ButtonMenu triggers a right-aligned `MenuController`. `BoardStateSwitcher` is removed.
- **Hari palette**: drops the custom `hari-toggle-no-hover` styling now that the generated `.sdn-button-toggle` states are correct; toggles rely on `sdn-state-activated`.
- **Shared**: promotes `useComboboxPosition` into `@lib/menus` for reuse.
- Regenerated the `packages/editor/seldon/**` output from the reworked `seldon-editor.json`.

## 🔗 Related Issues

_None_

## 🧪 Type of Change

- 🐛 Bug fix
- ✨ New feature

## 📦 Affected Packages

- `@seldon/editor`

## 📸 Screenshots/Videos

_N/A_

## 🔍 Code Quality Checklist

- Code follows the project's style guidelines
- Self-review of the code has been performed
- Code is properly commented, particularly in hard-to-understand areas
- No console.log statements or debugging code left in
- TypeScript types are properly defined, no use of "as any"
- No unused imports or variables

## 📋 Breaking Changes

_None_

## 🚀 Deployment Notes

_None_

## 📚 Documentation Updates

_None_

## ⚠️ Additional Notes

The `packages/editor/seldon/**` files are generated from `seldon-editor.json` via `npm run export:seldon`; regenerate after any further design-file changes. `tsc` passes across the editor package.

---

I have read the CLA and I agree to its terms.

Github: AndreiSeldon
Organization: SeldonDigital