### PR TITLE
Handle a missing Ollama default model in both editors

### DIFF
--- a/packages/editor-react/app/ai/use-ai-chat.ts
+++ b/packages/editor-react/app/ai/use-ai-chat.ts
@@ -24,7 +24,11 @@ import {
 } from "@seldon/editor/lib/ai/apply-report"
 import { describeChanges } from "@seldon/editor/lib/ai/change-summary"
 import { checkTurnIntegrity } from "@seldon/editor/lib/ai/check-turn-integrity"
-import { logAiTurn, logAiWarning, logWarm } from "@seldon/editor/lib/ai/log-turn"
+import {
+  logAiTurn,
+  logAiWarning,
+  logWarm,
+} from "@seldon/editor/lib/ai/log-turn"
 import {
   type AgentConfig,
   getAgentConfig,

--- a/packages/editor-react/app/ai/use-ai-chat.ts
+++ b/packages/editor-react/app/ai/use-ai-chat.ts
@@ -24,7 +24,7 @@ import {
 } from "@seldon/editor/lib/ai/apply-report"
 import { describeChanges } from "@seldon/editor/lib/ai/change-summary"
 import { checkTurnIntegrity } from "@seldon/editor/lib/ai/check-turn-integrity"
-import { logAiTurn, logWarm } from "@seldon/editor/lib/ai/log-turn"
+import { logAiTurn, logAiWarning, logWarm } from "@seldon/editor/lib/ai/log-turn"
 import {
   type AgentConfig,
   getAgentConfig,
@@ -133,7 +133,10 @@ const useStore = create<AiChatState>((set) => ({
   setConfig: (config) =>
     set((state) => ({
       config,
-      model: state.model ?? config.defaults.model,
+      model:
+        state.model && config.models.includes(state.model)
+          ? state.model
+          : config.defaults.model,
       thinkingLevel: state.thinkingLevel ?? config.defaults.thinkingLevel,
     })),
   setModel: (model) => set({ model }),
@@ -388,7 +391,10 @@ export function useHari() {
         const { model } = useStore.getState()
         const { metrics } = await warmAgent({ model })
         if (isAiLoggingEnabled()) logWarm(metrics)
-      } catch {
+      } catch (error) {
+        logAiWarning(
+          error instanceof Error ? error.message : "Agent warm-up failed.",
+        )
         // Warm-up is best-effort; a failure just means the first turn loads cold.
       } finally {
         warmInFlight = null

--- a/packages/editor-react/scripts/ensure-ollama.mjs
+++ b/packages/editor-react/scripts/ensure-ollama.mjs
@@ -19,6 +19,10 @@ import { spawn } from "node:child_process"
 
 const HOST = process.env.OLLAMA_HOST ?? "http://127.0.0.1:11434"
 const PROBE_URL = `${HOST}/api/tags`
+// Mirrors the default in packages/ai/pi/model.ts's resolvePiModelId. Kept as a
+// literal here since this script runs under plain node, with no TS loader to
+// import that module directly.
+const DEFAULT_MODEL = process.env.SELDON_AI_MODEL ?? "gpt-oss:20b"
 const READY_TIMEOUT_MS = 20_000
 const POLL_INTERVAL_MS = 500
 
@@ -53,6 +57,39 @@ async function isRunning(timeoutMs = 1_000) {
 }
 
 const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms))
+
+/** Returns local Ollama model names, best-effort. */
+async function getInstalledModels(timeoutMs = 2_000) {
+  try {
+    const controller = new AbortController()
+    const timer = setTimeout(() => controller.abort(), timeoutMs)
+    const response = await fetch(PROBE_URL, { signal: controller.signal })
+    clearTimeout(timer)
+    if (!response.ok) return []
+    const data = await response.json()
+    return (data.models ?? [])
+      .map((entry) => entry.model ?? entry.name)
+      .filter((name) => typeof name === "string")
+  } catch {
+    return []
+  }
+}
+
+/** Warns in the terminal when the configured default model is not installed. */
+async function warnIfDefaultModelMissing() {
+  const models = await getInstalledModels()
+  if (models.length === 0) {
+    console.warn(
+      `No Ollama models are installed. Pull one before using Hari, for example: ollama pull ${DEFAULT_MODEL}`,
+    )
+    return
+  }
+  if (!models.includes(DEFAULT_MODEL)) {
+    console.warn(
+      `Configured AI model "${DEFAULT_MODEL}" is not installed in Ollama. Available models: ${models.join(", ")}. Pull it with: ollama pull ${DEFAULT_MODEL}`,
+    )
+  }
+}
 
 /**
  * Spawns `ollama serve` detached so it outlives this short-lived script. The
@@ -95,6 +132,7 @@ async function main() {
     console.log(
       `Ollama already running at ${HOST}. Performance settings apply only to a server this script starts; run "npm run ollama:kill" then "npm run dev" to apply them.`,
     )
+    await warnIfDefaultModelMissing()
     return
   }
 
@@ -108,6 +146,7 @@ async function main() {
   while (Date.now() < deadline) {
     if (await isRunning()) {
       console.log(`Ollama is ready at ${HOST}.`)
+      await warnIfDefaultModelMissing()
       return
     }
     await delay(POLL_INTERVAL_MS)

--- a/packages/editor-vue/app/ai/ai-chat-store.ts
+++ b/packages/editor-vue/app/ai/ai-chat-store.ts
@@ -79,7 +79,9 @@ export const useAiChatStore = defineStore("ai-chat", () => {
 
   function setConfig(next: AgentConfig): void {
     config.value = next
-    if (model.value === undefined) model.value = next.defaults.model
+    if (model.value === undefined || !next.models.includes(model.value)) {
+      model.value = next.defaults.model
+    }
     if (thinkingLevel.value === undefined) {
       thinkingLevel.value = next.defaults.thinkingLevel
     }

--- a/packages/editor-vue/app/ai/use-ai-chat.ts
+++ b/packages/editor-vue/app/ai/use-ai-chat.ts
@@ -14,6 +14,7 @@ import {
 } from "@seldon/editor/lib/ai/apply-report"
 import { describeChanges } from "@seldon/editor/lib/ai/change-summary"
 import { checkTurnIntegrity } from "@seldon/editor/lib/ai/check-turn-integrity"
+import { logAiWarning } from "@seldon/editor/lib/ai/log-turn"
 import {
   getAgentConfig,
   runAgentChat,
@@ -277,7 +278,10 @@ export function useAiChat() {
         const config = await getAgentConfig()
         if (config) store.setConfig(config)
         await warmAgent({ model: store.model })
-      } catch {
+      } catch (error) {
+        logAiWarning(
+          error instanceof Error ? error.message : "Agent warm-up failed.",
+        )
         // Warm-up is best-effort; a failure just means the first turn loads cold.
       } finally {
         warmInFlight = null

--- a/packages/editor/lib/ai/log-turn.ts
+++ b/packages/editor/lib/ai/log-turn.ts
@@ -47,6 +47,11 @@ function aiLog(message: string, ...args: unknown[]): void {
   console.log(`${AI_TAG} ${message}`, AI_TAG_STYLE, "", ...args)
 }
 
+/** Logs an AI warning with the same purple [seldon/ai] badge as the debug rows. */
+export function logAiWarning(message: string, ...args: unknown[]): void {
+  console.warn(`${AI_TAG} ${message}`, AI_TAG_STYLE, "", ...args)
+}
+
 /** Logs one applied action's target header and each property's before -> after. */
 function logActionChange(
   before: Workspace,

--- a/packages/editor/lib/ai/run-agent-chat.ts
+++ b/packages/editor/lib/ai/run-agent-chat.ts
@@ -8,6 +8,7 @@ import type {
   SelectionScope,
   ThinkingLevelOption,
 } from "@seldon/ai"
+import { logAiWarning } from "@seldon/editor/lib/ai/log-turn"
 import type {
   BoardKey,
   Workspace,
@@ -41,6 +42,8 @@ export type AgentConfig = {
     model: string
     thinkingLevel: ThinkingLevelOption
   }
+  /** Set when the configured default model is not installed in Ollama. */
+  warnings?: string[]
 }
 
 export type AgentChatResponse = {
@@ -135,7 +138,9 @@ export async function getAgentConfig(): Promise<AgentConfig | undefined> {
   try {
     const response = await fetch("/api/agent/config")
     if (!response.ok) return undefined
-    return (await response.json()) as AgentConfig
+    const config = (await response.json()) as AgentConfig
+    for (const warning of config.warnings ?? []) logAiWarning(warning)
+    return config
   } catch {
     return undefined
   }
@@ -160,7 +165,14 @@ export async function warmAgent(warm?: {
     body: JSON.stringify(warm ?? {}),
   })
   if (!response.ok) {
-    throw new Error("Agent warm-up failed.")
+    let message = "Agent warm-up failed."
+    try {
+      const data = (await response.json()) as { error?: string }
+      if (data?.error) message = data.error
+    } catch {
+      // Response was not JSON; keep the default message.
+    }
+    throw new Error(message)
   }
   return (await response.json()) as WarmResponse
 }

--- a/packages/editor/vite/agent-handler.ts
+++ b/packages/editor/vite/agent-handler.ts
@@ -75,7 +75,7 @@ export async function runAgent(
       selectedBoardId: body.selectedBoardId,
       scope: body.scope,
       resourceTargetId: body.resourceTargetId,
-      model: body.model,
+      model: await resolveAvailableModel(body.model),
       thinkingLevel: body.thinkingLevel,
       thinkingCapable: body.thinkingCapable,
       noThink: body.noThink,
@@ -97,6 +97,8 @@ export type AgentConfig = {
     model: string
     thinkingLevel: ThinkingLevelOption
   }
+  /** Set when the configured default model is not installed in Ollama. */
+  warnings?: string[]
 }
 
 const OLLAMA_HOST = process.env.OLLAMA_HOST ?? "http://127.0.0.1:11434"
@@ -141,6 +143,39 @@ async function showModelCapabilities(
   }
 }
 
+/** Message shown when a model is not installed in the local Ollama server. */
+function missingModelMessage(model: string, installed: string[]): string {
+  if (installed.length === 0) {
+    return `AI model "${model}" is not installed in Ollama. No local Ollama models are installed. Pull it with: ollama pull ${model}`
+  }
+  return `AI model "${model}" is not installed in Ollama. Available models: ${installed.join(", ")}. Pull it with: ollama pull ${model}`
+}
+
+/**
+ * Resolves the model a request should actually use. An explicitly requested
+ * model must be installed, or the request is rejected with a clear message
+ * instead of silently running (and likely failing) against a missing model.
+ * With no request, falls back to the configured default when installed, else
+ * the first discovered model. When Ollama reports no models at all, the
+ * request proceeds best-effort so the underlying Ollama error surfaces.
+ */
+async function resolveAvailableModel(
+  requestedModel: string | undefined,
+): Promise<string> {
+  const configuredDefaultModel = resolvePiModelId()
+  const discovered = await listOllamaModels()
+  if (discovered.length === 0) return requestedModel ?? configuredDefaultModel
+  if (requestedModel) {
+    if (!discovered.includes(requestedModel)) {
+      throw new Error(missingModelMessage(requestedModel, discovered))
+    }
+    return requestedModel
+  }
+  return discovered.includes(configuredDefaultModel)
+    ? configuredDefaultModel
+    : discovered[0]
+}
+
 /**
  * Returns the session-config choices for the Hari palette: the locally available
  * models, the thinking menu resolved per model from Ollama's reported
@@ -148,11 +183,16 @@ async function showModelCapabilities(
  * best-effort and come from the local Ollama server.
  */
 export async function agentConfig(): Promise<AgentConfig> {
-  const defaultModel = resolvePiModelId()
+  const configuredDefaultModel = resolvePiModelId()
   const discovered = await listOllamaModels()
-  const models = discovered.includes(defaultModel)
-    ? discovered
-    : [defaultModel, ...discovered]
+  const models = discovered.length > 0 ? discovered : [configuredDefaultModel]
+  const defaultModel = models.includes(configuredDefaultModel)
+    ? configuredDefaultModel
+    : models[0]
+  const warnings =
+    discovered.length > 0 && !discovered.includes(configuredDefaultModel)
+      ? [missingModelMessage(configuredDefaultModel, discovered)]
+      : undefined
   const thinkingByModel: Record<string, ModelThinking> = {}
   const clampedLevels: Record<string, ThinkingLevelOption> = {}
   await Promise.all(
@@ -170,6 +210,7 @@ export async function agentConfig(): Promise<AgentConfig> {
       model: defaultModel,
       thinkingLevel: thinkingByModel[defaultModel]?.default ?? "off",
     },
+    warnings,
   }
 }
 
@@ -186,6 +227,8 @@ export type WarmResult = {
 export async function warmAgent(body?: {
   model?: string
 }): Promise<WarmResult> {
-  const metrics = await warmModel({ model: body?.model })
+  const metrics = await warmModel({
+    model: await resolveAvailableModel(body?.model),
+  })
   return { ok: true, metrics }
 }


### PR DESCRIPTION
## Summary

Rebases and completes #47 (which no longer applied after #55 split the single editor app into `editor-react`/`editor-vue`, moving or duplicating every file that PR touched). Same underlying bug, reworked against the current AI-chat/config shape (`thinkingByModel`/`clampedLevels`) and applied to **both** editors, since Vue now has its own copy of the AI chat hook that #47 predates.

- `agentConfig()` no longer silently offers/defaults to a model that isn't actually installed in Ollama; it now returns only installed models (or the configured default as a last resort when Ollama reports none) and a `warnings` field when the configured default is missing.
- New `resolveAvailableModel()` in `agent-handler.ts`: an explicit requested model must be installed or the request is rejected with a clear "not installed, pull it with..." message, instead of running best-effort against a missing model.
- Both `editor-react` and `editor-vue`'s AI chat state now reset a stale client-side model selection when the refreshed config no longer includes it (previously only set the model if it was `undefined`, never corrected a stale-but-defined selection).
- Warm-up failures now surface through the shared `[seldon/ai]` console warning (`logAiWarning`, added to `packages/editor/lib/ai/log-turn.ts`) in both editors, instead of failing silently.
- `packages/editor-react/scripts/ensure-ollama.mjs` keeps the terminal-side warning when the configured default isn't installed (Vue has no equivalent script; it relies on the React app's Ollama startup).

Closes/supersedes #47 — same intent, rebased onto current `main` and extended to Vue.

## Test plan
- [x] `npm run lint` / `npm run quality` pass in `editor`, `editor-react`, `editor-vue`
- [x] `node --check` on `ensure-ollama.mjs`
- [x] Manually traced the request path: `runAgent`/`warmAgent` throw via `resolveAvailableModel`, which the existing `/api/agent` and `/api/agent/warm` routes already surface as `{error: message}` JSON (verified in `agent-api-plugin.ts`), matching what the client already parses