### PR TITLE
Fix/menus label alignment

### DIFF
--- a/packages/editor/apps/react/seldon/seldon-editor.json
+++ b/packages/editor/apps/react/seldon/seldon-editor.json
@@ -15304,7 +15304,7 @@
         },
         "align": {
           "type": "option",
-          "value": "bottom-left"
+          "value": "left"
         }
       }
     },

--- a/packages/editor/apps/react/seldon/styles.css
+++ b/packages/editor/apps/react/seldon/styles.css
@@ -439,7 +439,7 @@ body {
   padding-inline-end: var(--sdn-paddings-compact);
   padding-bottom: var(--sdn-paddings-compact);
   padding-inline-start: var(--sdn-paddings-cozy);
-  box-shadow: 0px 1px 0.25rem 0.062rem hsl(0 0% 0% / 10%);
+  box-shadow: 0px 1px 0.25rem 0.0625rem hsl(0 0% 0% / 10%);
   align-self: stretch;
   height: fit-content;
   flex-shrink: 0;
@@ -505,7 +505,7 @@ body {
   padding-inline-end: var(--sdn-paddings-compact);
   padding-bottom: var(--sdn-paddings-tight);
   padding-inline-start: var(--sdn-paddings-compact);
-  box-shadow: 0px 0px 0.062rem 0.062rem hsl(0 0% 0% / 8%);
+  box-shadow: 0px 0px 0.0625rem 0.0625rem hsl(0 0% 0% / 8%);
   width: fit-content;
   height: fit-content;
   flex-shrink: 0;
@@ -704,7 +704,7 @@ body {
   flex-wrap: nowrap;
   display: flex;
   flex-direction: column;
-  box-shadow: 0px 4px 0.5rem 0.188rem rgb(0 0 0 / 15%);
+  box-shadow: 0px 4px 0.5rem 0.1875rem rgb(0 0 0 / 15%);
   width: 450px;
   height: fit-content;
   flex-shrink: 0;
@@ -717,7 +717,7 @@ body {
   flex-wrap: nowrap;
   display: flex;
   flex-direction: column;
-  box-shadow: 0px 4px 0.5rem 0.188rem color-mix(in srgb, var(--sdn-swatch-black) 15%, transparent);
+  box-shadow: 0px 4px 0.5rem 0.1875rem color-mix(in srgb, var(--sdn-swatch-black) 15%, transparent);
   width: 450px;
   height: fit-content;
   flex-shrink: 0;
@@ -730,7 +730,7 @@ body {
   flex-wrap: nowrap;
   display: flex;
   flex-direction: column;
-  box-shadow: 0px 4px 0.5rem 0.188rem rgb(0 0 0 / 15%);
+  box-shadow: 0px 4px 0.5rem 0.1875rem rgb(0 0 0 / 15%);
   width: 500px;
   height: fit-content;
   flex-shrink: 0;
@@ -1035,7 +1035,7 @@ body {
   box-shadow:
     inset -0.5px -0.5px 0.5px 0px hsl(0 0% 15% / 20%),
     inset 0.5px 0.5px 0.5px 0px hsl(0 0% 96% / 30%),
-    0px 0px 0.125rem 0.031rem color-mix(in srgb, var(--sdn-swatch-primary) 30%, transparent);
+    0px 0px 0.125rem 0.03125rem color-mix(in srgb, var(--sdn-swatch-primary) 30%, transparent);
   align-self: stretch;
   height: fit-content;
   flex-shrink: 0;
@@ -1199,7 +1199,7 @@ body {
   align-items: start;
   justify-content: start;
   gap: var(--sdn-gaps-compact);
-  box-shadow: 0px 4px 0.5rem 0.188rem rgb(0 0 0 / 15%);
+  box-shadow: 0px 4px 0.5rem 0.1875rem rgb(0 0 0 / 15%);
   width: fit-content;
   height: fit-content;
   flex-shrink: 0;
@@ -1233,7 +1233,7 @@ body {
   flex-wrap: nowrap;
   display: flex;
   flex-direction: row;
-  align-items: end;
+  align-items: center;
   justify-content: start;
   gap: var(--sdn-gaps-compact);
   padding-top: var(--sdn-paddings-tight);
@@ -1255,7 +1255,7 @@ body {
   align-items: start;
   justify-content: start;
   gap: var(--sdn-gaps-compact);
-  box-shadow: 0px 4px 0.5rem 0.188rem rgb(0 0 0 / 15%);
+  box-shadow: 0px 4px 0.5rem 0.1875rem rgb(0 0 0 / 15%);
   align-self: stretch;
   height: fit-content;
   flex-shrink: 0;
@@ -1458,7 +1458,7 @@ body {
   flex-direction: column;
   gap: auto;
   justify-content: space-between;
-  box-shadow: 0px 4px 0.5rem 0.188rem rgb(0 0 0 / 15%);
+  box-shadow: 0px 4px 0.5rem 0.1875rem rgb(0 0 0 / 15%);
   width: 450px;
   height: 350px;
   flex-shrink: 0;
@@ -1474,7 +1474,7 @@ body {
   flex-direction: column;
   gap: auto;
   justify-content: space-between;
-  box-shadow: 0px 4px 0.5rem 0.188rem hsl(0 0% 0% / 15%);
+  box-shadow: 0px 4px 0.5rem 0.1875rem hsl(0 0% 0% / 15%);
   width: 450px;
   height: 350px;
   flex-shrink: 0;
@@ -1490,7 +1490,7 @@ body {
   flex-direction: column;
   gap: auto;
   justify-content: space-between;
-  box-shadow: 0px 4px 0.5rem 0.188rem hsl(0 0% 0% / 15%);
+  box-shadow: 0px 4px 0.5rem 0.1875rem hsl(0 0% 0% / 15%);
   width: 450px;
   height: 400px;
   flex-shrink: 0;
@@ -1506,7 +1506,7 @@ body {
   flex-direction: column;
   gap: auto;
   justify-content: space-between;
-  box-shadow: 0px 4px 0.5rem 0.188rem rgb(0 0 0 / 15%);
+  box-shadow: 0px 4px 0.5rem 0.1875rem rgb(0 0 0 / 15%);
   align-self: stretch;
   height: 500px;
   flex-shrink: 0;
@@ -1521,7 +1521,7 @@ body {
   display: flex;
   flex-direction: column;
   gap: 0;
-  box-shadow: 0px 4px 0.5rem 0.188rem rgb(0 0 0 / 15%);
+  box-shadow: 0px 4px 0.5rem 0.1875rem rgb(0 0 0 / 15%);
   width: 450px;
   height: 350px;
   flex-shrink: 0;
@@ -1887,9 +1887,9 @@ body {
   background-color: var(--sdn-swatch-gray);
   cursor: pointer;
   color: var(--sdn-hc-on-gray);
-  box-shadow: inset 0px 0px 0.125rem 0.031rem
+  box-shadow: inset 0px 0px 0.125rem 0.03125rem
     color-mix(in srgb, var(--sdn-swatch-black) 30%, transparent);
-  width: 1.501rem;
+  width: 1.5rem;
   height: fit-content;
   flex-shrink: 0;
   font-size: var(--sdn-font-size-xxsmall);
@@ -2140,7 +2140,7 @@ body {
 .sdn-button-menu--ipe0 {
   width: unset;
   flex-shrink: unset;
-  box-shadow: 0px 1px 0.062rem 0.062rem hsl(0 0% 0% / 10%);
+  box-shadow: 0px 1px 0.0625rem 0.0625rem hsl(0 0% 0% / 10%);
   flex: 1 0 0;
   min-width: 0;
 }
@@ -2156,7 +2156,7 @@ body {
 }
 
 .sdn-button-menu--truc {
-  box-shadow: 0px 1px 0.062rem 0.062rem hsl(0 0% 0% / 10%);
+  box-shadow: 0px 1px 0.0625rem 0.0625rem hsl(0 0% 0% / 10%);
 }
 
 .sdn-button-simple--dbgs {
@@ -2276,7 +2276,7 @@ body {
   align-self: unset;
   flex-shrink: unset;
   flex: 1 0 0;
-  height: 2.002rem;
+  height: 2rem;
   min-width: 0;
   border: var(--hairline) solid var(--sdn-swatch-primary);
 }
@@ -2285,7 +2285,7 @@ body {
   background-color: var(--sdn-swatch-offWhite);
   padding-top: 0;
   padding-bottom: 0;
-  box-shadow: inset 0px 0px 0.125rem 0.031rem
+  box-shadow: inset 0px 0px 0.125rem 0.03125rem
     color-mix(in srgb, var(--sdn-swatch-black) 12%, transparent);
   margin: var(--sdn-margins-tight);
   border: var(--hairline) solid color-mix(in srgb, var(--sdn-swatch-primary) 50%, transparent);
@@ -2307,7 +2307,7 @@ body {
   align-self: unset;
   flex-shrink: unset;
   background-color: var(--sdn-swatch-offWhite);
-  box-shadow: inset 0px 0px 0.062rem 0.062rem
+  box-shadow: inset 0px 0px 0.0625rem 0.0625rem
     color-mix(in srgb, var(--sdn-swatch-black) 10%, transparent);
   flex: 1 0 0;
   min-width: 0;
@@ -2514,7 +2514,8 @@ body {
   padding-bottom: var(--sdn-paddings-tight);
   padding-inline-start: var(--sdn-paddings-comfortable);
   box-shadow:
-    inset 0px 0px 0.125rem 0.031rem color-mix(in srgb, var(--sdn-swatch-offWhite) 30%, transparent),
+    inset 0px 0px 0.125rem 0.03125rem
+      color-mix(in srgb, var(--sdn-swatch-offWhite) 30%, transparent),
     0px 0px 0.25rem 0.125rem color-mix(in srgb, var(--sdn-swatch-offBlack) 20%, transparent);
   width: fit-content;
   flex-shrink: 0;
@@ -2668,7 +2669,8 @@ body {
   align-items: start;
   justify-content: start;
   gap: var(--sdn-gaps-compact);
-  box-shadow: 0px 1px 0.125rem 0.031rem color-mix(in srgb, var(--sdn-swatch-black) 20%, transparent);
+  box-shadow: 0px 1px 0.125rem 0.03125rem
+    color-mix(in srgb, var(--sdn-swatch-black) 20%, transparent);
   padding: var(--sdn-paddings-compact);
   border-radius: var(--sdn-corners-tight);
   border: var(--hairline) solid var(--sdn-swatch-offBlack-b50);
@@ -3003,7 +3005,7 @@ body {
 }
 
 .sdn-icon--km45 {
-  width: 1.501rem;
+  width: 1.5rem;
   color: var(--sdn-hc-on-white);
 }
 
@@ -3012,7 +3014,7 @@ body {
 }
 
 .sdn-icon--mene {
-  width: 1.501rem;
+  width: 1.5rem;
 }
 
 .sdn-icon--pbp5 {
@@ -3085,9 +3087,9 @@ body {
 .sdn-image--98gd {
   align-self: unset;
   flex: unset;
-  width: 2.998rem;
+  width: 3rem;
   flex-shrink: 0;
-  height: 2.998rem;
+  height: 3rem;
   border-radius: 99999px;
   border: var(--sdn-border-width-medium) solid var(--sdn-swatch-offBlack);
 }
@@ -3095,9 +3097,9 @@ body {
 .sdn-image--9jgp {
   align-self: unset;
   flex: unset;
-  width: 2.998rem;
+  width: 3rem;
   flex-shrink: 0;
-  height: 2.998rem;
+  height: 3rem;
   border-radius: var(--sdn-corners-tight);
   border: var(--sdn-border-width-medium) solid var(--sdn-swatch-primary);
 }
@@ -3125,9 +3127,9 @@ body {
   align-self: unset;
   flex: unset;
   box-shadow: 0px 0px 0px 0.125rem var(--sdn-swatch-white);
-  width: 2.998rem;
+  width: 3rem;
   flex-shrink: 0;
-  height: 2.998rem;
+  height: 3rem;
   right: -5rem;
   position: absolute;
   border-radius: 99999px;
@@ -3137,9 +3139,9 @@ body {
 .sdn-image--to5v {
   align-self: unset;
   flex: unset;
-  width: 2.998rem;
+  width: 3rem;
   flex-shrink: 0;
-  height: 2.998rem;
+  height: 3rem;
   border-radius: 99999px;
 }
 
@@ -3147,9 +3149,9 @@ body {
   align-self: unset;
   flex: unset;
   box-shadow: 0px 0px 0px 0.125rem var(--sdn-swatch-white);
-  width: 2.998rem;
+  width: 3rem;
   flex-shrink: 0;
-  height: 2.998rem;
+  height: 3rem;
   right: -2.5rem;
   position: absolute;
   border-radius: 99999px;
@@ -3159,9 +3161,9 @@ body {
 .sdn-image--zjyq {
   align-self: unset;
   flex: unset;
-  width: 2.998rem;
+  width: 3rem;
   flex-shrink: 0;
-  height: 2.998rem;
+  height: 3rem;
   border-radius: 99999px;
   border: var(--sdn-border-width-medium) solid var(--sdn-swatch-primary);
 }
@@ -3199,7 +3201,7 @@ body {
   padding-bottom: var(--sdn-paddings-tight);
   padding-inline-start: var(--sdn-paddings-compact);
   flex: 1 0 0;
-  height: 2.002rem;
+  height: 2rem;
   min-width: 0;
   border: var(--hairline) solid var(--sdn-swatch-primary);
 }

--- a/packages/editor/apps/react/seldon/styles/adobe-spectrum.css
+++ b/packages/editor/apps/react/seldon/styles/adobe-spectrum.css
@@ -78,49 +78,49 @@
   --sdn-swatch-accent-bn30: hsl(239 65% 42%);
   --sdn-swatch-gray-b50: hsl(210 4% 78%);
   /* Sizes */
-  --sdn-sizes-tiny: 0.183rem;
-  --sdn-sizes-xxsmall: 0.322rem;
-  --sdn-sizes-xsmall: 0.567rem;
-  --sdn-sizes-small: 0.79rem;
+  --sdn-sizes-tiny: 0.1875rem;
+  --sdn-sizes-xxsmall: 0.328125rem;
+  --sdn-sizes-xsmall: 0.5625rem;
+  --sdn-sizes-small: 0.796875rem;
   --sdn-sizes-medium: 1rem;
-  --sdn-sizes-large: 1.394rem;
-  --sdn-sizes-xlarge: 1.763rem;
-  --sdn-sizes-xxlarge: 2.452rem;
-  --sdn-sizes-huge: 3.103rem;
+  --sdn-sizes-large: 1.390625rem;
+  --sdn-sizes-xlarge: 1.765625rem;
+  --sdn-sizes-xxlarge: 2.453125rem;
+  --sdn-sizes-huge: 3.109375rem;
   /* Margins */
-  --sdn-margins-tight: 0.322rem;
-  --sdn-margins-compact: 0.567rem;
+  --sdn-margins-tight: 0.328125rem;
+  --sdn-margins-compact: 0.5625rem;
   --sdn-margins-cozy: 1rem;
-  --sdn-margins-comfortable: 1.763rem;
-  --sdn-margins-open: 3.103rem;
+  --sdn-margins-comfortable: 1.765625rem;
+  --sdn-margins-open: 3.109375rem;
   /* Paddings */
-  --sdn-paddings-tight: 0.322rem;
-  --sdn-paddings-compact: 0.567rem;
+  --sdn-paddings-tight: 0.328125rem;
+  --sdn-paddings-compact: 0.5625rem;
   --sdn-paddings-cozy: 1rem;
-  --sdn-paddings-comfortable: 1.763rem;
-  --sdn-paddings-open: 3.103rem;
+  --sdn-paddings-comfortable: 1.765625rem;
+  --sdn-paddings-open: 3.109375rem;
   /* Gaps */
-  --sdn-gaps-tight: 0.322rem;
-  --sdn-gaps-compact: 0.567rem;
+  --sdn-gaps-tight: 0.328125rem;
+  --sdn-gaps-compact: 0.5625rem;
   --sdn-gaps-cozy: 1rem;
-  --sdn-gaps-comfortable: 1.763rem;
-  --sdn-gaps-open: 3.103rem;
+  --sdn-gaps-comfortable: 1.765625rem;
+  --sdn-gaps-open: 3.109375rem;
   /* Corners */
-  --sdn-corners-tight: 0.322rem;
-  --sdn-corners-compact: 0.567rem;
-  --sdn-corners-cozy: 1.394rem;
-  --sdn-corners-comfortable: 1.763rem;
-  --sdn-corners-open: 2.452rem;
+  --sdn-corners-tight: 0.328125rem;
+  --sdn-corners-compact: 0.5625rem;
+  --sdn-corners-cozy: 1.390625rem;
+  --sdn-corners-comfortable: 1.765625rem;
+  --sdn-corners-open: 2.453125rem;
   /* Font Sizes */
-  --sdn-font-size-tiny: 0.567rem;
-  --sdn-font-size-xxsmall: 0.681rem;
-  --sdn-font-size-xsmall: 0.79rem;
-  --sdn-font-size-small: 0.896rem;
+  --sdn-font-size-tiny: 0.5625rem;
+  --sdn-font-size-xxsmall: 0.6875rem;
+  --sdn-font-size-xsmall: 0.796875rem;
+  --sdn-font-size-small: 0.890625rem;
   --sdn-font-size-medium: 1rem;
-  --sdn-font-size-large: 1.394rem;
-  --sdn-font-size-xlarge: 1.763rem;
-  --sdn-font-size-xxlarge: 2.452rem;
-  --sdn-font-size-huge: 3.103rem;
+  --sdn-font-size-large: 1.390625rem;
+  --sdn-font-size-xlarge: 1.765625rem;
+  --sdn-font-size-xxlarge: 2.453125rem;
+  --sdn-font-size-huge: 3.109375rem;
   /* Font Weights */
   --sdn-font-weight-thin: 100;
   --sdn-font-weight-xlight: 200;
@@ -140,11 +140,11 @@
   --sdn-line-height-comfortable: 2;
   --sdn-line-height-open: 2.5;
   /* Border Widths */
-  --sdn-border-width-xsmall: 0.059rem;
-  --sdn-border-width-small: 0.112rem;
-  --sdn-border-width-medium: 0.183rem;
-  --sdn-border-width-large: 0.322rem;
-  --sdn-border-width-xlarge: 0.567rem;
+  --sdn-border-width-xsmall: 0.0625rem;
+  --sdn-border-width-small: 0.109375rem;
+  --sdn-border-width-medium: 0.1875rem;
+  --sdn-border-width-large: 0.328125rem;
+  --sdn-border-width-xlarge: 0.5625rem;
   /* High Contrast */
   --sdn-hc-on-white: hsl(210 4% 12%);
   --sdn-hc-on-gray: hsl(210 4% 98%);

--- a/packages/editor/apps/react/seldon/styles/earth.css
+++ b/packages/editor/apps/react/seldon/styles/earth.css
@@ -81,49 +81,49 @@
   --sdn-swatch-accent-bn30: hsl(158 32% 25.9%);
   --sdn-swatch-gray-b50: hsl(16 12% 78%);
   /* Sizes */
-  --sdn-sizes-tiny: 0.069rem;
-  --sdn-sizes-xxsmall: 0.168rem;
-  --sdn-sizes-xsmall: 0.409rem;
-  --sdn-sizes-small: 0.69rem;
+  --sdn-sizes-tiny: 0.0625rem;
+  --sdn-sizes-xxsmall: 0.171875rem;
+  --sdn-sizes-xsmall: 0.40625rem;
+  --sdn-sizes-small: 0.6875rem;
   --sdn-sizes-medium: 1rem;
-  --sdn-sizes-large: 1.687rem;
-  --sdn-sizes-xlarge: 2.445rem;
-  --sdn-sizes-xxlarge: 4.113rem;
-  --sdn-sizes-huge: 5.959rem;
+  --sdn-sizes-large: 1.6875rem;
+  --sdn-sizes-xlarge: 2.4375rem;
+  --sdn-sizes-xxlarge: 4.109375rem;
+  --sdn-sizes-huge: 5.953125rem;
   /* Margins */
-  --sdn-margins-tight: 0.168rem;
-  --sdn-margins-compact: 0.409rem;
+  --sdn-margins-tight: 0.171875rem;
+  --sdn-margins-compact: 0.40625rem;
   --sdn-margins-cozy: 1rem;
-  --sdn-margins-comfortable: 2.445rem;
-  --sdn-margins-open: 14.569rem;
+  --sdn-margins-comfortable: 2.4375rem;
+  --sdn-margins-open: 14.5625rem;
   /* Paddings */
-  --sdn-paddings-tight: 0.168rem;
-  --sdn-paddings-compact: 0.409rem;
+  --sdn-paddings-tight: 0.171875rem;
+  --sdn-paddings-compact: 0.40625rem;
   --sdn-paddings-cozy: 1rem;
-  --sdn-paddings-comfortable: 2.445rem;
-  --sdn-paddings-open: 14.569rem;
+  --sdn-paddings-comfortable: 2.4375rem;
+  --sdn-paddings-open: 14.5625rem;
   /* Gaps */
-  --sdn-gaps-tight: 0.168rem;
-  --sdn-gaps-compact: 0.409rem;
+  --sdn-gaps-tight: 0.171875rem;
+  --sdn-gaps-compact: 0.40625rem;
   --sdn-gaps-cozy: 1rem;
-  --sdn-gaps-comfortable: 2.445rem;
-  --sdn-gaps-open: 14.569rem;
+  --sdn-gaps-comfortable: 2.4375rem;
+  --sdn-gaps-open: 14.5625rem;
   /* Corners */
-  --sdn-corners-tight: 0.168rem;
-  --sdn-corners-compact: 0.409rem;
-  --sdn-corners-cozy: 1.295rem;
-  --sdn-corners-comfortable: 2.445rem;
-  --sdn-corners-open: 4.113rem;
+  --sdn-corners-tight: 0.171875rem;
+  --sdn-corners-compact: 0.40625rem;
+  --sdn-corners-cozy: 1.296875rem;
+  --sdn-corners-comfortable: 2.4375rem;
+  --sdn-corners-open: 4.109375rem;
   /* Font Sizes */
-  --sdn-font-size-tiny: 0.409rem;
-  --sdn-font-size-xxsmall: 0.545rem;
-  --sdn-font-size-xsmall: 0.69rem;
-  --sdn-font-size-small: 0.842rem;
+  --sdn-font-size-tiny: 0.40625rem;
+  --sdn-font-size-xxsmall: 0.546875rem;
+  --sdn-font-size-xsmall: 0.6875rem;
+  --sdn-font-size-small: 0.84375rem;
   --sdn-font-size-medium: 1rem;
-  --sdn-font-size-large: 1.687rem;
-  --sdn-font-size-xlarge: 2.445rem;
-  --sdn-font-size-xxlarge: 4.113rem;
-  --sdn-font-size-huge: 5.959rem;
+  --sdn-font-size-large: 1.6875rem;
+  --sdn-font-size-xlarge: 2.4375rem;
+  --sdn-font-size-xxlarge: 4.109375rem;
+  --sdn-font-size-huge: 5.953125rem;
   /* Font Weights */
   --sdn-font-weight-thin: 100;
   --sdn-font-weight-xlight: 200;
@@ -143,11 +143,11 @@
   --sdn-line-height-comfortable: 2;
   --sdn-line-height-open: 2.5;
   /* Border Widths */
-  --sdn-border-width-xsmall: 0.012rem;
-  --sdn-border-width-small: 0.032rem;
-  --sdn-border-width-medium: 0.069rem;
-  --sdn-border-width-large: 0.168rem;
-  --sdn-border-width-xlarge: 0.409rem;
+  --sdn-border-width-xsmall: 0.015625rem;
+  --sdn-border-width-small: 0.03125rem;
+  --sdn-border-width-medium: 0.0625rem;
+  --sdn-border-width-large: 0.171875rem;
+  --sdn-border-width-xlarge: 0.40625rem;
   /* High Contrast */
   --sdn-hc-on-white: hsl(16 12% 8%);
   --sdn-hc-on-gray: hsl(16 12% 98%);

--- a/packages/editor/apps/react/seldon/styles/google-material.css
+++ b/packages/editor/apps/react/seldon/styles/google-material.css
@@ -85,43 +85,43 @@
   --sdn-sizes-xsmall: 0.5rem;
   --sdn-sizes-small: 0.75rem;
   --sdn-sizes-medium: 1rem;
-  --sdn-sizes-large: 1.501rem;
-  --sdn-sizes-xlarge: 2.002rem;
-  --sdn-sizes-xxlarge: 2.998rem;
-  --sdn-sizes-huge: 3.998rem;
+  --sdn-sizes-large: 1.5rem;
+  --sdn-sizes-xlarge: 2rem;
+  --sdn-sizes-xxlarge: 3rem;
+  --sdn-sizes-huge: 4rem;
   /* Margins */
   --sdn-margins-tight: 0.25rem;
   --sdn-margins-compact: 0.5rem;
   --sdn-margins-cozy: 1rem;
-  --sdn-margins-comfortable: 2.002rem;
-  --sdn-margins-open: 3.998rem;
+  --sdn-margins-comfortable: 2rem;
+  --sdn-margins-open: 4rem;
   /* Paddings */
   --sdn-paddings-tight: 0.25rem;
   --sdn-paddings-compact: 0.5rem;
   --sdn-paddings-cozy: 1rem;
-  --sdn-paddings-comfortable: 2.002rem;
-  --sdn-paddings-open: 3.998rem;
+  --sdn-paddings-comfortable: 2rem;
+  --sdn-paddings-open: 4rem;
   /* Gaps */
   --sdn-gaps-tight: 0.25rem;
   --sdn-gaps-compact: 0.5rem;
   --sdn-gaps-cozy: 1rem;
-  --sdn-gaps-comfortable: 2.002rem;
-  --sdn-gaps-open: 3.998rem;
+  --sdn-gaps-comfortable: 2rem;
+  --sdn-gaps-open: 4rem;
   /* Corners */
   --sdn-corners-tight: 0.25rem;
   --sdn-corners-compact: 0.5rem;
   --sdn-corners-cozy: 1rem;
-  --sdn-corners-comfortable: 1.501rem;
-  --sdn-corners-open: 2.002rem;
+  --sdn-corners-comfortable: 1.5rem;
+  --sdn-corners-open: 2rem;
   /* Font Sizes */
   --sdn-font-size-tiny: 0.5rem;
-  --sdn-font-size-xxsmall: 0.624rem;
+  --sdn-font-size-xxsmall: 0.625rem;
   --sdn-font-size-xsmall: 0.75rem;
   --sdn-font-size-small: 0.875rem;
   --sdn-font-size-medium: 1rem;
-  --sdn-font-size-large: 1.376rem;
-  --sdn-font-size-xlarge: 2.002rem;
-  --sdn-font-size-xxlarge: 3.56rem;
+  --sdn-font-size-large: 1.375rem;
+  --sdn-font-size-xlarge: 2rem;
+  --sdn-font-size-xxlarge: 3.5625rem;
   --sdn-font-size-huge: 4.5rem;
   /* Font Weights */
   --sdn-font-weight-thin: 100;
@@ -142,8 +142,8 @@
   --sdn-line-height-comfortable: 2;
   --sdn-line-height-open: 2.5;
   /* Border Widths */
-  --sdn-border-width-xsmall: 0.031rem;
-  --sdn-border-width-small: 0.069rem;
+  --sdn-border-width-xsmall: 0.03125rem;
+  --sdn-border-width-small: 0.0625rem;
   --sdn-border-width-medium: 0.125rem;
   --sdn-border-width-large: 0.25rem;
   --sdn-border-width-xlarge: 0.5rem;

--- a/packages/editor/apps/react/seldon/styles/high-contrast.css
+++ b/packages/editor/apps/react/seldon/styles/high-contrast.css
@@ -83,44 +83,44 @@
   --sdn-sizes-xsmall: 0.5rem;
   --sdn-sizes-small: 0.75rem;
   --sdn-sizes-medium: 1rem;
-  --sdn-sizes-large: 1.501rem;
-  --sdn-sizes-xlarge: 2.002rem;
-  --sdn-sizes-xxlarge: 2.998rem;
-  --sdn-sizes-huge: 3.998rem;
+  --sdn-sizes-large: 1.5rem;
+  --sdn-sizes-xlarge: 2rem;
+  --sdn-sizes-xxlarge: 3rem;
+  --sdn-sizes-huge: 4rem;
   /* Margins */
   --sdn-margins-tight: 0.25rem;
   --sdn-margins-compact: 0.5rem;
   --sdn-margins-cozy: 1rem;
-  --sdn-margins-comfortable: 2.002rem;
-  --sdn-margins-open: 3.998rem;
+  --sdn-margins-comfortable: 2rem;
+  --sdn-margins-open: 4rem;
   /* Paddings */
   --sdn-paddings-tight: 0.25rem;
   --sdn-paddings-compact: 0.5rem;
   --sdn-paddings-cozy: 1rem;
-  --sdn-paddings-comfortable: 2.002rem;
-  --sdn-paddings-open: 3.998rem;
+  --sdn-paddings-comfortable: 2rem;
+  --sdn-paddings-open: 4rem;
   /* Gaps */
   --sdn-gaps-tight: 0.25rem;
   --sdn-gaps-compact: 0.5rem;
   --sdn-gaps-cozy: 1rem;
-  --sdn-gaps-comfortable: 2.002rem;
-  --sdn-gaps-open: 3.998rem;
+  --sdn-gaps-comfortable: 2rem;
+  --sdn-gaps-open: 4rem;
   /* Corners */
   --sdn-corners-tight: 0.25rem;
   --sdn-corners-compact: 0.5rem;
   --sdn-corners-cozy: 1rem;
-  --sdn-corners-comfortable: 1.501rem;
-  --sdn-corners-open: 2.002rem;
+  --sdn-corners-comfortable: 1.5rem;
+  --sdn-corners-open: 2rem;
   /* Font Sizes */
   --sdn-font-size-tiny: 0.5rem;
-  --sdn-font-size-xxsmall: 0.624rem;
+  --sdn-font-size-xxsmall: 0.625rem;
   --sdn-font-size-xsmall: 0.75rem;
   --sdn-font-size-small: 0.875rem;
   --sdn-font-size-medium: 1rem;
-  --sdn-font-size-large: 1.501rem;
-  --sdn-font-size-xlarge: 2.002rem;
-  --sdn-font-size-xxlarge: 2.998rem;
-  --sdn-font-size-huge: 3.998rem;
+  --sdn-font-size-large: 1.5rem;
+  --sdn-font-size-xlarge: 2rem;
+  --sdn-font-size-xxlarge: 3rem;
+  --sdn-font-size-huge: 4rem;
   /* Font Weights */
   --sdn-font-weight-thin: 100;
   --sdn-font-weight-xlight: 200;
@@ -140,8 +140,8 @@
   --sdn-line-height-comfortable: 2;
   --sdn-line-height-open: 2.5;
   /* Border Widths */
-  --sdn-border-width-xsmall: 0.031rem;
-  --sdn-border-width-small: 0.069rem;
+  --sdn-border-width-xsmall: 0.03125rem;
+  --sdn-border-width-small: 0.0625rem;
   --sdn-border-width-medium: 0.125rem;
   --sdn-border-width-large: 0.25rem;
   --sdn-border-width-xlarge: 0.5rem;

--- a/packages/editor/apps/react/seldon/styles/ibm-carbon.css
+++ b/packages/editor/apps/react/seldon/styles/ibm-carbon.css
@@ -78,49 +78,49 @@
   --sdn-swatch-accent-bn30: hsl(262 88% 41.3%);
   --sdn-swatch-gray-b50: hsl(218 12% 78%);
   /* Sizes */
-  --sdn-sizes-tiny: 0.183rem;
-  --sdn-sizes-xxsmall: 0.322rem;
-  --sdn-sizes-xsmall: 0.567rem;
-  --sdn-sizes-small: 0.79rem;
+  --sdn-sizes-tiny: 0.1875rem;
+  --sdn-sizes-xxsmall: 0.328125rem;
+  --sdn-sizes-xsmall: 0.5625rem;
+  --sdn-sizes-small: 0.796875rem;
   --sdn-sizes-medium: 1rem;
-  --sdn-sizes-large: 1.394rem;
-  --sdn-sizes-xlarge: 1.763rem;
-  --sdn-sizes-xxlarge: 2.452rem;
-  --sdn-sizes-huge: 3.103rem;
+  --sdn-sizes-large: 1.390625rem;
+  --sdn-sizes-xlarge: 1.765625rem;
+  --sdn-sizes-xxlarge: 2.453125rem;
+  --sdn-sizes-huge: 3.109375rem;
   /* Margins */
-  --sdn-margins-tight: 0.322rem;
-  --sdn-margins-compact: 0.567rem;
+  --sdn-margins-tight: 0.328125rem;
+  --sdn-margins-compact: 0.5625rem;
   --sdn-margins-cozy: 1rem;
-  --sdn-margins-comfortable: 1.763rem;
-  --sdn-margins-open: 3.103rem;
+  --sdn-margins-comfortable: 1.765625rem;
+  --sdn-margins-open: 3.109375rem;
   /* Paddings */
-  --sdn-paddings-tight: 0.322rem;
-  --sdn-paddings-compact: 0.567rem;
+  --sdn-paddings-tight: 0.328125rem;
+  --sdn-paddings-compact: 0.5625rem;
   --sdn-paddings-cozy: 1rem;
-  --sdn-paddings-comfortable: 1.763rem;
-  --sdn-paddings-open: 3.103rem;
+  --sdn-paddings-comfortable: 1.765625rem;
+  --sdn-paddings-open: 3.109375rem;
   /* Gaps */
-  --sdn-gaps-tight: 0.322rem;
-  --sdn-gaps-compact: 0.567rem;
+  --sdn-gaps-tight: 0.328125rem;
+  --sdn-gaps-compact: 0.5625rem;
   --sdn-gaps-cozy: 1rem;
-  --sdn-gaps-comfortable: 1.763rem;
-  --sdn-gaps-open: 3.103rem;
+  --sdn-gaps-comfortable: 1.765625rem;
+  --sdn-gaps-open: 3.109375rem;
   /* Corners */
-  --sdn-corners-tight: 0.104rem;
-  --sdn-corners-compact: 0.183rem;
-  --sdn-corners-cozy: 0.322rem;
-  --sdn-corners-comfortable: 0.567rem;
+  --sdn-corners-tight: 0.109375rem;
+  --sdn-corners-compact: 0.1875rem;
+  --sdn-corners-cozy: 0.328125rem;
+  --sdn-corners-comfortable: 0.5625rem;
   --sdn-corners-open: 1rem;
   /* Font Sizes */
-  --sdn-font-size-tiny: 0.567rem;
-  --sdn-font-size-xxsmall: 0.681rem;
-  --sdn-font-size-xsmall: 0.79rem;
-  --sdn-font-size-small: 0.896rem;
+  --sdn-font-size-tiny: 0.5625rem;
+  --sdn-font-size-xxsmall: 0.6875rem;
+  --sdn-font-size-xsmall: 0.796875rem;
+  --sdn-font-size-small: 0.890625rem;
   --sdn-font-size-medium: 1rem;
-  --sdn-font-size-large: 1.44rem;
-  --sdn-font-size-xlarge: 1.763rem;
-  --sdn-font-size-xxlarge: 2.452rem;
-  --sdn-font-size-huge: 3.103rem;
+  --sdn-font-size-large: 1.4375rem;
+  --sdn-font-size-xlarge: 1.765625rem;
+  --sdn-font-size-xxlarge: 2.453125rem;
+  --sdn-font-size-huge: 3.109375rem;
   /* Font Weights */
   --sdn-font-weight-thin: 100;
   --sdn-font-weight-xlight: 200;
@@ -140,11 +140,11 @@
   --sdn-line-height-comfortable: 2;
   --sdn-line-height-open: 2.5;
   /* Border Widths */
-  --sdn-border-width-xsmall: 0.059rem;
-  --sdn-border-width-small: 0.112rem;
-  --sdn-border-width-medium: 0.183rem;
-  --sdn-border-width-large: 0.322rem;
-  --sdn-border-width-xlarge: 0.567rem;
+  --sdn-border-width-xsmall: 0.0625rem;
+  --sdn-border-width-small: 0.109375rem;
+  --sdn-border-width-medium: 0.1875rem;
+  --sdn-border-width-large: 0.328125rem;
+  --sdn-border-width-xlarge: 0.5625rem;
   /* High Contrast */
   --sdn-hc-on-white: hsl(218 12% 8%);
   --sdn-hc-on-gray: hsl(218 12% 98%);

--- a/packages/editor/apps/react/seldon/styles/industrial.css
+++ b/packages/editor/apps/react/seldon/styles/industrial.css
@@ -83,44 +83,44 @@
   --sdn-sizes-xsmall: 0.5rem;
   --sdn-sizes-small: 0.75rem;
   --sdn-sizes-medium: 1rem;
-  --sdn-sizes-large: 1.501rem;
-  --sdn-sizes-xlarge: 2.002rem;
-  --sdn-sizes-xxlarge: 2.998rem;
-  --sdn-sizes-huge: 3.998rem;
+  --sdn-sizes-large: 1.5rem;
+  --sdn-sizes-xlarge: 2rem;
+  --sdn-sizes-xxlarge: 3rem;
+  --sdn-sizes-huge: 4rem;
   /* Margins */
   --sdn-margins-tight: 0.25rem;
   --sdn-margins-compact: 0.5rem;
   --sdn-margins-cozy: 1rem;
-  --sdn-margins-comfortable: 2.002rem;
-  --sdn-margins-open: 3.998rem;
+  --sdn-margins-comfortable: 2rem;
+  --sdn-margins-open: 4rem;
   /* Paddings */
   --sdn-paddings-tight: 0.25rem;
   --sdn-paddings-compact: 0.5rem;
   --sdn-paddings-cozy: 1rem;
-  --sdn-paddings-comfortable: 2.002rem;
-  --sdn-paddings-open: 3.998rem;
+  --sdn-paddings-comfortable: 2rem;
+  --sdn-paddings-open: 4rem;
   /* Gaps */
   --sdn-gaps-tight: 0.25rem;
   --sdn-gaps-compact: 0.5rem;
   --sdn-gaps-cozy: 1rem;
-  --sdn-gaps-comfortable: 2.002rem;
-  --sdn-gaps-open: 3.998rem;
+  --sdn-gaps-comfortable: 2rem;
+  --sdn-gaps-open: 4rem;
   /* Corners */
-  --sdn-corners-tight: 0.031rem;
-  --sdn-corners-compact: 0.062rem;
+  --sdn-corners-tight: 0.03125rem;
+  --sdn-corners-compact: 0.0625rem;
   --sdn-corners-cozy: 0.125rem;
   --sdn-corners-comfortable: 0.25rem;
   --sdn-corners-open: 0.5rem;
   /* Font Sizes */
   --sdn-font-size-tiny: 0.5rem;
-  --sdn-font-size-xxsmall: 0.624rem;
+  --sdn-font-size-xxsmall: 0.625rem;
   --sdn-font-size-xsmall: 0.75rem;
   --sdn-font-size-small: 0.875rem;
   --sdn-font-size-medium: 1rem;
-  --sdn-font-size-large: 1.501rem;
-  --sdn-font-size-xlarge: 2.002rem;
-  --sdn-font-size-xxlarge: 2.998rem;
-  --sdn-font-size-huge: 3.998rem;
+  --sdn-font-size-large: 1.5rem;
+  --sdn-font-size-xlarge: 2rem;
+  --sdn-font-size-xxlarge: 3rem;
+  --sdn-font-size-huge: 4rem;
   /* Font Weights */
   --sdn-font-weight-thin: 100;
   --sdn-font-weight-xlight: 200;
@@ -140,8 +140,8 @@
   --sdn-line-height-comfortable: 2;
   --sdn-line-height-open: 2.5;
   /* Border Widths */
-  --sdn-border-width-xsmall: 0.031rem;
-  --sdn-border-width-small: 0.069rem;
+  --sdn-border-width-xsmall: 0.03125rem;
+  --sdn-border-width-small: 0.0625rem;
   --sdn-border-width-medium: 0.125rem;
   --sdn-border-width-large: 0.25rem;
   --sdn-border-width-xlarge: 0.5rem;

--- a/packages/editor/apps/react/seldon/styles/pop-punk.css
+++ b/packages/editor/apps/react/seldon/styles/pop-punk.css
@@ -78,49 +78,49 @@
   --sdn-swatch-accent-bn30: hsl(208 97% 32.2%);
   --sdn-swatch-gray-b50: hsl(344 12% 78%);
   /* Sizes */
-  --sdn-sizes-tiny: 0.069rem;
-  --sdn-sizes-xxsmall: 0.168rem;
-  --sdn-sizes-xsmall: 0.409rem;
-  --sdn-sizes-small: 0.69rem;
+  --sdn-sizes-tiny: 0.0625rem;
+  --sdn-sizes-xxsmall: 0.171875rem;
+  --sdn-sizes-xsmall: 0.40625rem;
+  --sdn-sizes-small: 0.6875rem;
   --sdn-sizes-medium: 1rem;
-  --sdn-sizes-large: 1.687rem;
-  --sdn-sizes-xlarge: 2.445rem;
-  --sdn-sizes-xxlarge: 4.113rem;
-  --sdn-sizes-huge: 5.959rem;
+  --sdn-sizes-large: 1.6875rem;
+  --sdn-sizes-xlarge: 2.4375rem;
+  --sdn-sizes-xxlarge: 4.109375rem;
+  --sdn-sizes-huge: 5.953125rem;
   /* Margins */
-  --sdn-margins-tight: 0.168rem;
-  --sdn-margins-compact: 0.409rem;
+  --sdn-margins-tight: 0.171875rem;
+  --sdn-margins-compact: 0.40625rem;
   --sdn-margins-cozy: 1rem;
-  --sdn-margins-comfortable: 2.445rem;
-  --sdn-margins-open: 14.569rem;
+  --sdn-margins-comfortable: 2.4375rem;
+  --sdn-margins-open: 14.5625rem;
   /* Paddings */
-  --sdn-paddings-tight: 0.168rem;
-  --sdn-paddings-compact: 0.409rem;
+  --sdn-paddings-tight: 0.171875rem;
+  --sdn-paddings-compact: 0.40625rem;
   --sdn-paddings-cozy: 1rem;
-  --sdn-paddings-comfortable: 2.445rem;
-  --sdn-paddings-open: 14.569rem;
+  --sdn-paddings-comfortable: 2.4375rem;
+  --sdn-paddings-open: 14.5625rem;
   /* Gaps */
-  --sdn-gaps-tight: 0.168rem;
-  --sdn-gaps-compact: 0.409rem;
+  --sdn-gaps-tight: 0.171875rem;
+  --sdn-gaps-compact: 0.40625rem;
   --sdn-gaps-cozy: 1rem;
-  --sdn-gaps-comfortable: 2.445rem;
-  --sdn-gaps-open: 14.569rem;
+  --sdn-gaps-comfortable: 2.4375rem;
+  --sdn-gaps-open: 14.5625rem;
   /* Corners */
-  --sdn-corners-tight: 0.168rem;
-  --sdn-corners-compact: 0.409rem;
-  --sdn-corners-cozy: 1.687rem;
-  --sdn-corners-comfortable: 2.445rem;
-  --sdn-corners-open: 4.113rem;
+  --sdn-corners-tight: 0.171875rem;
+  --sdn-corners-compact: 0.40625rem;
+  --sdn-corners-cozy: 1.6875rem;
+  --sdn-corners-comfortable: 2.4375rem;
+  --sdn-corners-open: 4.109375rem;
   /* Font Sizes */
-  --sdn-font-size-tiny: 0.409rem;
-  --sdn-font-size-xxsmall: 0.545rem;
-  --sdn-font-size-xsmall: 0.69rem;
-  --sdn-font-size-small: 0.842rem;
+  --sdn-font-size-tiny: 0.40625rem;
+  --sdn-font-size-xxsmall: 0.546875rem;
+  --sdn-font-size-xsmall: 0.6875rem;
+  --sdn-font-size-small: 0.84375rem;
   --sdn-font-size-medium: 1rem;
-  --sdn-font-size-large: 1.687rem;
-  --sdn-font-size-xlarge: 2.445rem;
-  --sdn-font-size-xxlarge: 4.113rem;
-  --sdn-font-size-huge: 5.959rem;
+  --sdn-font-size-large: 1.6875rem;
+  --sdn-font-size-xlarge: 2.4375rem;
+  --sdn-font-size-xxlarge: 4.109375rem;
+  --sdn-font-size-huge: 5.953125rem;
   /* Font Weights */
   --sdn-font-weight-thin: 100;
   --sdn-font-weight-xlight: 200;
@@ -140,11 +140,11 @@
   --sdn-line-height-comfortable: 2;
   --sdn-line-height-open: 2.5;
   /* Border Widths */
-  --sdn-border-width-xsmall: 0.012rem;
-  --sdn-border-width-small: 0.032rem;
-  --sdn-border-width-medium: 0.069rem;
-  --sdn-border-width-large: 0.168rem;
-  --sdn-border-width-xlarge: 0.409rem;
+  --sdn-border-width-xsmall: 0.015625rem;
+  --sdn-border-width-small: 0.03125rem;
+  --sdn-border-width-medium: 0.0625rem;
+  --sdn-border-width-large: 0.171875rem;
+  --sdn-border-width-xlarge: 0.40625rem;
   /* High Contrast */
   --sdn-hc-on-white: hsl(344 12% 8%);
   --sdn-hc-on-gray: hsl(344 12% 98%);

--- a/packages/editor/apps/react/seldon/styles/seldon.css
+++ b/packages/editor/apps/react/seldon/styles/seldon.css
@@ -83,44 +83,44 @@
   --sdn-sizes-xsmall: 0.5rem;
   --sdn-sizes-small: 0.75rem;
   --sdn-sizes-medium: 1rem;
-  --sdn-sizes-large: 1.501rem;
-  --sdn-sizes-xlarge: 2.002rem;
-  --sdn-sizes-xxlarge: 2.998rem;
-  --sdn-sizes-huge: 3.998rem;
+  --sdn-sizes-large: 1.5rem;
+  --sdn-sizes-xlarge: 2rem;
+  --sdn-sizes-xxlarge: 3rem;
+  --sdn-sizes-huge: 4rem;
   /* Margins */
   --sdn-margins-tight: 0.25rem;
   --sdn-margins-compact: 0.5rem;
   --sdn-margins-cozy: 1rem;
-  --sdn-margins-comfortable: 2.002rem;
-  --sdn-margins-open: 3.998rem;
+  --sdn-margins-comfortable: 2rem;
+  --sdn-margins-open: 4rem;
   /* Paddings */
   --sdn-paddings-tight: 0.25rem;
   --sdn-paddings-compact: 0.5rem;
   --sdn-paddings-cozy: 1rem;
-  --sdn-paddings-comfortable: 2.002rem;
-  --sdn-paddings-open: 3.998rem;
+  --sdn-paddings-comfortable: 2rem;
+  --sdn-paddings-open: 4rem;
   /* Gaps */
   --sdn-gaps-tight: 0.25rem;
   --sdn-gaps-compact: 0.5rem;
   --sdn-gaps-cozy: 1rem;
-  --sdn-gaps-comfortable: 2.002rem;
-  --sdn-gaps-open: 3.998rem;
+  --sdn-gaps-comfortable: 2rem;
+  --sdn-gaps-open: 4rem;
   /* Corners */
   --sdn-corners-tight: 0.25rem;
   --sdn-corners-compact: 0.5rem;
   --sdn-corners-cozy: 1rem;
-  --sdn-corners-comfortable: 1.501rem;
-  --sdn-corners-open: 2.002rem;
+  --sdn-corners-comfortable: 1.5rem;
+  --sdn-corners-open: 2rem;
   /* Font Sizes */
   --sdn-font-size-tiny: 0.5rem;
-  --sdn-font-size-xxsmall: 0.624rem;
+  --sdn-font-size-xxsmall: 0.625rem;
   --sdn-font-size-xsmall: 0.75rem;
   --sdn-font-size-small: 0.875rem;
   --sdn-font-size-medium: 1rem;
-  --sdn-font-size-large: 1.501rem;
-  --sdn-font-size-xlarge: 2.002rem;
-  --sdn-font-size-xxlarge: 2.998rem;
-  --sdn-font-size-huge: 3.998rem;
+  --sdn-font-size-large: 1.5rem;
+  --sdn-font-size-xlarge: 2rem;
+  --sdn-font-size-xxlarge: 3rem;
+  --sdn-font-size-huge: 4rem;
   /* Font Weights */
   --sdn-font-weight-thin: 100;
   --sdn-font-weight-xlight: 200;
@@ -140,8 +140,8 @@
   --sdn-line-height-comfortable: 2;
   --sdn-line-height-open: 2.5;
   /* Border Widths */
-  --sdn-border-width-xsmall: 0.031rem;
-  --sdn-border-width-small: 0.069rem;
+  --sdn-border-width-xsmall: 0.03125rem;
+  --sdn-border-width-small: 0.0625rem;
   --sdn-border-width-medium: 0.125rem;
   --sdn-border-width-large: 0.25rem;
   --sdn-border-width-xlarge: 0.5rem;

--- a/packages/editor/apps/react/seldon/styles/sunset-blue.css
+++ b/packages/editor/apps/react/seldon/styles/sunset-blue.css
@@ -83,44 +83,44 @@
   --sdn-sizes-xsmall: 0.5rem;
   --sdn-sizes-small: 0.75rem;
   --sdn-sizes-medium: 1rem;
-  --sdn-sizes-large: 1.501rem;
-  --sdn-sizes-xlarge: 2.002rem;
-  --sdn-sizes-xxlarge: 2.998rem;
-  --sdn-sizes-huge: 3.998rem;
+  --sdn-sizes-large: 1.5rem;
+  --sdn-sizes-xlarge: 2rem;
+  --sdn-sizes-xxlarge: 3rem;
+  --sdn-sizes-huge: 4rem;
   /* Margins */
   --sdn-margins-tight: 0.25rem;
   --sdn-margins-compact: 0.5rem;
   --sdn-margins-cozy: 1rem;
-  --sdn-margins-comfortable: 2.002rem;
-  --sdn-margins-open: 3.998rem;
+  --sdn-margins-comfortable: 2rem;
+  --sdn-margins-open: 4rem;
   /* Paddings */
   --sdn-paddings-tight: 0.25rem;
   --sdn-paddings-compact: 0.5rem;
   --sdn-paddings-cozy: 1rem;
-  --sdn-paddings-comfortable: 2.002rem;
-  --sdn-paddings-open: 3.998rem;
+  --sdn-paddings-comfortable: 2rem;
+  --sdn-paddings-open: 4rem;
   /* Gaps */
   --sdn-gaps-tight: 0.25rem;
   --sdn-gaps-compact: 0.5rem;
   --sdn-gaps-cozy: 1rem;
-  --sdn-gaps-comfortable: 2.002rem;
-  --sdn-gaps-open: 3.998rem;
+  --sdn-gaps-comfortable: 2rem;
+  --sdn-gaps-open: 4rem;
   /* Corners */
   --sdn-corners-tight: 0.25rem;
   --sdn-corners-compact: 0.375rem;
   --sdn-corners-cozy: 0.5rem;
-  --sdn-corners-comfortable: 0.624rem;
+  --sdn-corners-comfortable: 0.625rem;
   --sdn-corners-open: 1rem;
   /* Font Sizes */
   --sdn-font-size-tiny: 0.5rem;
-  --sdn-font-size-xxsmall: 0.624rem;
+  --sdn-font-size-xxsmall: 0.625rem;
   --sdn-font-size-xsmall: 0.75rem;
   --sdn-font-size-small: 0.875rem;
   --sdn-font-size-medium: 1rem;
-  --sdn-font-size-large: 1.563rem;
-  --sdn-font-size-xlarge: 2.002rem;
-  --sdn-font-size-xxlarge: 2.998rem;
-  --sdn-font-size-huge: 3.998rem;
+  --sdn-font-size-large: 1.5625rem;
+  --sdn-font-size-xlarge: 2rem;
+  --sdn-font-size-xxlarge: 3rem;
+  --sdn-font-size-huge: 4rem;
   /* Font Weights */
   --sdn-font-weight-thin: 100;
   --sdn-font-weight-xlight: 200;
@@ -140,8 +140,8 @@
   --sdn-line-height-comfortable: 2;
   --sdn-line-height-open: 2.5;
   /* Border Widths */
-  --sdn-border-width-xsmall: 0.031rem;
-  --sdn-border-width-small: 0.069rem;
+  --sdn-border-width-xsmall: 0.03125rem;
+  --sdn-border-width-small: 0.0625rem;
   --sdn-border-width-medium: 0.125rem;
   --sdn-border-width-large: 0.25rem;
   --sdn-border-width-xlarge: 0.5rem;

--- a/packages/editor/apps/react/seldon/styles/wildberry.css
+++ b/packages/editor/apps/react/seldon/styles/wildberry.css
@@ -78,49 +78,49 @@
   --sdn-swatch-accent-bn30: hsl(47 87% 37.1%);
   --sdn-swatch-gray-b50: hsl(327 12% 78%);
   /* Sizes */
-  --sdn-sizes-tiny: 0.219rem;
-  --sdn-sizes-xxsmall: 0.387rem;
-  --sdn-sizes-xsmall: 0.681rem;
-  --sdn-sizes-small: 0.949rem;
+  --sdn-sizes-tiny: 0.21875rem;
+  --sdn-sizes-xxsmall: 0.390625rem;
+  --sdn-sizes-xsmall: 0.6875rem;
+  --sdn-sizes-small: 0.953125rem;
   --sdn-sizes-medium: 1.2rem;
-  --sdn-sizes-large: 1.672rem;
-  --sdn-sizes-xlarge: 2.116rem;
-  --sdn-sizes-xxlarge: 2.943rem;
-  --sdn-sizes-huge: 3.723rem;
+  --sdn-sizes-large: 1.671875rem;
+  --sdn-sizes-xlarge: 2.109375rem;
+  --sdn-sizes-xxlarge: 2.9375rem;
+  --sdn-sizes-huge: 3.71875rem;
   /* Margins */
-  --sdn-margins-tight: 0.387rem;
-  --sdn-margins-compact: 0.681rem;
+  --sdn-margins-tight: 0.390625rem;
+  --sdn-margins-compact: 0.6875rem;
   --sdn-margins-cozy: 1.2rem;
-  --sdn-margins-comfortable: 2.116rem;
-  --sdn-margins-open: 3.723rem;
+  --sdn-margins-comfortable: 2.109375rem;
+  --sdn-margins-open: 3.71875rem;
   /* Paddings */
-  --sdn-paddings-tight: 0.387rem;
-  --sdn-paddings-compact: 0.681rem;
+  --sdn-paddings-tight: 0.390625rem;
+  --sdn-paddings-compact: 0.6875rem;
   --sdn-paddings-cozy: 1.2rem;
-  --sdn-paddings-comfortable: 2.116rem;
-  --sdn-paddings-open: 3.723rem;
+  --sdn-paddings-comfortable: 2.109375rem;
+  --sdn-paddings-open: 3.71875rem;
   /* Gaps */
-  --sdn-gaps-tight: 0.387rem;
-  --sdn-gaps-compact: 0.681rem;
+  --sdn-gaps-tight: 0.390625rem;
+  --sdn-gaps-compact: 0.6875rem;
   --sdn-gaps-cozy: 1.2rem;
-  --sdn-gaps-comfortable: 2.116rem;
-  --sdn-gaps-open: 3.723rem;
+  --sdn-gaps-comfortable: 2.109375rem;
+  --sdn-gaps-open: 3.71875rem;
   /* Corners */
-  --sdn-corners-tight: 0.773rem;
+  --sdn-corners-tight: 0.765625rem;
   --sdn-corners-compact: 1rem;
   --sdn-corners-cozy: 1.2rem;
-  --sdn-corners-comfortable: 1.712rem;
-  --sdn-corners-open: 2.89rem;
+  --sdn-corners-comfortable: 1.71875rem;
+  --sdn-corners-open: 2.890625rem;
   /* Font Sizes */
-  --sdn-font-size-tiny: 0.638rem;
-  --sdn-font-size-xxsmall: 0.766rem;
-  --sdn-font-size-xsmall: 0.889rem;
-  --sdn-font-size-small: 1.008rem;
+  --sdn-font-size-tiny: 0.640625rem;
+  --sdn-font-size-xxsmall: 0.765625rem;
+  --sdn-font-size-xsmall: 0.890625rem;
+  --sdn-font-size-small: 1.015625rem;
   --sdn-font-size-medium: 1.125rem;
-  --sdn-font-size-large: 1.62rem;
-  --sdn-font-size-xlarge: 1.983rem;
-  --sdn-font-size-xxlarge: 2.759rem;
-  --sdn-font-size-huge: 3.49rem;
+  --sdn-font-size-large: 1.625rem;
+  --sdn-font-size-xlarge: 1.984375rem;
+  --sdn-font-size-xxlarge: 2.765625rem;
+  --sdn-font-size-huge: 3.484375rem;
   /* Font Weights */
   --sdn-font-weight-thin: 100;
   --sdn-font-weight-xlight: 200;
@@ -140,11 +140,11 @@
   --sdn-line-height-comfortable: 2;
   --sdn-line-height-open: 2.5;
   /* Border Widths */
-  --sdn-border-width-xsmall: 0.071rem;
-  --sdn-border-width-small: 0.135rem;
-  --sdn-border-width-medium: 0.219rem;
-  --sdn-border-width-large: 0.387rem;
-  --sdn-border-width-xlarge: 0.681rem;
+  --sdn-border-width-xsmall: 0.078125rem;
+  --sdn-border-width-small: 0.140625rem;
+  --sdn-border-width-medium: 0.21875rem;
+  --sdn-border-width-large: 0.390625rem;
+  --sdn-border-width-xlarge: 0.6875rem;
   /* High Contrast */
   --sdn-hc-on-white: hsl(327 12% 8%);
   --sdn-hc-on-gray: hsl(327 12% 98%);

--- a/packages/editor/apps/vue/seldon/seldon-editor.json
+++ b/packages/editor/apps/vue/seldon/seldon-editor.json
@@ -15304,7 +15304,7 @@
         },
         "align": {
           "type": "option",
-          "value": "bottom-left"
+          "value": "left"
         }
       }
     },

--- a/packages/editor/apps/vue/seldon/styles.css
+++ b/packages/editor/apps/vue/seldon/styles.css
@@ -426,7 +426,7 @@ body {
   padding-inline-end: var(--sdn-paddings-compact);
   padding-bottom: var(--sdn-paddings-compact);
   padding-inline-start: var(--sdn-paddings-cozy);
-  box-shadow: 0px 1px 0.25rem 0.062rem hsl(0 0% 0% / 10%);
+  box-shadow: 0px 1px 0.25rem 0.0625rem hsl(0 0% 0% / 10%);
   align-self: stretch;
   height: fit-content;
   flex-shrink: 0;
@@ -492,7 +492,7 @@ body {
   padding-inline-end: var(--sdn-paddings-compact);
   padding-bottom: var(--sdn-paddings-tight);
   padding-inline-start: var(--sdn-paddings-compact);
-  box-shadow: 0px 0px 0.062rem 0.062rem hsl(0 0% 0% / 8%);
+  box-shadow: 0px 0px 0.0625rem 0.0625rem hsl(0 0% 0% / 8%);
   width: fit-content;
   height: fit-content;
   flex-shrink: 0;
@@ -691,7 +691,7 @@ body {
   flex-wrap: nowrap;
   display: flex;
   flex-direction: column;
-  box-shadow: 0px 4px 0.5rem 0.188rem rgb(0 0 0 / 15%);
+  box-shadow: 0px 4px 0.5rem 0.1875rem rgb(0 0 0 / 15%);
   width: 450px;
   height: fit-content;
   flex-shrink: 0;
@@ -704,7 +704,7 @@ body {
   flex-wrap: nowrap;
   display: flex;
   flex-direction: column;
-  box-shadow: 0px 4px 0.5rem 0.188rem color-mix(in srgb, var(--sdn-swatch-black) 15%, transparent);
+  box-shadow: 0px 4px 0.5rem 0.1875rem color-mix(in srgb, var(--sdn-swatch-black) 15%, transparent);
   width: 450px;
   height: fit-content;
   flex-shrink: 0;
@@ -717,7 +717,7 @@ body {
   flex-wrap: nowrap;
   display: flex;
   flex-direction: column;
-  box-shadow: 0px 4px 0.5rem 0.188rem rgb(0 0 0 / 15%);
+  box-shadow: 0px 4px 0.5rem 0.1875rem rgb(0 0 0 / 15%);
   width: 500px;
   height: fit-content;
   flex-shrink: 0;
@@ -1022,7 +1022,7 @@ body {
   box-shadow:
     inset -0.5px -0.5px 0.5px 0px hsl(0 0% 15% / 20%),
     inset 0.5px 0.5px 0.5px 0px hsl(0 0% 96% / 30%),
-    0px 0px 0.125rem 0.031rem color-mix(in srgb, var(--sdn-swatch-primary) 30%, transparent);
+    0px 0px 0.125rem 0.03125rem color-mix(in srgb, var(--sdn-swatch-primary) 30%, transparent);
   align-self: stretch;
   height: fit-content;
   flex-shrink: 0;
@@ -1186,7 +1186,7 @@ body {
   align-items: start;
   justify-content: start;
   gap: var(--sdn-gaps-compact);
-  box-shadow: 0px 4px 0.5rem 0.188rem rgb(0 0 0 / 15%);
+  box-shadow: 0px 4px 0.5rem 0.1875rem rgb(0 0 0 / 15%);
   width: fit-content;
   height: fit-content;
   flex-shrink: 0;
@@ -1220,7 +1220,7 @@ body {
   flex-wrap: nowrap;
   display: flex;
   flex-direction: row;
-  align-items: end;
+  align-items: center;
   justify-content: start;
   gap: var(--sdn-gaps-compact);
   padding-top: var(--sdn-paddings-tight);
@@ -1242,7 +1242,7 @@ body {
   align-items: start;
   justify-content: start;
   gap: var(--sdn-gaps-compact);
-  box-shadow: 0px 4px 0.5rem 0.188rem rgb(0 0 0 / 15%);
+  box-shadow: 0px 4px 0.5rem 0.1875rem rgb(0 0 0 / 15%);
   align-self: stretch;
   height: fit-content;
   flex-shrink: 0;
@@ -1445,7 +1445,7 @@ body {
   flex-direction: column;
   gap: auto;
   justify-content: space-between;
-  box-shadow: 0px 4px 0.5rem 0.188rem rgb(0 0 0 / 15%);
+  box-shadow: 0px 4px 0.5rem 0.1875rem rgb(0 0 0 / 15%);
   width: 450px;
   height: 350px;
   flex-shrink: 0;
@@ -1461,7 +1461,7 @@ body {
   flex-direction: column;
   gap: auto;
   justify-content: space-between;
-  box-shadow: 0px 4px 0.5rem 0.188rem hsl(0 0% 0% / 15%);
+  box-shadow: 0px 4px 0.5rem 0.1875rem hsl(0 0% 0% / 15%);
   width: 450px;
   height: 350px;
   flex-shrink: 0;
@@ -1477,7 +1477,7 @@ body {
   flex-direction: column;
   gap: auto;
   justify-content: space-between;
-  box-shadow: 0px 4px 0.5rem 0.188rem hsl(0 0% 0% / 15%);
+  box-shadow: 0px 4px 0.5rem 0.1875rem hsl(0 0% 0% / 15%);
   width: 450px;
   height: 400px;
   flex-shrink: 0;
@@ -1493,7 +1493,7 @@ body {
   flex-direction: column;
   gap: auto;
   justify-content: space-between;
-  box-shadow: 0px 4px 0.5rem 0.188rem rgb(0 0 0 / 15%);
+  box-shadow: 0px 4px 0.5rem 0.1875rem rgb(0 0 0 / 15%);
   align-self: stretch;
   height: 500px;
   flex-shrink: 0;
@@ -1508,7 +1508,7 @@ body {
   display: flex;
   flex-direction: column;
   gap: 0;
-  box-shadow: 0px 4px 0.5rem 0.188rem rgb(0 0 0 / 15%);
+  box-shadow: 0px 4px 0.5rem 0.1875rem rgb(0 0 0 / 15%);
   width: 450px;
   height: 350px;
   flex-shrink: 0;
@@ -1874,9 +1874,9 @@ body {
   background-color: var(--sdn-swatch-gray);
   cursor: pointer;
   color: var(--sdn-hc-on-gray);
-  box-shadow: inset 0px 0px 0.125rem 0.031rem
+  box-shadow: inset 0px 0px 0.125rem 0.03125rem
     color-mix(in srgb, var(--sdn-swatch-black) 30%, transparent);
-  width: 1.501rem;
+  width: 1.5rem;
   height: fit-content;
   flex-shrink: 0;
   font-size: var(--sdn-font-size-xxsmall);
@@ -2127,7 +2127,7 @@ body {
 .sdn-button-menu--ipe0 {
   width: unset;
   flex-shrink: unset;
-  box-shadow: 0px 1px 0.062rem 0.062rem hsl(0 0% 0% / 10%);
+  box-shadow: 0px 1px 0.0625rem 0.0625rem hsl(0 0% 0% / 10%);
   flex: 1 0 0;
   min-width: 0;
 }
@@ -2143,7 +2143,7 @@ body {
 }
 
 .sdn-button-menu--truc {
-  box-shadow: 0px 1px 0.062rem 0.062rem hsl(0 0% 0% / 10%);
+  box-shadow: 0px 1px 0.0625rem 0.0625rem hsl(0 0% 0% / 10%);
 }
 
 .sdn-button-simple--dbgs {
@@ -2263,7 +2263,7 @@ body {
   align-self: unset;
   flex-shrink: unset;
   flex: 1 0 0;
-  height: 2.002rem;
+  height: 2rem;
   min-width: 0;
   border: var(--hairline) solid var(--sdn-swatch-primary);
 }
@@ -2272,7 +2272,7 @@ body {
   background-color: var(--sdn-swatch-offWhite);
   padding-top: 0;
   padding-bottom: 0;
-  box-shadow: inset 0px 0px 0.125rem 0.031rem
+  box-shadow: inset 0px 0px 0.125rem 0.03125rem
     color-mix(in srgb, var(--sdn-swatch-black) 12%, transparent);
   margin: var(--sdn-margins-tight);
   border: var(--hairline) solid color-mix(in srgb, var(--sdn-swatch-primary) 50%, transparent);
@@ -2294,7 +2294,7 @@ body {
   align-self: unset;
   flex-shrink: unset;
   background-color: var(--sdn-swatch-offWhite);
-  box-shadow: inset 0px 0px 0.062rem 0.062rem
+  box-shadow: inset 0px 0px 0.0625rem 0.0625rem
     color-mix(in srgb, var(--sdn-swatch-black) 10%, transparent);
   flex: 1 0 0;
   min-width: 0;
@@ -2501,7 +2501,8 @@ body {
   padding-bottom: var(--sdn-paddings-tight);
   padding-inline-start: var(--sdn-paddings-comfortable);
   box-shadow:
-    inset 0px 0px 0.125rem 0.031rem color-mix(in srgb, var(--sdn-swatch-offWhite) 30%, transparent),
+    inset 0px 0px 0.125rem 0.03125rem
+      color-mix(in srgb, var(--sdn-swatch-offWhite) 30%, transparent),
     0px 0px 0.25rem 0.125rem color-mix(in srgb, var(--sdn-swatch-offBlack) 20%, transparent);
   width: fit-content;
   flex-shrink: 0;
@@ -2655,7 +2656,8 @@ body {
   align-items: start;
   justify-content: start;
   gap: var(--sdn-gaps-compact);
-  box-shadow: 0px 1px 0.125rem 0.031rem color-mix(in srgb, var(--sdn-swatch-black) 20%, transparent);
+  box-shadow: 0px 1px 0.125rem 0.03125rem
+    color-mix(in srgb, var(--sdn-swatch-black) 20%, transparent);
   padding: var(--sdn-paddings-compact);
   border-radius: var(--sdn-corners-tight);
   border: var(--hairline) solid var(--sdn-swatch-offBlack-b50);
@@ -2990,7 +2992,7 @@ body {
 }
 
 .sdn-icon--km45 {
-  width: 1.501rem;
+  width: 1.5rem;
   color: var(--sdn-hc-on-white);
 }
 
@@ -2999,7 +3001,7 @@ body {
 }
 
 .sdn-icon--mene {
-  width: 1.501rem;
+  width: 1.5rem;
 }
 
 .sdn-icon--pbp5 {
@@ -3072,9 +3074,9 @@ body {
 .sdn-image--98gd {
   align-self: unset;
   flex: unset;
-  width: 2.998rem;
+  width: 3rem;
   flex-shrink: 0;
-  height: 2.998rem;
+  height: 3rem;
   border-radius: 99999px;
   border: var(--sdn-border-width-medium) solid var(--sdn-swatch-offBlack);
 }
@@ -3082,9 +3084,9 @@ body {
 .sdn-image--9jgp {
   align-self: unset;
   flex: unset;
-  width: 2.998rem;
+  width: 3rem;
   flex-shrink: 0;
-  height: 2.998rem;
+  height: 3rem;
   border-radius: var(--sdn-corners-tight);
   border: var(--sdn-border-width-medium) solid var(--sdn-swatch-primary);
 }
@@ -3112,9 +3114,9 @@ body {
   align-self: unset;
   flex: unset;
   box-shadow: 0px 0px 0px 0.125rem var(--sdn-swatch-white);
-  width: 2.998rem;
+  width: 3rem;
   flex-shrink: 0;
-  height: 2.998rem;
+  height: 3rem;
   right: -5rem;
   position: absolute;
   border-radius: 99999px;
@@ -3124,9 +3126,9 @@ body {
 .sdn-image--to5v {
   align-self: unset;
   flex: unset;
-  width: 2.998rem;
+  width: 3rem;
   flex-shrink: 0;
-  height: 2.998rem;
+  height: 3rem;
   border-radius: 99999px;
 }
 
@@ -3134,9 +3136,9 @@ body {
   align-self: unset;
   flex: unset;
   box-shadow: 0px 0px 0px 0.125rem var(--sdn-swatch-white);
-  width: 2.998rem;
+  width: 3rem;
   flex-shrink: 0;
-  height: 2.998rem;
+  height: 3rem;
   right: -2.5rem;
   position: absolute;
   border-radius: 99999px;
@@ -3146,9 +3148,9 @@ body {
 .sdn-image--zjyq {
   align-self: unset;
   flex: unset;
-  width: 2.998rem;
+  width: 3rem;
   flex-shrink: 0;
-  height: 2.998rem;
+  height: 3rem;
   border-radius: 99999px;
   border: var(--sdn-border-width-medium) solid var(--sdn-swatch-primary);
 }
@@ -3186,7 +3188,7 @@ body {
   padding-bottom: var(--sdn-paddings-tight);
   padding-inline-start: var(--sdn-paddings-compact);
   flex: 1 0 0;
-  height: 2.002rem;
+  height: 2rem;
   min-width: 0;
   border: var(--hairline) solid var(--sdn-swatch-primary);
 }

--- a/packages/editor/apps/vue/seldon/styles/adobe-spectrum.css
+++ b/packages/editor/apps/vue/seldon/styles/adobe-spectrum.css
@@ -65,49 +65,49 @@
   --sdn-swatch-accent-bn30: hsl(239 65% 42%);
   --sdn-swatch-gray-b50: hsl(210 4% 78%);
   /* Sizes */
-  --sdn-sizes-tiny: 0.183rem;
-  --sdn-sizes-xxsmall: 0.322rem;
-  --sdn-sizes-xsmall: 0.567rem;
-  --sdn-sizes-small: 0.79rem;
+  --sdn-sizes-tiny: 0.1875rem;
+  --sdn-sizes-xxsmall: 0.328125rem;
+  --sdn-sizes-xsmall: 0.5625rem;
+  --sdn-sizes-small: 0.796875rem;
   --sdn-sizes-medium: 1rem;
-  --sdn-sizes-large: 1.394rem;
-  --sdn-sizes-xlarge: 1.763rem;
-  --sdn-sizes-xxlarge: 2.452rem;
-  --sdn-sizes-huge: 3.103rem;
+  --sdn-sizes-large: 1.390625rem;
+  --sdn-sizes-xlarge: 1.765625rem;
+  --sdn-sizes-xxlarge: 2.453125rem;
+  --sdn-sizes-huge: 3.109375rem;
   /* Margins */
-  --sdn-margins-tight: 0.322rem;
-  --sdn-margins-compact: 0.567rem;
+  --sdn-margins-tight: 0.328125rem;
+  --sdn-margins-compact: 0.5625rem;
   --sdn-margins-cozy: 1rem;
-  --sdn-margins-comfortable: 1.763rem;
-  --sdn-margins-open: 3.103rem;
+  --sdn-margins-comfortable: 1.765625rem;
+  --sdn-margins-open: 3.109375rem;
   /* Paddings */
-  --sdn-paddings-tight: 0.322rem;
-  --sdn-paddings-compact: 0.567rem;
+  --sdn-paddings-tight: 0.328125rem;
+  --sdn-paddings-compact: 0.5625rem;
   --sdn-paddings-cozy: 1rem;
-  --sdn-paddings-comfortable: 1.763rem;
-  --sdn-paddings-open: 3.103rem;
+  --sdn-paddings-comfortable: 1.765625rem;
+  --sdn-paddings-open: 3.109375rem;
   /* Gaps */
-  --sdn-gaps-tight: 0.322rem;
-  --sdn-gaps-compact: 0.567rem;
+  --sdn-gaps-tight: 0.328125rem;
+  --sdn-gaps-compact: 0.5625rem;
   --sdn-gaps-cozy: 1rem;
-  --sdn-gaps-comfortable: 1.763rem;
-  --sdn-gaps-open: 3.103rem;
+  --sdn-gaps-comfortable: 1.765625rem;
+  --sdn-gaps-open: 3.109375rem;
   /* Corners */
-  --sdn-corners-tight: 0.322rem;
-  --sdn-corners-compact: 0.567rem;
-  --sdn-corners-cozy: 1.394rem;
-  --sdn-corners-comfortable: 1.763rem;
-  --sdn-corners-open: 2.452rem;
+  --sdn-corners-tight: 0.328125rem;
+  --sdn-corners-compact: 0.5625rem;
+  --sdn-corners-cozy: 1.390625rem;
+  --sdn-corners-comfortable: 1.765625rem;
+  --sdn-corners-open: 2.453125rem;
   /* Font Sizes */
-  --sdn-font-size-tiny: 0.567rem;
-  --sdn-font-size-xxsmall: 0.681rem;
-  --sdn-font-size-xsmall: 0.79rem;
-  --sdn-font-size-small: 0.896rem;
+  --sdn-font-size-tiny: 0.5625rem;
+  --sdn-font-size-xxsmall: 0.6875rem;
+  --sdn-font-size-xsmall: 0.796875rem;
+  --sdn-font-size-small: 0.890625rem;
   --sdn-font-size-medium: 1rem;
-  --sdn-font-size-large: 1.394rem;
-  --sdn-font-size-xlarge: 1.763rem;
-  --sdn-font-size-xxlarge: 2.452rem;
-  --sdn-font-size-huge: 3.103rem;
+  --sdn-font-size-large: 1.390625rem;
+  --sdn-font-size-xlarge: 1.765625rem;
+  --sdn-font-size-xxlarge: 2.453125rem;
+  --sdn-font-size-huge: 3.109375rem;
   /* Font Weights */
   --sdn-font-weight-thin: 100;
   --sdn-font-weight-xlight: 200;
@@ -127,11 +127,11 @@
   --sdn-line-height-comfortable: 2;
   --sdn-line-height-open: 2.5;
   /* Border Widths */
-  --sdn-border-width-xsmall: 0.059rem;
-  --sdn-border-width-small: 0.112rem;
-  --sdn-border-width-medium: 0.183rem;
-  --sdn-border-width-large: 0.322rem;
-  --sdn-border-width-xlarge: 0.567rem;
+  --sdn-border-width-xsmall: 0.0625rem;
+  --sdn-border-width-small: 0.109375rem;
+  --sdn-border-width-medium: 0.1875rem;
+  --sdn-border-width-large: 0.328125rem;
+  --sdn-border-width-xlarge: 0.5625rem;
   /* High Contrast */
   --sdn-hc-on-white: hsl(210 4% 12%);
   --sdn-hc-on-gray: hsl(210 4% 98%);

--- a/packages/editor/apps/vue/seldon/styles/earth.css
+++ b/packages/editor/apps/vue/seldon/styles/earth.css
@@ -68,49 +68,49 @@
   --sdn-swatch-accent-bn30: hsl(158 32% 25.9%);
   --sdn-swatch-gray-b50: hsl(16 12% 78%);
   /* Sizes */
-  --sdn-sizes-tiny: 0.069rem;
-  --sdn-sizes-xxsmall: 0.168rem;
-  --sdn-sizes-xsmall: 0.409rem;
-  --sdn-sizes-small: 0.69rem;
+  --sdn-sizes-tiny: 0.0625rem;
+  --sdn-sizes-xxsmall: 0.171875rem;
+  --sdn-sizes-xsmall: 0.40625rem;
+  --sdn-sizes-small: 0.6875rem;
   --sdn-sizes-medium: 1rem;
-  --sdn-sizes-large: 1.687rem;
-  --sdn-sizes-xlarge: 2.445rem;
-  --sdn-sizes-xxlarge: 4.113rem;
-  --sdn-sizes-huge: 5.959rem;
+  --sdn-sizes-large: 1.6875rem;
+  --sdn-sizes-xlarge: 2.4375rem;
+  --sdn-sizes-xxlarge: 4.109375rem;
+  --sdn-sizes-huge: 5.953125rem;
   /* Margins */
-  --sdn-margins-tight: 0.168rem;
-  --sdn-margins-compact: 0.409rem;
+  --sdn-margins-tight: 0.171875rem;
+  --sdn-margins-compact: 0.40625rem;
   --sdn-margins-cozy: 1rem;
-  --sdn-margins-comfortable: 2.445rem;
-  --sdn-margins-open: 14.569rem;
+  --sdn-margins-comfortable: 2.4375rem;
+  --sdn-margins-open: 14.5625rem;
   /* Paddings */
-  --sdn-paddings-tight: 0.168rem;
-  --sdn-paddings-compact: 0.409rem;
+  --sdn-paddings-tight: 0.171875rem;
+  --sdn-paddings-compact: 0.40625rem;
   --sdn-paddings-cozy: 1rem;
-  --sdn-paddings-comfortable: 2.445rem;
-  --sdn-paddings-open: 14.569rem;
+  --sdn-paddings-comfortable: 2.4375rem;
+  --sdn-paddings-open: 14.5625rem;
   /* Gaps */
-  --sdn-gaps-tight: 0.168rem;
-  --sdn-gaps-compact: 0.409rem;
+  --sdn-gaps-tight: 0.171875rem;
+  --sdn-gaps-compact: 0.40625rem;
   --sdn-gaps-cozy: 1rem;
-  --sdn-gaps-comfortable: 2.445rem;
-  --sdn-gaps-open: 14.569rem;
+  --sdn-gaps-comfortable: 2.4375rem;
+  --sdn-gaps-open: 14.5625rem;
   /* Corners */
-  --sdn-corners-tight: 0.168rem;
-  --sdn-corners-compact: 0.409rem;
-  --sdn-corners-cozy: 1.295rem;
-  --sdn-corners-comfortable: 2.445rem;
-  --sdn-corners-open: 4.113rem;
+  --sdn-corners-tight: 0.171875rem;
+  --sdn-corners-compact: 0.40625rem;
+  --sdn-corners-cozy: 1.296875rem;
+  --sdn-corners-comfortable: 2.4375rem;
+  --sdn-corners-open: 4.109375rem;
   /* Font Sizes */
-  --sdn-font-size-tiny: 0.409rem;
-  --sdn-font-size-xxsmall: 0.545rem;
-  --sdn-font-size-xsmall: 0.69rem;
-  --sdn-font-size-small: 0.842rem;
+  --sdn-font-size-tiny: 0.40625rem;
+  --sdn-font-size-xxsmall: 0.546875rem;
+  --sdn-font-size-xsmall: 0.6875rem;
+  --sdn-font-size-small: 0.84375rem;
   --sdn-font-size-medium: 1rem;
-  --sdn-font-size-large: 1.687rem;
-  --sdn-font-size-xlarge: 2.445rem;
-  --sdn-font-size-xxlarge: 4.113rem;
-  --sdn-font-size-huge: 5.959rem;
+  --sdn-font-size-large: 1.6875rem;
+  --sdn-font-size-xlarge: 2.4375rem;
+  --sdn-font-size-xxlarge: 4.109375rem;
+  --sdn-font-size-huge: 5.953125rem;
   /* Font Weights */
   --sdn-font-weight-thin: 100;
   --sdn-font-weight-xlight: 200;
@@ -130,11 +130,11 @@
   --sdn-line-height-comfortable: 2;
   --sdn-line-height-open: 2.5;
   /* Border Widths */
-  --sdn-border-width-xsmall: 0.012rem;
-  --sdn-border-width-small: 0.032rem;
-  --sdn-border-width-medium: 0.069rem;
-  --sdn-border-width-large: 0.168rem;
-  --sdn-border-width-xlarge: 0.409rem;
+  --sdn-border-width-xsmall: 0.015625rem;
+  --sdn-border-width-small: 0.03125rem;
+  --sdn-border-width-medium: 0.0625rem;
+  --sdn-border-width-large: 0.171875rem;
+  --sdn-border-width-xlarge: 0.40625rem;
   /* High Contrast */
   --sdn-hc-on-white: hsl(16 12% 8%);
   --sdn-hc-on-gray: hsl(16 12% 98%);

--- a/packages/editor/apps/vue/seldon/styles/google-material.css
+++ b/packages/editor/apps/vue/seldon/styles/google-material.css
@@ -72,43 +72,43 @@
   --sdn-sizes-xsmall: 0.5rem;
   --sdn-sizes-small: 0.75rem;
   --sdn-sizes-medium: 1rem;
-  --sdn-sizes-large: 1.501rem;
-  --sdn-sizes-xlarge: 2.002rem;
-  --sdn-sizes-xxlarge: 2.998rem;
-  --sdn-sizes-huge: 3.998rem;
+  --sdn-sizes-large: 1.5rem;
+  --sdn-sizes-xlarge: 2rem;
+  --sdn-sizes-xxlarge: 3rem;
+  --sdn-sizes-huge: 4rem;
   /* Margins */
   --sdn-margins-tight: 0.25rem;
   --sdn-margins-compact: 0.5rem;
   --sdn-margins-cozy: 1rem;
-  --sdn-margins-comfortable: 2.002rem;
-  --sdn-margins-open: 3.998rem;
+  --sdn-margins-comfortable: 2rem;
+  --sdn-margins-open: 4rem;
   /* Paddings */
   --sdn-paddings-tight: 0.25rem;
   --sdn-paddings-compact: 0.5rem;
   --sdn-paddings-cozy: 1rem;
-  --sdn-paddings-comfortable: 2.002rem;
-  --sdn-paddings-open: 3.998rem;
+  --sdn-paddings-comfortable: 2rem;
+  --sdn-paddings-open: 4rem;
   /* Gaps */
   --sdn-gaps-tight: 0.25rem;
   --sdn-gaps-compact: 0.5rem;
   --sdn-gaps-cozy: 1rem;
-  --sdn-gaps-comfortable: 2.002rem;
-  --sdn-gaps-open: 3.998rem;
+  --sdn-gaps-comfortable: 2rem;
+  --sdn-gaps-open: 4rem;
   /* Corners */
   --sdn-corners-tight: 0.25rem;
   --sdn-corners-compact: 0.5rem;
   --sdn-corners-cozy: 1rem;
-  --sdn-corners-comfortable: 1.501rem;
-  --sdn-corners-open: 2.002rem;
+  --sdn-corners-comfortable: 1.5rem;
+  --sdn-corners-open: 2rem;
   /* Font Sizes */
   --sdn-font-size-tiny: 0.5rem;
-  --sdn-font-size-xxsmall: 0.624rem;
+  --sdn-font-size-xxsmall: 0.625rem;
   --sdn-font-size-xsmall: 0.75rem;
   --sdn-font-size-small: 0.875rem;
   --sdn-font-size-medium: 1rem;
-  --sdn-font-size-large: 1.376rem;
-  --sdn-font-size-xlarge: 2.002rem;
-  --sdn-font-size-xxlarge: 3.56rem;
+  --sdn-font-size-large: 1.375rem;
+  --sdn-font-size-xlarge: 2rem;
+  --sdn-font-size-xxlarge: 3.5625rem;
   --sdn-font-size-huge: 4.5rem;
   /* Font Weights */
   --sdn-font-weight-thin: 100;
@@ -129,8 +129,8 @@
   --sdn-line-height-comfortable: 2;
   --sdn-line-height-open: 2.5;
   /* Border Widths */
-  --sdn-border-width-xsmall: 0.031rem;
-  --sdn-border-width-small: 0.069rem;
+  --sdn-border-width-xsmall: 0.03125rem;
+  --sdn-border-width-small: 0.0625rem;
   --sdn-border-width-medium: 0.125rem;
   --sdn-border-width-large: 0.25rem;
   --sdn-border-width-xlarge: 0.5rem;

--- a/packages/editor/apps/vue/seldon/styles/high-contrast.css
+++ b/packages/editor/apps/vue/seldon/styles/high-contrast.css
@@ -70,44 +70,44 @@
   --sdn-sizes-xsmall: 0.5rem;
   --sdn-sizes-small: 0.75rem;
   --sdn-sizes-medium: 1rem;
-  --sdn-sizes-large: 1.501rem;
-  --sdn-sizes-xlarge: 2.002rem;
-  --sdn-sizes-xxlarge: 2.998rem;
-  --sdn-sizes-huge: 3.998rem;
+  --sdn-sizes-large: 1.5rem;
+  --sdn-sizes-xlarge: 2rem;
+  --sdn-sizes-xxlarge: 3rem;
+  --sdn-sizes-huge: 4rem;
   /* Margins */
   --sdn-margins-tight: 0.25rem;
   --sdn-margins-compact: 0.5rem;
   --sdn-margins-cozy: 1rem;
-  --sdn-margins-comfortable: 2.002rem;
-  --sdn-margins-open: 3.998rem;
+  --sdn-margins-comfortable: 2rem;
+  --sdn-margins-open: 4rem;
   /* Paddings */
   --sdn-paddings-tight: 0.25rem;
   --sdn-paddings-compact: 0.5rem;
   --sdn-paddings-cozy: 1rem;
-  --sdn-paddings-comfortable: 2.002rem;
-  --sdn-paddings-open: 3.998rem;
+  --sdn-paddings-comfortable: 2rem;
+  --sdn-paddings-open: 4rem;
   /* Gaps */
   --sdn-gaps-tight: 0.25rem;
   --sdn-gaps-compact: 0.5rem;
   --sdn-gaps-cozy: 1rem;
-  --sdn-gaps-comfortable: 2.002rem;
-  --sdn-gaps-open: 3.998rem;
+  --sdn-gaps-comfortable: 2rem;
+  --sdn-gaps-open: 4rem;
   /* Corners */
   --sdn-corners-tight: 0.25rem;
   --sdn-corners-compact: 0.5rem;
   --sdn-corners-cozy: 1rem;
-  --sdn-corners-comfortable: 1.501rem;
-  --sdn-corners-open: 2.002rem;
+  --sdn-corners-comfortable: 1.5rem;
+  --sdn-corners-open: 2rem;
   /* Font Sizes */
   --sdn-font-size-tiny: 0.5rem;
-  --sdn-font-size-xxsmall: 0.624rem;
+  --sdn-font-size-xxsmall: 0.625rem;
   --sdn-font-size-xsmall: 0.75rem;
   --sdn-font-size-small: 0.875rem;
   --sdn-font-size-medium: 1rem;
-  --sdn-font-size-large: 1.501rem;
-  --sdn-font-size-xlarge: 2.002rem;
-  --sdn-font-size-xxlarge: 2.998rem;
-  --sdn-font-size-huge: 3.998rem;
+  --sdn-font-size-large: 1.5rem;
+  --sdn-font-size-xlarge: 2rem;
+  --sdn-font-size-xxlarge: 3rem;
+  --sdn-font-size-huge: 4rem;
   /* Font Weights */
   --sdn-font-weight-thin: 100;
   --sdn-font-weight-xlight: 200;
@@ -127,8 +127,8 @@
   --sdn-line-height-comfortable: 2;
   --sdn-line-height-open: 2.5;
   /* Border Widths */
-  --sdn-border-width-xsmall: 0.031rem;
-  --sdn-border-width-small: 0.069rem;
+  --sdn-border-width-xsmall: 0.03125rem;
+  --sdn-border-width-small: 0.0625rem;
   --sdn-border-width-medium: 0.125rem;
   --sdn-border-width-large: 0.25rem;
   --sdn-border-width-xlarge: 0.5rem;

--- a/packages/editor/apps/vue/seldon/styles/ibm-carbon.css
+++ b/packages/editor/apps/vue/seldon/styles/ibm-carbon.css
@@ -65,49 +65,49 @@
   --sdn-swatch-accent-bn30: hsl(262 88% 41.3%);
   --sdn-swatch-gray-b50: hsl(218 12% 78%);
   /* Sizes */
-  --sdn-sizes-tiny: 0.183rem;
-  --sdn-sizes-xxsmall: 0.322rem;
-  --sdn-sizes-xsmall: 0.567rem;
-  --sdn-sizes-small: 0.79rem;
+  --sdn-sizes-tiny: 0.1875rem;
+  --sdn-sizes-xxsmall: 0.328125rem;
+  --sdn-sizes-xsmall: 0.5625rem;
+  --sdn-sizes-small: 0.796875rem;
   --sdn-sizes-medium: 1rem;
-  --sdn-sizes-large: 1.394rem;
-  --sdn-sizes-xlarge: 1.763rem;
-  --sdn-sizes-xxlarge: 2.452rem;
-  --sdn-sizes-huge: 3.103rem;
+  --sdn-sizes-large: 1.390625rem;
+  --sdn-sizes-xlarge: 1.765625rem;
+  --sdn-sizes-xxlarge: 2.453125rem;
+  --sdn-sizes-huge: 3.109375rem;
   /* Margins */
-  --sdn-margins-tight: 0.322rem;
-  --sdn-margins-compact: 0.567rem;
+  --sdn-margins-tight: 0.328125rem;
+  --sdn-margins-compact: 0.5625rem;
   --sdn-margins-cozy: 1rem;
-  --sdn-margins-comfortable: 1.763rem;
-  --sdn-margins-open: 3.103rem;
+  --sdn-margins-comfortable: 1.765625rem;
+  --sdn-margins-open: 3.109375rem;
   /* Paddings */
-  --sdn-paddings-tight: 0.322rem;
-  --sdn-paddings-compact: 0.567rem;
+  --sdn-paddings-tight: 0.328125rem;
+  --sdn-paddings-compact: 0.5625rem;
   --sdn-paddings-cozy: 1rem;
-  --sdn-paddings-comfortable: 1.763rem;
-  --sdn-paddings-open: 3.103rem;
+  --sdn-paddings-comfortable: 1.765625rem;
+  --sdn-paddings-open: 3.109375rem;
   /* Gaps */
-  --sdn-gaps-tight: 0.322rem;
-  --sdn-gaps-compact: 0.567rem;
+  --sdn-gaps-tight: 0.328125rem;
+  --sdn-gaps-compact: 0.5625rem;
   --sdn-gaps-cozy: 1rem;
-  --sdn-gaps-comfortable: 1.763rem;
-  --sdn-gaps-open: 3.103rem;
+  --sdn-gaps-comfortable: 1.765625rem;
+  --sdn-gaps-open: 3.109375rem;
   /* Corners */
-  --sdn-corners-tight: 0.104rem;
-  --sdn-corners-compact: 0.183rem;
-  --sdn-corners-cozy: 0.322rem;
-  --sdn-corners-comfortable: 0.567rem;
+  --sdn-corners-tight: 0.109375rem;
+  --sdn-corners-compact: 0.1875rem;
+  --sdn-corners-cozy: 0.328125rem;
+  --sdn-corners-comfortable: 0.5625rem;
   --sdn-corners-open: 1rem;
   /* Font Sizes */
-  --sdn-font-size-tiny: 0.567rem;
-  --sdn-font-size-xxsmall: 0.681rem;
-  --sdn-font-size-xsmall: 0.79rem;
-  --sdn-font-size-small: 0.896rem;
+  --sdn-font-size-tiny: 0.5625rem;
+  --sdn-font-size-xxsmall: 0.6875rem;
+  --sdn-font-size-xsmall: 0.796875rem;
+  --sdn-font-size-small: 0.890625rem;
   --sdn-font-size-medium: 1rem;
-  --sdn-font-size-large: 1.44rem;
-  --sdn-font-size-xlarge: 1.763rem;
-  --sdn-font-size-xxlarge: 2.452rem;
-  --sdn-font-size-huge: 3.103rem;
+  --sdn-font-size-large: 1.4375rem;
+  --sdn-font-size-xlarge: 1.765625rem;
+  --sdn-font-size-xxlarge: 2.453125rem;
+  --sdn-font-size-huge: 3.109375rem;
   /* Font Weights */
   --sdn-font-weight-thin: 100;
   --sdn-font-weight-xlight: 200;
@@ -127,11 +127,11 @@
   --sdn-line-height-comfortable: 2;
   --sdn-line-height-open: 2.5;
   /* Border Widths */
-  --sdn-border-width-xsmall: 0.059rem;
-  --sdn-border-width-small: 0.112rem;
-  --sdn-border-width-medium: 0.183rem;
-  --sdn-border-width-large: 0.322rem;
-  --sdn-border-width-xlarge: 0.567rem;
+  --sdn-border-width-xsmall: 0.0625rem;
+  --sdn-border-width-small: 0.109375rem;
+  --sdn-border-width-medium: 0.1875rem;
+  --sdn-border-width-large: 0.328125rem;
+  --sdn-border-width-xlarge: 0.5625rem;
   /* High Contrast */
   --sdn-hc-on-white: hsl(218 12% 8%);
   --sdn-hc-on-gray: hsl(218 12% 98%);

--- a/packages/editor/apps/vue/seldon/styles/industrial.css
+++ b/packages/editor/apps/vue/seldon/styles/industrial.css
@@ -70,44 +70,44 @@
   --sdn-sizes-xsmall: 0.5rem;
   --sdn-sizes-small: 0.75rem;
   --sdn-sizes-medium: 1rem;
-  --sdn-sizes-large: 1.501rem;
-  --sdn-sizes-xlarge: 2.002rem;
-  --sdn-sizes-xxlarge: 2.998rem;
-  --sdn-sizes-huge: 3.998rem;
+  --sdn-sizes-large: 1.5rem;
+  --sdn-sizes-xlarge: 2rem;
+  --sdn-sizes-xxlarge: 3rem;
+  --sdn-sizes-huge: 4rem;
   /* Margins */
   --sdn-margins-tight: 0.25rem;
   --sdn-margins-compact: 0.5rem;
   --sdn-margins-cozy: 1rem;
-  --sdn-margins-comfortable: 2.002rem;
-  --sdn-margins-open: 3.998rem;
+  --sdn-margins-comfortable: 2rem;
+  --sdn-margins-open: 4rem;
   /* Paddings */
   --sdn-paddings-tight: 0.25rem;
   --sdn-paddings-compact: 0.5rem;
   --sdn-paddings-cozy: 1rem;
-  --sdn-paddings-comfortable: 2.002rem;
-  --sdn-paddings-open: 3.998rem;
+  --sdn-paddings-comfortable: 2rem;
+  --sdn-paddings-open: 4rem;
   /* Gaps */
   --sdn-gaps-tight: 0.25rem;
   --sdn-gaps-compact: 0.5rem;
   --sdn-gaps-cozy: 1rem;
-  --sdn-gaps-comfortable: 2.002rem;
-  --sdn-gaps-open: 3.998rem;
+  --sdn-gaps-comfortable: 2rem;
+  --sdn-gaps-open: 4rem;
   /* Corners */
-  --sdn-corners-tight: 0.031rem;
-  --sdn-corners-compact: 0.062rem;
+  --sdn-corners-tight: 0.03125rem;
+  --sdn-corners-compact: 0.0625rem;
   --sdn-corners-cozy: 0.125rem;
   --sdn-corners-comfortable: 0.25rem;
   --sdn-corners-open: 0.5rem;
   /* Font Sizes */
   --sdn-font-size-tiny: 0.5rem;
-  --sdn-font-size-xxsmall: 0.624rem;
+  --sdn-font-size-xxsmall: 0.625rem;
   --sdn-font-size-xsmall: 0.75rem;
   --sdn-font-size-small: 0.875rem;
   --sdn-font-size-medium: 1rem;
-  --sdn-font-size-large: 1.501rem;
-  --sdn-font-size-xlarge: 2.002rem;
-  --sdn-font-size-xxlarge: 2.998rem;
-  --sdn-font-size-huge: 3.998rem;
+  --sdn-font-size-large: 1.5rem;
+  --sdn-font-size-xlarge: 2rem;
+  --sdn-font-size-xxlarge: 3rem;
+  --sdn-font-size-huge: 4rem;
   /* Font Weights */
   --sdn-font-weight-thin: 100;
   --sdn-font-weight-xlight: 200;
@@ -127,8 +127,8 @@
   --sdn-line-height-comfortable: 2;
   --sdn-line-height-open: 2.5;
   /* Border Widths */
-  --sdn-border-width-xsmall: 0.031rem;
-  --sdn-border-width-small: 0.069rem;
+  --sdn-border-width-xsmall: 0.03125rem;
+  --sdn-border-width-small: 0.0625rem;
   --sdn-border-width-medium: 0.125rem;
   --sdn-border-width-large: 0.25rem;
   --sdn-border-width-xlarge: 0.5rem;

--- a/packages/editor/apps/vue/seldon/styles/pop-punk.css
+++ b/packages/editor/apps/vue/seldon/styles/pop-punk.css
@@ -65,49 +65,49 @@
   --sdn-swatch-accent-bn30: hsl(208 97% 32.2%);
   --sdn-swatch-gray-b50: hsl(344 12% 78%);
   /* Sizes */
-  --sdn-sizes-tiny: 0.069rem;
-  --sdn-sizes-xxsmall: 0.168rem;
-  --sdn-sizes-xsmall: 0.409rem;
-  --sdn-sizes-small: 0.69rem;
+  --sdn-sizes-tiny: 0.0625rem;
+  --sdn-sizes-xxsmall: 0.171875rem;
+  --sdn-sizes-xsmall: 0.40625rem;
+  --sdn-sizes-small: 0.6875rem;
   --sdn-sizes-medium: 1rem;
-  --sdn-sizes-large: 1.687rem;
-  --sdn-sizes-xlarge: 2.445rem;
-  --sdn-sizes-xxlarge: 4.113rem;
-  --sdn-sizes-huge: 5.959rem;
+  --sdn-sizes-large: 1.6875rem;
+  --sdn-sizes-xlarge: 2.4375rem;
+  --sdn-sizes-xxlarge: 4.109375rem;
+  --sdn-sizes-huge: 5.953125rem;
   /* Margins */
-  --sdn-margins-tight: 0.168rem;
-  --sdn-margins-compact: 0.409rem;
+  --sdn-margins-tight: 0.171875rem;
+  --sdn-margins-compact: 0.40625rem;
   --sdn-margins-cozy: 1rem;
-  --sdn-margins-comfortable: 2.445rem;
-  --sdn-margins-open: 14.569rem;
+  --sdn-margins-comfortable: 2.4375rem;
+  --sdn-margins-open: 14.5625rem;
   /* Paddings */
-  --sdn-paddings-tight: 0.168rem;
-  --sdn-paddings-compact: 0.409rem;
+  --sdn-paddings-tight: 0.171875rem;
+  --sdn-paddings-compact: 0.40625rem;
   --sdn-paddings-cozy: 1rem;
-  --sdn-paddings-comfortable: 2.445rem;
-  --sdn-paddings-open: 14.569rem;
+  --sdn-paddings-comfortable: 2.4375rem;
+  --sdn-paddings-open: 14.5625rem;
   /* Gaps */
-  --sdn-gaps-tight: 0.168rem;
-  --sdn-gaps-compact: 0.409rem;
+  --sdn-gaps-tight: 0.171875rem;
+  --sdn-gaps-compact: 0.40625rem;
   --sdn-gaps-cozy: 1rem;
-  --sdn-gaps-comfortable: 2.445rem;
-  --sdn-gaps-open: 14.569rem;
+  --sdn-gaps-comfortable: 2.4375rem;
+  --sdn-gaps-open: 14.5625rem;
   /* Corners */
-  --sdn-corners-tight: 0.168rem;
-  --sdn-corners-compact: 0.409rem;
-  --sdn-corners-cozy: 1.687rem;
-  --sdn-corners-comfortable: 2.445rem;
-  --sdn-corners-open: 4.113rem;
+  --sdn-corners-tight: 0.171875rem;
+  --sdn-corners-compact: 0.40625rem;
+  --sdn-corners-cozy: 1.6875rem;
+  --sdn-corners-comfortable: 2.4375rem;
+  --sdn-corners-open: 4.109375rem;
   /* Font Sizes */
-  --sdn-font-size-tiny: 0.409rem;
-  --sdn-font-size-xxsmall: 0.545rem;
-  --sdn-font-size-xsmall: 0.69rem;
-  --sdn-font-size-small: 0.842rem;
+  --sdn-font-size-tiny: 0.40625rem;
+  --sdn-font-size-xxsmall: 0.546875rem;
+  --sdn-font-size-xsmall: 0.6875rem;
+  --sdn-font-size-small: 0.84375rem;
   --sdn-font-size-medium: 1rem;
-  --sdn-font-size-large: 1.687rem;
-  --sdn-font-size-xlarge: 2.445rem;
-  --sdn-font-size-xxlarge: 4.113rem;
-  --sdn-font-size-huge: 5.959rem;
+  --sdn-font-size-large: 1.6875rem;
+  --sdn-font-size-xlarge: 2.4375rem;
+  --sdn-font-size-xxlarge: 4.109375rem;
+  --sdn-font-size-huge: 5.953125rem;
   /* Font Weights */
   --sdn-font-weight-thin: 100;
   --sdn-font-weight-xlight: 200;
@@ -127,11 +127,11 @@
   --sdn-line-height-comfortable: 2;
   --sdn-line-height-open: 2.5;
   /* Border Widths */
-  --sdn-border-width-xsmall: 0.012rem;
-  --sdn-border-width-small: 0.032rem;
-  --sdn-border-width-medium: 0.069rem;
-  --sdn-border-width-large: 0.168rem;
-  --sdn-border-width-xlarge: 0.409rem;
+  --sdn-border-width-xsmall: 0.015625rem;
+  --sdn-border-width-small: 0.03125rem;
+  --sdn-border-width-medium: 0.0625rem;
+  --sdn-border-width-large: 0.171875rem;
+  --sdn-border-width-xlarge: 0.40625rem;
   /* High Contrast */
   --sdn-hc-on-white: hsl(344 12% 8%);
   --sdn-hc-on-gray: hsl(344 12% 98%);

--- a/packages/editor/apps/vue/seldon/styles/seldon.css
+++ b/packages/editor/apps/vue/seldon/styles/seldon.css
@@ -70,44 +70,44 @@
   --sdn-sizes-xsmall: 0.5rem;
   --sdn-sizes-small: 0.75rem;
   --sdn-sizes-medium: 1rem;
-  --sdn-sizes-large: 1.501rem;
-  --sdn-sizes-xlarge: 2.002rem;
-  --sdn-sizes-xxlarge: 2.998rem;
-  --sdn-sizes-huge: 3.998rem;
+  --sdn-sizes-large: 1.5rem;
+  --sdn-sizes-xlarge: 2rem;
+  --sdn-sizes-xxlarge: 3rem;
+  --sdn-sizes-huge: 4rem;
   /* Margins */
   --sdn-margins-tight: 0.25rem;
   --sdn-margins-compact: 0.5rem;
   --sdn-margins-cozy: 1rem;
-  --sdn-margins-comfortable: 2.002rem;
-  --sdn-margins-open: 3.998rem;
+  --sdn-margins-comfortable: 2rem;
+  --sdn-margins-open: 4rem;
   /* Paddings */
   --sdn-paddings-tight: 0.25rem;
   --sdn-paddings-compact: 0.5rem;
   --sdn-paddings-cozy: 1rem;
-  --sdn-paddings-comfortable: 2.002rem;
-  --sdn-paddings-open: 3.998rem;
+  --sdn-paddings-comfortable: 2rem;
+  --sdn-paddings-open: 4rem;
   /* Gaps */
   --sdn-gaps-tight: 0.25rem;
   --sdn-gaps-compact: 0.5rem;
   --sdn-gaps-cozy: 1rem;
-  --sdn-gaps-comfortable: 2.002rem;
-  --sdn-gaps-open: 3.998rem;
+  --sdn-gaps-comfortable: 2rem;
+  --sdn-gaps-open: 4rem;
   /* Corners */
   --sdn-corners-tight: 0.25rem;
   --sdn-corners-compact: 0.5rem;
   --sdn-corners-cozy: 1rem;
-  --sdn-corners-comfortable: 1.501rem;
-  --sdn-corners-open: 2.002rem;
+  --sdn-corners-comfortable: 1.5rem;
+  --sdn-corners-open: 2rem;
   /* Font Sizes */
   --sdn-font-size-tiny: 0.5rem;
-  --sdn-font-size-xxsmall: 0.624rem;
+  --sdn-font-size-xxsmall: 0.625rem;
   --sdn-font-size-xsmall: 0.75rem;
   --sdn-font-size-small: 0.875rem;
   --sdn-font-size-medium: 1rem;
-  --sdn-font-size-large: 1.501rem;
-  --sdn-font-size-xlarge: 2.002rem;
-  --sdn-font-size-xxlarge: 2.998rem;
-  --sdn-font-size-huge: 3.998rem;
+  --sdn-font-size-large: 1.5rem;
+  --sdn-font-size-xlarge: 2rem;
+  --sdn-font-size-xxlarge: 3rem;
+  --sdn-font-size-huge: 4rem;
   /* Font Weights */
   --sdn-font-weight-thin: 100;
   --sdn-font-weight-xlight: 200;
@@ -127,8 +127,8 @@
   --sdn-line-height-comfortable: 2;
   --sdn-line-height-open: 2.5;
   /* Border Widths */
-  --sdn-border-width-xsmall: 0.031rem;
-  --sdn-border-width-small: 0.069rem;
+  --sdn-border-width-xsmall: 0.03125rem;
+  --sdn-border-width-small: 0.0625rem;
   --sdn-border-width-medium: 0.125rem;
   --sdn-border-width-large: 0.25rem;
   --sdn-border-width-xlarge: 0.5rem;

--- a/packages/editor/apps/vue/seldon/styles/sunset-blue.css
+++ b/packages/editor/apps/vue/seldon/styles/sunset-blue.css
@@ -70,44 +70,44 @@
   --sdn-sizes-xsmall: 0.5rem;
   --sdn-sizes-small: 0.75rem;
   --sdn-sizes-medium: 1rem;
-  --sdn-sizes-large: 1.501rem;
-  --sdn-sizes-xlarge: 2.002rem;
-  --sdn-sizes-xxlarge: 2.998rem;
-  --sdn-sizes-huge: 3.998rem;
+  --sdn-sizes-large: 1.5rem;
+  --sdn-sizes-xlarge: 2rem;
+  --sdn-sizes-xxlarge: 3rem;
+  --sdn-sizes-huge: 4rem;
   /* Margins */
   --sdn-margins-tight: 0.25rem;
   --sdn-margins-compact: 0.5rem;
   --sdn-margins-cozy: 1rem;
-  --sdn-margins-comfortable: 2.002rem;
-  --sdn-margins-open: 3.998rem;
+  --sdn-margins-comfortable: 2rem;
+  --sdn-margins-open: 4rem;
   /* Paddings */
   --sdn-paddings-tight: 0.25rem;
   --sdn-paddings-compact: 0.5rem;
   --sdn-paddings-cozy: 1rem;
-  --sdn-paddings-comfortable: 2.002rem;
-  --sdn-paddings-open: 3.998rem;
+  --sdn-paddings-comfortable: 2rem;
+  --sdn-paddings-open: 4rem;
   /* Gaps */
   --sdn-gaps-tight: 0.25rem;
   --sdn-gaps-compact: 0.5rem;
   --sdn-gaps-cozy: 1rem;
-  --sdn-gaps-comfortable: 2.002rem;
-  --sdn-gaps-open: 3.998rem;
+  --sdn-gaps-comfortable: 2rem;
+  --sdn-gaps-open: 4rem;
   /* Corners */
   --sdn-corners-tight: 0.25rem;
   --sdn-corners-compact: 0.375rem;
   --sdn-corners-cozy: 0.5rem;
-  --sdn-corners-comfortable: 0.624rem;
+  --sdn-corners-comfortable: 0.625rem;
   --sdn-corners-open: 1rem;
   /* Font Sizes */
   --sdn-font-size-tiny: 0.5rem;
-  --sdn-font-size-xxsmall: 0.624rem;
+  --sdn-font-size-xxsmall: 0.625rem;
   --sdn-font-size-xsmall: 0.75rem;
   --sdn-font-size-small: 0.875rem;
   --sdn-font-size-medium: 1rem;
-  --sdn-font-size-large: 1.563rem;
-  --sdn-font-size-xlarge: 2.002rem;
-  --sdn-font-size-xxlarge: 2.998rem;
-  --sdn-font-size-huge: 3.998rem;
+  --sdn-font-size-large: 1.5625rem;
+  --sdn-font-size-xlarge: 2rem;
+  --sdn-font-size-xxlarge: 3rem;
+  --sdn-font-size-huge: 4rem;
   /* Font Weights */
   --sdn-font-weight-thin: 100;
   --sdn-font-weight-xlight: 200;
@@ -127,8 +127,8 @@
   --sdn-line-height-comfortable: 2;
   --sdn-line-height-open: 2.5;
   /* Border Widths */
-  --sdn-border-width-xsmall: 0.031rem;
-  --sdn-border-width-small: 0.069rem;
+  --sdn-border-width-xsmall: 0.03125rem;
+  --sdn-border-width-small: 0.0625rem;
   --sdn-border-width-medium: 0.125rem;
   --sdn-border-width-large: 0.25rem;
   --sdn-border-width-xlarge: 0.5rem;

--- a/packages/editor/apps/vue/seldon/styles/wildberry.css
+++ b/packages/editor/apps/vue/seldon/styles/wildberry.css
@@ -65,49 +65,49 @@
   --sdn-swatch-accent-bn30: hsl(47 87% 37.1%);
   --sdn-swatch-gray-b50: hsl(327 12% 78%);
   /* Sizes */
-  --sdn-sizes-tiny: 0.219rem;
-  --sdn-sizes-xxsmall: 0.387rem;
-  --sdn-sizes-xsmall: 0.681rem;
-  --sdn-sizes-small: 0.949rem;
+  --sdn-sizes-tiny: 0.21875rem;
+  --sdn-sizes-xxsmall: 0.390625rem;
+  --sdn-sizes-xsmall: 0.6875rem;
+  --sdn-sizes-small: 0.953125rem;
   --sdn-sizes-medium: 1.2rem;
-  --sdn-sizes-large: 1.672rem;
-  --sdn-sizes-xlarge: 2.116rem;
-  --sdn-sizes-xxlarge: 2.943rem;
-  --sdn-sizes-huge: 3.723rem;
+  --sdn-sizes-large: 1.671875rem;
+  --sdn-sizes-xlarge: 2.109375rem;
+  --sdn-sizes-xxlarge: 2.9375rem;
+  --sdn-sizes-huge: 3.71875rem;
   /* Margins */
-  --sdn-margins-tight: 0.387rem;
-  --sdn-margins-compact: 0.681rem;
+  --sdn-margins-tight: 0.390625rem;
+  --sdn-margins-compact: 0.6875rem;
   --sdn-margins-cozy: 1.2rem;
-  --sdn-margins-comfortable: 2.116rem;
-  --sdn-margins-open: 3.723rem;
+  --sdn-margins-comfortable: 2.109375rem;
+  --sdn-margins-open: 3.71875rem;
   /* Paddings */
-  --sdn-paddings-tight: 0.387rem;
-  --sdn-paddings-compact: 0.681rem;
+  --sdn-paddings-tight: 0.390625rem;
+  --sdn-paddings-compact: 0.6875rem;
   --sdn-paddings-cozy: 1.2rem;
-  --sdn-paddings-comfortable: 2.116rem;
-  --sdn-paddings-open: 3.723rem;
+  --sdn-paddings-comfortable: 2.109375rem;
+  --sdn-paddings-open: 3.71875rem;
   /* Gaps */
-  --sdn-gaps-tight: 0.387rem;
-  --sdn-gaps-compact: 0.681rem;
+  --sdn-gaps-tight: 0.390625rem;
+  --sdn-gaps-compact: 0.6875rem;
   --sdn-gaps-cozy: 1.2rem;
-  --sdn-gaps-comfortable: 2.116rem;
-  --sdn-gaps-open: 3.723rem;
+  --sdn-gaps-comfortable: 2.109375rem;
+  --sdn-gaps-open: 3.71875rem;
   /* Corners */
-  --sdn-corners-tight: 0.773rem;
+  --sdn-corners-tight: 0.765625rem;
   --sdn-corners-compact: 1rem;
   --sdn-corners-cozy: 1.2rem;
-  --sdn-corners-comfortable: 1.712rem;
-  --sdn-corners-open: 2.89rem;
+  --sdn-corners-comfortable: 1.71875rem;
+  --sdn-corners-open: 2.890625rem;
   /* Font Sizes */
-  --sdn-font-size-tiny: 0.638rem;
-  --sdn-font-size-xxsmall: 0.766rem;
-  --sdn-font-size-xsmall: 0.889rem;
-  --sdn-font-size-small: 1.008rem;
+  --sdn-font-size-tiny: 0.640625rem;
+  --sdn-font-size-xxsmall: 0.765625rem;
+  --sdn-font-size-xsmall: 0.890625rem;
+  --sdn-font-size-small: 1.015625rem;
   --sdn-font-size-medium: 1.125rem;
-  --sdn-font-size-large: 1.62rem;
-  --sdn-font-size-xlarge: 1.983rem;
-  --sdn-font-size-xxlarge: 2.759rem;
-  --sdn-font-size-huge: 3.49rem;
+  --sdn-font-size-large: 1.625rem;
+  --sdn-font-size-xlarge: 1.984375rem;
+  --sdn-font-size-xxlarge: 2.765625rem;
+  --sdn-font-size-huge: 3.484375rem;
   /* Font Weights */
   --sdn-font-weight-thin: 100;
   --sdn-font-weight-xlight: 200;
@@ -127,11 +127,11 @@
   --sdn-line-height-comfortable: 2;
   --sdn-line-height-open: 2.5;
   /* Border Widths */
-  --sdn-border-width-xsmall: 0.071rem;
-  --sdn-border-width-small: 0.135rem;
-  --sdn-border-width-medium: 0.219rem;
-  --sdn-border-width-large: 0.387rem;
-  --sdn-border-width-xlarge: 0.681rem;
+  --sdn-border-width-xsmall: 0.078125rem;
+  --sdn-border-width-small: 0.140625rem;
+  --sdn-border-width-medium: 0.21875rem;
+  --sdn-border-width-large: 0.390625rem;
+  --sdn-border-width-xlarge: 0.6875rem;
   /* High Contrast */
   --sdn-hc-on-white: hsl(327 12% 8%);
   --sdn-hc-on-gray: hsl(327 12% 98%);


### PR DESCRIPTION
## 📝 Description

Fixes menu label alignment and regenerates theme token output for consistency.

- Changed the menu label `align` option from `bottom-left` to `left` in `seldon-editor.json` (react and vue apps).
- Regenerated stock theme CSS so modulated token values render as clean rounded units (e.g. `2.002rem` → `2rem`, `3.998rem` → `4rem`, `0.069rem` → `0.0625rem`) across all themes.
- Adjusted box-shadow properties for styling consistency.

Only generated editor app output changed; no core logic or schema changes.

## 🔗 Related Issues

_None_

## 🧪 Type of Change

- 🐛 Bug fix

## 📦 Affected Packages

- `@seldon/editor`

## 📸 Screenshots/Videos

_N/A_

## 🔍 Code Quality Checklist

- Code follows the project's style guidelines
- Self-review of the code has been performed
- Code is properly commented, particularly in hard-to-understand areas
- No console.log statements or debugging code left in
- TypeScript types are properly defined, no use of "as any"
- No unused imports or variables

## 📋 Breaking Changes

_None_

## 🚀 Deployment Notes

_None_

## 📚 Documentation Updates

_None_

## ⚠️ Additional Notes

_None_

---

I have read the CLA and I agree to its terms.

Github: AndreiSeldon
Organization: [ ORGANIZATION ]