### PR TITLE
Feature/ai component composition

### DIFF
--- a/packages/ai/README.md
+++ b/packages/ai/README.md
@@ -237,6 +237,7 @@ Tools come in two groups, assembled per turn in [pi/tools/](./pi/tools), one too
 | `widen_scope` | The next level up the hierarchy |
 | `list_boards`, `find_nodes`, `board_summary` | Boards and nodes across the workspace |
 | `get_component_vocabulary` | Settable properties and value shapes for a component |
+| `describe_catalog_component` | A component's composition: default child tree, named variants, and each child's baked overrides |
 | `list_theme_tokens`, `search_theme_tokens` | Theme token ids and paths |
 | `search_icons` | Enabled icon ids for the symbol property |
 | `search_fonts` | Enabled font family values for the font.family facet |

--- a/packages/ai/pi/system-prompt.ts
+++ b/packages/ai/pi/system-prompt.ts
@@ -154,7 +154,11 @@ Finding a target you cannot see:
 Other tools:
 - When you need a component's settable properties or value shapes, call
   get_component_vocabulary with its catalog id, and pass a category to narrow it.
-  When you need addable component ids, call list_catalog_ids. When unsure of an
+  To preview what a component assembles into before you insert it, call
+  describe_catalog_component with its catalog id: it returns the default child
+  tree and named variants, so trust one insert_component to yield that whole tree
+  rather than rebuilding it child by child. When you need addable component ids,
+  call list_catalog_ids. When unsure of an
   action's payload keys, call get_action_spec, and list_action_types to discover
   an action name, or suggest_action to find one by intent.
 - Prefer narrow reads over widening scope. Call describe_node to read one node

--- a/packages/ai/pi/tools/context/describe-catalog-component.ts
+++ b/packages/ai/pi/tools/context/describe-catalog-component.ts
@@ -1,0 +1,40 @@
+import {
+  type ToolDefinition,
+  defineTool,
+} from "@earendil-works/pi-coding-agent"
+import { Type } from "typebox"
+
+import { componentCompositionSection } from "../../../prompt/context-sections/component-composition"
+import { resolveCatalogId } from "../mutations/catalog-ids"
+import { joinOrEmpty, textResult } from "./shared"
+
+/**
+ * Returns a catalog component's composition: its default child tree, named
+ * variants, and the overrides each child bakes in. Lets the model foresee what
+ * inserting the component yields, so it trusts one insert_component instead of
+ * rebuilding the tree child by child.
+ */
+export function createDescribeCatalogComponentTool(): ToolDefinition {
+  return defineTool({
+    name: "describe_catalog_component",
+    label: "Describe Catalog Component",
+    description:
+      "Return a catalog component's composition: its default child tree, named variants, and the overrides each child bakes in. Preview it before insert_component; inserting the component yields this whole tree in one step.",
+    parameters: Type.Object({
+      catalogId: Type.String({
+        description: "Catalog id, for example menu or button.",
+      }),
+    }),
+    execute: async (_id, params) => {
+      const resolved = resolveCatalogId(params.catalogId)
+      if (!resolved.id)
+        return textResult(resolved.message ?? "Unknown catalog id.")
+      const lines = componentCompositionSection(resolved.id)
+      const body = joinOrEmpty(
+        lines,
+        `No composition found for "${resolved.id}". Use list_catalog_ids for valid ids.`,
+      )
+      return textResult(resolved.note ? `${resolved.note}\n${body}` : body)
+    },
+  })
+}

--- a/packages/ai/pi/tools/context/index.ts
+++ b/packages/ai/pi/tools/context/index.ts
@@ -3,6 +3,7 @@ import type { ToolDefinition } from "@earendil-works/pi-coding-agent"
 import type { ResolvedContext } from "../../editor-context"
 import type { PiTurnState } from "../turn-state"
 import { createBoardSummaryTool } from "./board-summary"
+import { createDescribeCatalogComponentTool } from "./describe-catalog-component"
 import { createDescribeNodeTool } from "./describe-node"
 import { createFindNodesTool } from "./find-nodes"
 import { createGetActionSpecTool } from "./get-action-spec"
