### PR TITLE
Share home page copy between the React and Vue editors

### DIFF
--- a/packages/editor-react/app/home/HomePage.bespoke.tsx
+++ b/packages/editor-react/app/home/HomePage.bespoke.tsx
@@ -1,4 +1,5 @@
 // BESPOKE-VIEW: hand-authored home screen markup. Styling comes from home.css.
+import { HOME_CONTENT } from "@seldon/editor/lib/home/home-content"
 import { type StoredWorkspace } from "@seldon/editor/lib/storage/workspace-store"
 import { Link } from "react-router"
 
@@ -23,11 +24,8 @@ export function HomeView({
   return (
     <main className="home">
       <header>
-        <h1 className="home-title">Seldon · Editor</h1>
-        <p className="home-subtitle">
-          Workspaces are stored on your machine and shared with the Vue editor.
-          Open a workspace.json file or create a new workspace.
-        </p>
+        <h1 className="home-title">{HOME_CONTENT.title}</h1>
+        <p className="home-subtitle">{HOME_CONTENT.subtitle("Vue")}</p>
       </header>
 
       <div className="home-actions">
@@ -36,23 +34,25 @@ export function HomeView({
           className="home-button home-button-primary"
           onClick={onNew}
         >
-          New workspace
+          {HOME_CONTENT.newWorkspaceButton}
         </button>
         <button
           type="button"
           className="home-button home-button-secondary"
           onClick={onImport}
         >
-          Open workspace.json
+          {HOME_CONTENT.openWorkspaceButton}
         </button>
       </div>
 
       <section>
-        <h2 className="home-section-title">Recent workspaces</h2>
+        <h2 className="home-section-title">
+          {HOME_CONTENT.recentWorkspacesHeading}
+        </h2>
         {loading ? (
-          <p className="home-muted">Loading…</p>
+          <p className="home-muted">{HOME_CONTENT.loading}</p>
         ) : workspaces.length === 0 ? (
-          <p className="home-muted">No workspaces yet.</p>
+          <p className="home-muted">{HOME_CONTENT.noWorkspaces}</p>
         ) : (
           <ul className="home-list">
             {workspaces.map((ws) => (
@@ -68,7 +68,7 @@ export function HomeView({
                   className="home-delete"
                   onClick={() => onDelete(ws.id)}
                 >
-                  Delete
+                  {HOME_CONTENT.deleteButton}
                 </button>
               </li>
             ))}

--- a/packages/editor-react/app/home/HomePage.tsx
+++ b/packages/editor-react/app/home/HomePage.tsx
@@ -1,4 +1,5 @@
 import { selectFile } from "@seldon/editor/lib/helpers/select-file"
+import { HOME_CONTENT } from "@seldon/editor/lib/home/home-content"
 import {
   type StoredWorkspace,
   createStoredWorkspace,
@@ -29,7 +30,11 @@ export default function HomePage() {
   }, [refresh])
 
   const handleNew = useCallback(async () => {
-    const name = prompt("Workspace name", "Untitled") ?? "Untitled"
+    const name =
+      prompt(
+        HOME_CONTENT.newWorkspaceNamePrompt,
+        HOME_CONTENT.defaultWorkspaceName,
+      ) ?? HOME_CONTENT.defaultWorkspaceName
     const record = await createStoredWorkspace(name, createEmptyWorkspace())
     navigate(`/${record.id}`)
   }, [navigate])
@@ -47,7 +52,7 @@ export default function HomePage() {
 
   const handleDelete = useCallback(
     async (id: string) => {
-      if (!confirm("Delete this workspace?")) return
+      if (!confirm(HOME_CONTENT.deleteConfirm)) return
       await deleteStoredWorkspace(id)
       await refresh()
     },

--- a/packages/editor-vue/app/editor-chrome.css
+++ b/packages/editor-vue/app/editor-chrome.css
@@ -21,6 +21,10 @@
   );
 }
 
+body {
+  background: var(--sdn-swatch-black);
+}
+
 /*
  * Topbar rainbow strip. The resting strip is a static interface gradient. During
  * a local export the strip grows and `useTopbarGradientAnimation` repaints the

--- a/packages/editor-vue/app/home/HomePage.vue
+++ b/packages/editor-vue/app/home/HomePage.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { createEmptyWorkspace } from "@seldon/core"
 import type { Workspace } from "@seldon/core/workspace/types"
+import { HOME_CONTENT } from "@seldon/editor/lib/home/home-content"
 import {
   createStoredWorkspace,
   deleteStoredWorkspace,
@@ -24,7 +25,10 @@ async function refresh(): Promise<void> {
 }
 
 async function create(): Promise<void> {
-  const record = await createStoredWorkspace("Untitled", createEmptyWorkspace())
+  const record = await createStoredWorkspace(
+    HOME_CONTENT.defaultWorkspaceName,
+    createEmptyWorkspace(),
+  )
   router.push(`/${record.id}`)
 }
 
@@ -76,14 +80,16 @@ onMounted(refresh)
 
 <template>
   <main class="home">
-    <h1 class="home-title">Seldon Editor (Vue)</h1>
-    <p class="home-subtitle">
-      Workspaces are stored on your machine and shared with the React editor.
-    </p>
+    <h1 class="home-title">{{ HOME_CONTENT.title }}</h1>
+    <p class="home-subtitle">{{ HOME_CONTENT.subtitle("React") }}</p>
 
     <div class="home-actions">
-      <button class="home-create" @click="create">New workspace</button>
-      <button class="home-import" @click="triggerImport">Import…</button>
+      <button class="home-create" @click="create">
+        {{ HOME_CONTENT.newWorkspaceButton }}
+      </button>
+      <button class="home-import" @click="triggerImport">
+        {{ HOME_CONTENT.openWorkspaceButton }}
+      </button>
       <input
         ref="fileInput"
         type="file"
@@ -93,9 +99,12 @@ onMounted(refresh)
       />
     </div>
 
-    <p v-if="loading" class="home-empty">Loading…</p>
+    <h2 class="home-section-title">
+      {{ HOME_CONTENT.recentWorkspacesHeading }}
+    </h2>
+    <p v-if="loading" class="home-empty">{{ HOME_CONTENT.loading }}</p>
     <p v-else-if="workspaces.length === 0" class="home-empty">
-      No workspaces yet.
+      {{ HOME_CONTENT.noWorkspaces }}
     </p>
 
     <ul v-else class="home-list">
@@ -109,7 +118,9 @@ onMounted(refresh)
         <button class="home-item__action" @click="duplicate(ws)">
           Duplicate
         </button>
-        <button class="home-item__delete" @click="remove(ws.id)">Delete</button>
+        <button class="home-item__delete" @click="remove(ws.id)">
+          {{ HOME_CONTENT.deleteButton }}
+        </button>
       </li>
     </ul>
   </main>
@@ -139,6 +150,14 @@ onMounted(refresh)
   display: flex;
   flex-wrap: wrap;
   gap: 0.75rem;
+}
+.home-section-title {
+  margin-bottom: 0.75rem;
+  font-size: 0.8125rem;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: rgba(255, 255, 255, 0.5);
 }
 .home-create {
   border-radius: 0.25rem;

--- a/packages/editor-vue/app/home/HomePage.vue
+++ b/packages/editor-vue/app/home/HomePage.vue
@@ -76,7 +76,7 @@ onMounted(refresh)
 
 <template>
   <main class="home">
-    <h1>Seldon Editor (Vue)</h1>
+    <h1 class="home-title">Seldon Editor (Vue)</h1>
     <p class="home-subtitle">
       Workspaces are stored on your machine and shared with the React editor.
     </p>
@@ -117,35 +117,46 @@ onMounted(refresh)
 
 <style scoped>
 .home {
-  padding: 3rem;
-  max-width: 720px;
   margin: 0 auto;
-  color: #18181b;
-  font-family:
-    ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  display: flex;
+  min-height: 100vh;
+  max-width: 42rem;
+  flex-direction: column;
+  gap: 2rem;
+  padding: 2.5rem;
+  color: #fff;
+}
+.home-title {
+  font-size: 1.25rem;
+  font-weight: 600;
 }
 .home-subtitle {
-  color: #52525b;
+  margin-top: 0.5rem;
+  font-size: 0.8125rem;
+  color: rgba(255, 255, 255, 0.7);
 }
 .home-actions {
   display: flex;
-  gap: 0.5rem;
-  margin: 1rem 0 2rem;
+  flex-wrap: wrap;
+  gap: 0.75rem;
 }
 .home-create {
+  border-radius: 0.25rem;
   padding: 0.5rem 1rem;
+  font-size: 0.8125rem;
+  font-weight: 500;
+  background: #fff;
+  color: #000;
   border: none;
-  border-radius: 6px;
-  background: #18181b;
-  color: #fff;
   cursor: pointer;
 }
 .home-import {
+  border-radius: 0.25rem;
   padding: 0.5rem 1rem;
-  border: 1px solid #e4e4e7;
-  border-radius: 6px;
-  background: #fff;
-  color: #18181b;
+  font-size: 0.8125rem;
+  border: 1px solid rgba(255, 255, 255, 0.3);
+  background: transparent;
+  color: inherit;
   cursor: pointer;
 }
 .home-file {
@@ -153,49 +164,65 @@ onMounted(refresh)
 }
 .home-item__action {
   padding: 0 0.75rem;
-  border: 1px solid #e4e4e7;
-  border-radius: 6px;
-  background: #fff;
-  color: #18181b;
+  border-radius: 0.25rem;
+  border: 1px solid rgba(255, 255, 255, 0.3);
+  background: transparent;
+  color: inherit;
+  font-size: 0.75rem;
   cursor: pointer;
 }
 .home-empty {
-  color: #a1a1aa;
+  font-size: 0.8125rem;
+  color: rgba(255, 255, 255, 0.6);
 }
 .home-list {
   list-style: none;
   padding: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
+  border-radius: 0.25rem;
+  border: 1px solid rgba(255, 255, 255, 0.1);
 }
 .home-item {
   display: flex;
   align-items: stretch;
   gap: 0.5rem;
+  padding: 0.75rem 1rem;
+}
+.home-item + .home-item {
+  border-top: 1px solid rgba(255, 255, 255, 0.1);
 }
 .home-item__open {
   flex: 1;
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 0.75rem 1rem;
-  border: 1px solid #e4e4e7;
-  border-radius: 6px;
-  background: #fff;
+  min-width: 0;
+  border: none;
+  background: transparent;
+  color: inherit;
   cursor: pointer;
   text-align: left;
 }
+.home-item__name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-weight: 500;
+}
 .home-item__meta {
   font-size: 0.75rem;
-  color: #a1a1aa;
+  color: rgba(255, 255, 255, 0.5);
+  white-space: nowrap;
 }
 .home-item__delete {
   padding: 0 0.75rem;
-  border: 1px solid #e4e4e7;
-  border-radius: 6px;
-  background: #fff;
-  color: #b91c1c;
+  border-radius: 0.25rem;
+  border: 1px solid rgba(255, 255, 255, 0.3);
+  background: transparent;
+  color: rgba(255, 255, 255, 0.5);
+  font-size: 0.75rem;
   cursor: pointer;
+}
+.home-item__delete:hover {
+  color: #fff;
 }
 </style>

--- a/packages/editor/lib/home/home-content.ts
+++ b/packages/editor/lib/home/home-content.ts
@@ -1,0 +1,21 @@
+export type OtherEditor = "React" | "Vue"
+
+/**
+ * Copy shared by both editors' home screens, so the two mirrored apps never
+ * drift the way their bespoke CSS is allowed to. Each app supplies its own
+ * name for the other editor since that half of the sentence is app-specific.
+ */
+export const HOME_CONTENT = {
+  title: "Seldon · Editor",
+  subtitle: (otherEditor: OtherEditor) =>
+    `Workspaces are stored on your machine and shared with the ${otherEditor} editor. Open a workspace.json file or create a new workspace.`,
+  newWorkspaceButton: "New workspace",
+  openWorkspaceButton: "Open workspace.json",
+  recentWorkspacesHeading: "Recent workspaces",
+  loading: "Loading…",
+  noWorkspaces: "No workspaces yet.",
+  deleteButton: "Delete",
+  deleteConfirm: "Delete this workspace?",
+  newWorkspaceNamePrompt: "Workspace name",
+  defaultWorkspaceName: "Untitled",
+}


### PR DESCRIPTION
## Summary
- The React and Vue home screens hand-duplicated their own copy and had drifted: different titles ("Seldon · Editor" vs "Seldon Editor (Vue)"), different subtitle wording, "Open workspace.json" vs "Import…", and Vue was missing the "Recent workspaces" section heading entirely.
- Added `packages/editor/lib/home/home-content.ts`, a shared, framework-neutral `HOME_CONTENT` module (title, subtitle template, button labels, section heading, loading/empty states, delete strings).
- Pointed `packages/editor-react/app/home/HomePage.tsx` + `HomePage.bespoke.tsx` and `packages/editor-vue/app/home/HomePage.vue` at the shared module instead of their own literals.
- Left color/styling values untouched — those are already hand-authored per app in this part of the codebase (see stacked PR #57), so this PR only unifies text.

Stacked on #57 (dark theme restyle) since both touch `HomePage.vue`.

## Test plan
- [x] `npm run lint` and `npm run quality` pass in `editor`, `editor-react`, `editor-vue`
- [x] Verified visually: both editors now render identical title/subtitle/button labels/section heading