### PR TITLE
Repair duplicate node refs so an affected workspace still opens

### DIFF
--- a/packages/core/workspace/middleware/migration/README.md
+++ b/packages/core/workspace/middleware/migration/README.md
@@ -26,7 +26,7 @@ Versioned steps live under `steps/`, one file per target version. Version 1 is t
 
 ## Repair Steps
 
-Repair steps run on every load, regardless of stored version. They cover stock theme and icon set renames that must also reach files already stamped at the current version. Each repair guards itself and only rewrites the references it matches, so it is safe to re-run.
+Repair steps run on every load, regardless of stored version. They cover stock theme and icon set renames that must also reach files already stamped at the current version, board order, and duplicate node refs. Each repair guards itself and only rewrites the references it matches, so it is safe to re-run.
 
 ## Version Guards
 

--- a/packages/core/workspace/middleware/migration/migrate-workspace.test.ts
+++ b/packages/core/workspace/middleware/migration/migrate-workspace.test.ts
@@ -5,7 +5,7 @@ import { CURRENT_WORKSPACE_VERSION, migrateWorkspace } from "./migrate-workspace
 
 describe("migrateWorkspace", () => {
   it("exposes the current version constant", () => {
-    expect(CURRENT_WORKSPACE_VERSION).toBe(17)
+    expect(CURRENT_WORKSPACE_VERSION).toBe(18)
   })
 
   it("leaves a workspace already at the current version unchanged", () => {

--- a/packages/core/workspace/middleware/migration/migrate-workspace.ts
+++ b/packages/core/workspace/middleware/migration/migrate-workspace.ts
@@ -15,12 +15,13 @@ import { migrateV14EnumBooleanOption } from "./steps/migrate-00014-enum-boolean-
 import { migrateV15DisplayPlaceholderToStub } from "./steps/migrate-00015-display-placeholder-to-stub"
 import { migrateV16LayeredOverrideLength } from "./steps/migrate-00016-layered-override-length"
 import { migrateV17DropInitialOverrides } from "./steps/migrate-00017-drop-initial-overrides"
+import { migrateV18UniqueNodeRefs } from "./steps/migrate-00018-unique-node-refs"
 import { repairBoardOrder } from "./steps/repair-board-order"
 
 import type { Workspace } from "../../model/workspace"
 
 /** Current workspace file version after migration steps on load. */
-export const CURRENT_WORKSPACE_VERSION = 17
+export const CURRENT_WORKSPACE_VERSION = 18
 
 type MigrationStep = (workspace: Workspace) => Workspace
 
@@ -42,6 +43,7 @@ const MIGRATION_STEPS: Partial<Record<number, MigrationStep>> = {
   15: migrateV15DisplayPlaceholderToStub,
   16: migrateV16LayeredOverrideLength,
   17: migrateV17DropInitialOverrides,
+  18: migrateV18UniqueNodeRefs,
 }
 
 if (!MIGRATION_STEPS[CURRENT_WORKSPACE_VERSION]) {
@@ -64,11 +66,17 @@ if (!MIGRATION_STEPS[CURRENT_WORKSPACE_VERSION]) {
  * Board order is derived rather than authored, so `repairBoardOrder` also runs
  * here to re-sort a loaded file with the current ordering logic instead of the
  * order stored when it was saved.
+ *
+ * A duplicate node ref can enter a file at any version, through an import, a
+ * hand edit, or a copy written by an older build, and verification refuses to
+ * open the file. `migrateV18UniqueNodeRefs` runs here as well so such a file
+ * still opens.
  */
 const REPAIR_STEPS: MigrationStep[] = [
   migrateV3ThemeRenames,
   migrateV6IconSetRenames,
   migrateV12DialogToPanels,
+  migrateV18UniqueNodeRefs,
   repairBoardOrder,
 ]
 

--- a/packages/core/workspace/middleware/migration/steps/migrate-00018-unique-node-refs.ts
+++ b/packages/core/workspace/middleware/migration/steps/migrate-00018-unique-node-refs.ts
@@ -1,0 +1,52 @@
+import type { Workspace } from "../../../model/workspace"
+
+/**
+ * v18: drop a `ref` that another node already claims.
+ *
+ * A ref must stay unique across the workspace, because generated code targets a
+ * node by that name alone. A stored file can still hold two nodes with the same
+ * ref, from an import, a hand edit, or a copy written by an older build, and
+ * verification refuses to open it. The first node to claim a ref keeps it and
+ * every later node loses it, matching the export registry, which keeps the first
+ * and ignores the rest. Guarded and idempotent, safe to re-run.
+ */
+
+/** Ref as uniqueness compares it, or null when the node carries none. */
+function refKey(node: { ref?: string }): string | null {
+  const trimmed = node.ref?.trim()
+
+  return trimmed ? trimmed : null
+}
+
+function migrationApplies(workspace: Workspace): boolean {
+  const seen = new Set<string>()
+
+  for (const node of Object.values(workspace.nodes)) {
+    const ref = refKey(node)
+
+    if (!ref) continue
+
+    if (seen.has(ref)) return true
+    seen.add(ref)
+  }
+
+  return false
+}
+
+export function migrateV18UniqueNodeRefs(workspace: Workspace): Workspace {
+  if (!migrationApplies(workspace)) return workspace
+
+  const next = structuredClone(workspace)
+  const seen = new Set<string>()
+
+  for (const node of Object.values(next.nodes)) {
+    const ref = refKey(node)
+
+    if (!ref) continue
+
+    if (seen.has(ref)) delete node.ref
+    else seen.add(ref)
+  }
+
+  return next
+}


### PR DESCRIPTION
## 📝 Description

PR #66 added a verifier that rejects two nodes sharing one `ref`, because the emitted registry would attribute one node's slots to the other. A workspace file that already holds a duplicate ref now fails that check and will not open.

Migration v18 repairs such a file. The first node to claim a ref keeps it, and every later node loses its `ref`. This matches the export registry, which keeps the first claim and ignores the rest.

A duplicate ref can enter a file at any version, through an import, a hand edit, or a copy written by an older build. The step is registered in two places for that reason. It runs as the version 18 migration step, and it runs in `REPAIR_STEPS` on every load regardless of the stored version. The step looks for a duplicate before it clones, so re-running it is safe.

`CURRENT_WORKSPACE_VERSION` moves from 17 to 18.

## 🔗 Related Issues

_None_

## 🧪 Type of Change

- 🐛 Bug fix

## 📦 Affected Packages

- `@seldon/core`

## 📸 Screenshots/Videos

_N/A_