@@ -46,6 +47,7 @@ export function createContextTools(
     createWidenScopeTool(state, resolved),
     createBoardSummaryTool(state, resolved),
     createGetComponentVocabularyTool(resolved),
+    createDescribeCatalogComponentTool(),
     createListThemeTokensTool(resolved),
     createSearchThemeTokensTool(resolved),
     createSearchIconsTool(resolved),

--- a/packages/ai/prompt/context-sections/component-composition.ts
+++ b/packages/ai/prompt/context-sections/component-composition.ts
@@ -1,0 +1,76 @@
+import { findComponentSchema } from "@seldon/core/components/catalog"
+import {
+  type SchemaChild,
+  hasVariants,
+  isComplexSchema,
+} from "@seldon/core/components/types"
+
+import { section } from "./section"
+
+/** The tail a child line prints after its component id: variant and baked override keys. */
+function childTail(child: SchemaChild): string {
+  const variant = child.variant ? ` variant "${child.variant}"` : ""
+  const overrideKeys = child.overrides ? Object.keys(child.overrides) : []
+  const overrides =
+    overrideKeys.length > 0 ? ` (overrides: ${overrideKeys.join(", ")})` : ""
+  return `${variant}${overrides}`
+}
+
+/**
+ * The lines for a child tree, indented two spaces per depth. A child prints its
+ * component id, its variant when it selects one, and the keys it overrides, but
+ * not the override values, so a deep tree stays compact. Nested children recurse
+ * one level deeper.
+ */
+function childLines(children: readonly SchemaChild[], depth: number): string[] {
+  const indent = "  ".repeat(depth + 1)
+  const lines: string[] = []
+  for (const child of children) {
+    lines.push(`${indent}- ${child.component}${childTail(child)}`)
+    if (child.children && child.children.length > 0) {
+      lines.push(...childLines(child.children, depth + 1))
+    }
+  }
+  return lines
+}
+
+/**
+ * Context section: a component's composition.
+ *
+ * The vocabulary section lists a component's settable properties, but never what
+ * it assembles into. This projects the schema's default composition tree, its
+ * named variants, and the overrides each child bakes in, all read from
+ * getComponentSchema, so the model can foresee that inserting one component
+ * yields its full child tree instead of rebuilding it child by child. Returns []
+ * when the id resolves to no schema, so the caller shows its own fallback.
+ */
+export function componentCompositionSection(catalogId: string): string[] {
+  const schema = findComponentSchema(catalogId)
+  if (!schema) return []
+
+  const body: string[] = [`${schema.id} [${schema.level}] - ${schema.intent}`]
+
+  if (isComplexSchema(schema)) {
+    const children = schema.default.children ?? []
+    if (children.length > 0) {
+      body.push("composition (default):")
+      body.push(...childLines(children, 0))
+    } else {
+      body.push("composition (default): (empty)")
+    }
+  } else {
+    body.push("leaf, no composition")
+  }
+
+  if (hasVariants(schema)) {
+    body.push("variants:")
+    for (const variant of schema.variants) {
+      body.push(`  - ${variant.id} (${variant.label})`)
+    }
+    body.push("Each variant is an alternate tree; insert one with insert_variant_instance.")
+  } else {
+    body.push("variants: (none)")
+  }
+
+  return section(`Composition for ${schema.id}:`, body)
+}

--- a/packages/ai/prompt/context-sections/component-composition.ts
+++ b/packages/ai/prompt/context-sections/component-composition.ts
@@ -67,7 +67,9 @@ export function componentCompositionSection(catalogId: string): string[] {
     for (const variant of schema.variants) {
       body.push(`  - ${variant.id} (${variant.label})`)
     }
-    body.push("Each variant is an alternate tree; insert one with insert_variant_instance.")
+    body.push(
+      "Each variant is an alternate tree; insert one with insert_variant_instance.",
+    )
   } else {
     body.push("variants: (none)")
   }


### PR DESCRIPTION
## 📝 Description

Add a `describe_catalog_component` read tool to the AI harness so the model can preview a component's composition before it builds. The tool projects a catalog component's default child tree, its named variants, and the overrides each child bakes in, all derived from `getComponentSchema` at inference time. This grounds component assembly in the real schema rather than the model rediscovering structure through repeated insert-and-inspect turns, so it can trust a single `insert_component` to yield the whole tree. Includes a new `componentCompositionSection` context builder, tool registration, a one-line system-prompt pointer, and a README tools-table entry.

## 🔗 Related Issues

## 🧪 Type of Change

- ✨ New feature
- 📚 Documentation update

## 📦 Affected Packages

- `@seldon/ai` (AI harness)

## 📸 Screenshots/Videos

_N/A_

## 🔍 Code Quality Checklist

- Code follows the project's style guidelines
- Self-review of the code has been performed
- Code is properly commented, particularly in hard-to-understand areas
- No console.log statements or debugging code left in
- TypeScript types are properly defined, no use of "as any"
- No unused imports or variables

## 📋 Breaking Changes

_None_

## 🚀 Deployment Notes

_None_

## 📚 Documentation Updates

- Added the `describe_catalog_component` row to the read-tools table in `packages/ai/README.md`.
- Added a pointer to the tool in the "Other tools" block of `packages/ai/pi/system-prompt.ts`.

## ⚠️ Additional Notes

The tool is fully generic: it operates on the shared `SchemaChild`/`SchemaVariant` types with no per-component branching, so it covers every catalog schema (verified against `menu`, `button`, and the `text` primitive). Scope routing to a component source is unchanged; it already lives deterministically in `set_properties`.

---

I have read the CLA and I agree to its terms.

Github: AndreiSeldon
Organization: Seldon Digital