### PR TITLE
Mention Vue editor in top-level README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Factory owns export and production code generation. It can be extended beyond on
 
 ---
 
-The [Seldon Editor](packages/editor/README.md) is a browser design client for Seldon workspaces. It runs locally on your computer, creates and stores workspaces, and needs no API, database, auth, or cloud service. The Editor runs as a single app on `localhost:5173`.
+The [Seldon Editor](packages/editor/README.md) is a browser design client for Seldon workspaces. It runs locally on your computer, creates and stores workspaces, and needs no API, database, auth, or cloud service. It ships as two mirrored apps that share the same underlying logic and workspace files: a [React build](packages/editor-react/README.md) on `localhost:5173` and a [Vue build](packages/editor-vue/README.md) on `localhost:5174`.
 
 A user opens a workspace with the Editor, edits components, and each action flows through the same Core reducer engine that an AI agent would use.
 


### PR DESCRIPTION
## Summary
- The top-level README's Editor section only mentioned the React app on `localhost:5173`, even though the repo ships a mirrored Vue editor on `localhost:5174` (see `packages/editor/README.md`).
- Updated the Editor paragraph to describe both mirrored builds and link to `packages/editor-react/README.md` and `packages/editor-vue/README.md`.

## Test plan
- [x] Reviewed rendered markdown for correct links