### PR TITLE
Fix/mcp editor store states

### DIFF
--- a/packages/ai/mcp/headless-host.ts
+++ b/packages/ai/mcp/headless-host.ts
@@ -14,6 +14,7 @@ import { createEmptyWorkspace } from "@seldon/core/workspace/helpers/create-empt
 import { EditSession, safeApply } from "../tools"
 import { WorkspaceStore } from "./store"
 
+import type { RejectedActionResult } from "../types"
 import type {
   CheckpointInfo,
   ExportedFile,
@@ -21,6 +22,7 @@ import type {
   McpHost,
   WorkspaceTarget,
 } from "./server"
+import type { StatToken } from "./store"
 import type { Workspace } from "@seldon/core/workspace/types"
 import type { ExportOptions } from "@seldon/factory"
 
@@ -33,10 +35,26 @@ const DEFAULT_COMPONENTS_FOLDER = "components"
 interface TargetState {
   workspace: Workspace
   version: number
+  rev: string
+  loadedToken: StatToken | null
   history: Workspace[]
   historyIndex: number
   checkpoints: CheckpointRecord[]
   queue: Promise<unknown>
+}
+
+/** True when two stat tokens differ, treating a missing file as a change. */
+function tokenChanged(a: StatToken | null, b: StatToken | null): boolean {
+  if (a === null || b === null) return a !== b
+
+  return a.mtimeMs !== b.mtimeMs || a.size !== b.size
+}
+
+/** The message a commit throws when the workspace moved on disk under it. */
+function commitConflictMessage(rejected: RejectedActionResult[]): string {
+  const reasons = rejected.map((entry) => `${entry.type}: ${entry.reason}`).join(" ")
+
+  return `Commit conflict: the workspace changed on disk and none of this change's actions still apply. ${reasons} Re-read the current state and retry.`
 }
 
 interface CheckpointRecord {
@@ -141,10 +159,18 @@ export class HeadlessHost implements McpHost {
     const state = await this.getState(targetId)
 
     return this.enqueue(state, async () => {
-      // Re-apply the session's accepted actions against the current workspace,
-      // not the snapshot the session opened on, so a concurrent commit that
-      // landed first is preserved rather than overwritten.
+      // Rebase onto disk under the lock, not the snapshot the session opened on,
+      // so an editor autosave or a concurrent commit that landed first is
+      // preserved. safeApply reruns each action through the linter and reducer,
+      // so an action that no longer applies to the fresh base is rejected rather
+      // than clobbering the newer state.
+      await this.reloadIfDiverged(targetId, state)
       const result = safeApply(state.workspace, session.actions)
+
+      if (result.applied.length === 0 && result.rejected.length > 0) {
+        throw new Error(commitConflictMessage(result.rejected))
+      }
+
       const version = await this.adopt(targetId, state, result.workspace)
 
       return { version }
@@ -184,11 +210,17 @@ export class HeadlessHost implements McpHost {
     const state = await this.getState(targetId)
 
     return this.enqueue(state, async () => {
+      if (await this.reloadIfDiverged(targetId, state)) {
+        return {
+          message: "History reset: the workspace changed outside this session. Nothing to undo.",
+        }
+      }
+
       if (state.historyIndex === 0) return { message: "Nothing to undo." }
       state.historyIndex -= 1
       state.workspace = state.history[state.historyIndex]
       state.version += 1
-      await this.store.write(targetId, state.workspace)
+      await this.writeState(targetId, state)
 
       return { version: state.version }
     })
@@ -198,11 +230,17 @@ export class HeadlessHost implements McpHost {
     const state = await this.getState(targetId)
 
     return this.enqueue(state, async () => {
+      if (await this.reloadIfDiverged(targetId, state)) {
+        return {
+          message: "History reset: the workspace changed outside this session. Nothing to redo.",
+        }
+      }
+
       if (state.historyIndex >= state.history.length - 1) return { message: "Nothing to redo." }
       state.historyIndex += 1
       state.workspace = state.history[state.historyIndex]
       state.version += 1
-      await this.store.write(targetId, state.workspace)
+      await this.writeState(targetId, state)
 
       return { version: state.version }
     })
@@ -255,27 +293,55 @@ export class HeadlessHost implements McpHost {
     const id = options.id ?? workspace.metadata.id ?? randomUUID()
 
     await this.store.write(id, workspace)
-    this.seedState(id, workspace)
+    const fresh = await this.store.readWithRev(id)
+    const token = await this.store.statToken(id)
+
+    this.seedState(id, fresh?.entry.workspace ?? workspace, fresh?.rev ?? "", token)
 
     return { id }
   }
 
-  /** Loads a target into memory once, then serves it from the cache. */
+  /**
+   * Serves a target read-through over the store. It seeds on first touch, then
+   * reconciles: a cheap `stat` gates whether to reload, and a content-rev change
+   * reseeds from disk so an editor autosave or another writer is picked up
+   * without a restart.
+   */
   private async getState(id: string): Promise<TargetState> {
     const cached = this.states.get(id)
+    const token = await this.store.statToken(id)
 
-    if (cached) return cached
-    const entry = await this.store.read(id)
+    if (cached) {
+      if (!tokenChanged(cached.loadedToken, token)) return cached
+      const fresh = await this.store.readWithRev(id)
 
-    if (!entry) throw new Error(`No workspace "${id}" in the store.`)
+      if (fresh && fresh.rev !== cached.rev) {
+        this.reseedFromDisk(cached, fresh.entry.workspace, fresh.rev, token)
+      } else {
+        cached.loadedToken = token
+      }
 
-    return this.seedState(id, entry.workspace)
+      return cached
+    }
+
+    const fresh = await this.store.readWithRev(id)
+
+    if (!fresh) throw new Error(`No workspace "${id}" in the store.`)
+
+    return this.seedState(id, fresh.entry.workspace, fresh.rev, token)
   }
 
-  private seedState(id: string, workspace: Workspace): TargetState {
+  private seedState(
+    id: string,
+    workspace: Workspace,
+    rev: string,
+    token: StatToken | null,
+  ): TargetState {
     const state: TargetState = {
       workspace,
       version: 0,
+      rev,
+      loadedToken: token,
       history: [workspace],
       historyIndex: 0,
       checkpoints: [],
@@ -285,6 +351,37 @@ export class HeadlessHost implements McpHost {
     this.states.set(id, state)
 
     return state
+  }
+
+  /**
+   * Reloads a target from disk in place as a new baseline. An external write
+   * invalidates the in-memory undo history, so history resets to the disk state.
+   * Checkpoints survive as the agent-safe revert.
+   */
+  private reseedFromDisk(
+    state: TargetState,
+    workspace: Workspace,
+    rev: string,
+    token: StatToken | null,
+  ): void {
+    state.workspace = workspace
+    state.rev = rev
+    state.loadedToken = token
+    state.history = [workspace]
+    state.historyIndex = 0
+    state.version += 1
+  }
+
+  /** Reseeds from disk when the stored rev diverged from the cached one. */
+  private async reloadIfDiverged(id: string, state: TargetState): Promise<boolean> {
+    const fresh = await this.store.readWithRev(id)
+
+    if (!fresh || fresh.rev === state.rev) return false
+    const token = await this.store.statToken(id)
+
+    this.reseedFromDisk(state, fresh.entry.workspace, fresh.rev, token)
+
+    return true
   }
 
   /** Serializes work on one target so read-modify-write-persist stays atomic. */
@@ -299,6 +396,15 @@ export class HeadlessHost implements McpHost {
     return next
   }
 
+  /** Persists the state's current workspace and refreshes its rev and token. */
+  private async writeState(id: string, state: TargetState): Promise<void> {
+    await this.store.write(id, state.workspace)
+    const fresh = await this.store.readWithRev(id)
+
+    if (fresh) state.rev = fresh.rev
+    state.loadedToken = await this.store.statToken(id)
+  }
+
   /** Adopts a new workspace as one revision: records history and persists. */
   private async adopt(id: string, state: TargetState, workspace: Workspace): Promise<number> {
     state.workspace = workspace
@@ -308,7 +414,7 @@ export class HeadlessHost implements McpHost {
     if (state.history.length > HISTORY_LIMIT) state.history.shift()
     state.historyIndex = state.history.length - 1
     state.version += 1
-    await this.store.write(id, workspace)
+    await this.writeState(id, state)
 
     return state.version
   }

--- a/packages/ai/mcp/store.ts
+++ b/packages/ai/mcp/store.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto"
 import fs from "node:fs/promises"
 import path from "node:path"
 
@@ -23,6 +24,18 @@ export interface StoreEntry {
   id: string
   workspace: Workspace
   label: string
+}
+
+/** A cheap freshness prefilter derived from the record file's stat. */
+export interface StatToken {
+  mtimeMs: number
+  size: number
+}
+
+/** A read plus the content revision hash of the serialized workspace. */
+export interface RevEntry {
+  entry: StoreEntry
+  rev: string
 }
 
 /**
@@ -58,6 +71,37 @@ export class WorkspaceStore {
     } catch {
       return null
     }
+  }
+
+  /**
+   * The record file's mtime and size, or null when it is absent. A caller
+   * compares this against a cached token to skip a full reload when the file has
+   * not changed, so the hot read path stays a single `stat`.
+   */
+  async statToken(id: string): Promise<StatToken | null> {
+    try {
+      const stat = await fs.stat(this.recordPath(id))
+
+      return { mtimeMs: stat.mtimeMs, size: stat.size }
+    } catch {
+      return null
+    }
+  }
+
+  /**
+   * Reads one workspace and its content revision, or null when absent. The rev
+   * is a hash of the ordered workspace, the same shape {@link write} persists,
+   * so two processes that read the same file compute the same rev. It ignores
+   * `updatedAt`, so a rewrite with identical content keeps the rev stable.
+   */
+  async readWithRev(id: string): Promise<RevEntry | null> {
+    const entry = await this.read(id)
+
+    if (!entry) return null
+    const ordered = orderWorkspaceNodeKeys(entry.workspace)
+    const rev = createHash("sha1").update(JSON.stringify(ordered)).digest("hex")
+
+    return { entry, rev }
   }
 
   /** Persists one workspace atomically, keeping a single `.bak` of the prior file. */

--- a/packages/bundles/foundation/vite/bridge-host.ts
+++ b/packages/bundles/foundation/vite/bridge-host.ts
@@ -201,8 +201,9 @@ export class BridgeHost implements McpHost {
 
   async export(targetId: string, options?: McpExportOptions): Promise<ExportedFile[]> {
     // Export always runs headless in the dev server, which has the factory and
-    // filesystem. A connected tab autosaves to the same store, so the headless
-    // read is current.
+    // filesystem. The headless host reads through to the store and reloads on a
+    // content change, so a connected tab's autosave is picked up and the export
+    // reflects the current workspace.
     return this.fallback.export(targetId, options)
   }
 

--- a/packages/editor/apps/react/app/editor/LocalWorkspaceShell.tsx
+++ b/packages/editor/apps/react/app/editor/LocalWorkspaceShell.tsx
@@ -3,6 +3,7 @@
 import { Layout as LayoutComponent } from "@app/Layout"
 import { useMcpBridge } from "@app/mcp/use-mcp-bridge"
 import { useWorkspaceAutosave } from "@app/persistence/hooks/use-workspace-autosave"
+import { useWorkspaceRemoteRefresh } from "@app/persistence/hooks/use-workspace-remote-refresh"
 import { useWorkspaceSyncStatus } from "@app/project/hooks/use-workspace-sync-status"
 import { useWorkspace } from "@app/workspace/hooks/use-workspace"
 
@@ -19,6 +20,7 @@ export function LocalWorkspaceShell({
   const isDirty = useWorkspaceSyncStatus(record.id)
 
   useWorkspaceAutosave(record, workspace, isDirty)
+  useWorkspaceRemoteRefresh(record, isDirty)
   useMcpBridge(record.id)
 
   return <LayoutComponent testId="canvas">{children}</LayoutComponent>

--- a/packages/editor/apps/react/app/persistence/hooks/use-workspace-remote-refresh.ts
+++ b/packages/editor/apps/react/app/persistence/hooks/use-workspace-remote-refresh.ts
@@ -1,0 +1,61 @@
+"use client"
+
+import { useWorkspaceSaveStore } from "@app/persistence/workspace-save-store"
+import { useDispatch } from "@app/workspace/hooks/use-dispatch"
+import { getStoredWorkspace } from "@seldon/editor/lib/storage/workspace-store"
+import { useEffect, useRef } from "react"
+
+import type { StoredWorkspace } from "@seldon/editor/lib/storage/workspace-store"
+
+/**
+ * Refreshes the open workspace when the shared store changes outside this tab,
+ * such as an MCP commit against the same `.seldon/workspaces` file. On window
+ * focus it reads the stored record, and when the store is newer than the tab's
+ * last write and the tab is clean, it adopts the stored workspace as one undo
+ * step. A dirty tab is left untouched, so a local edit is never clobbered by a
+ * remote change. The baseline is the save store's own record, so the tab's
+ * autosaves never trigger a self-reload.
+ */
+export function useWorkspaceRemoteRefresh(record: StoredWorkspace, isDirty: boolean): void {
+  const dispatch = useDispatch()
+  const setRecord = useWorkspaceSaveStore((state) => state.setRecord)
+  const isDirtyRef = useRef(isDirty)
+
+  useEffect(() => {
+    isDirtyRef.current = isDirty
+  }, [isDirty])
+
+  useEffect(() => {
+    const workspaceId = record.id
+
+    if (!workspaceId) return
+
+    const refresh = async () => {
+      if (isDirtyRef.current) return
+      const stored = await getStoredWorkspace(workspaceId)
+
+      if (!stored) return
+      const baseline = useWorkspaceSaveStore.getState().record?.updatedAt ?? record.updatedAt
+
+      if (stored.updatedAt <= baseline) return
+      dispatch({ type: "set_workspace", payload: { workspace: stored.workspace } })
+      setRecord(stored)
+    }
+
+    const onFocus = () => {
+      void refresh()
+    }
+
+    const onVisibilityChange = () => {
+      if (document.visibilityState === "visible") void refresh()
+    }
+
+    window.addEventListener("focus", onFocus)
+    document.addEventListener("visibilitychange", onVisibilityChange)
+
+    return () => {
+      window.removeEventListener("focus", onFocus)
+      document.removeEventListener("visibilitychange", onVisibilityChange)
+    }
+  }, [record.id, record.updatedAt, dispatch, setRecord])
+}

--- a/packages/editor/apps/react/sdn/refs/bindings.json
+++ b/packages/editor/apps/react/sdn/refs/bindings.json
@@ -2,7 +2,7 @@
   "version": 1,
   "mode": "full",
   "framework": "react",
-  "scannedFiles": 298,
+  "scannedFiles": 299,
   "refs": {
     "boardState": [
       {


### PR DESCRIPTION
## 📝 Description

Fixes concurrent-writer drift between the MCP `HeadlessHost` and the Editor over the shared `.seldon/workspaces` store. Previously the host loaded a workspace once into an in-memory `states` map and never re-read disk, so an engineer on MCP saw stale reads, `commitSession` clobbered the Editor's autosaves, and `undo`/`redo`/`export` operated on an old snapshot.

The host now works as a read-through and write-through cache over the disk store:

- `WorkspaceStore` gains `statToken` (a cheap `mtime`+`size` prefilter) and `readWithRev` (a SHA-1 content revision over the ordered workspace, stable across processes, ignoring `updatedAt`). No on-disk record shape change.
- `HeadlessHost.getState` reconciles before serving: a `stat` gates reload, and a revision change reseeds from disk, so an Editor autosave is picked up with no restart. Reads and `export` are always fresh.
- `commitSession` rebases the session's actions onto the disk base inside the per-target queue via `safeApply`, and rejects with a conflict directive when no action still applies, instead of overwriting newer state.
- `undo`, `redo`, and checkpoint restore guard against on-disk divergence and reset history from disk rather than clobbering external work. `adopt` and a new `writeState` refresh the cached revision after every write.
- The React Editor adds `useWorkspaceRemoteRefresh`, which adopts a newer store version on window focus when the tab is clean, and leaves a dirty tab untouched.

## 🔗 Related Issues

## 🧪 Type of Change

- 🐛 Bug fix
- ✨ New feature
- ⚡ Performance improvement

## 📦 Affected Packages

- `@seldon/editor`
- `@seldon/ai` (`packages/ai/mcp/*`: store and headless host)
- `@seldon/foundation` (`packages/bundles/foundation/vite/bridge-host.ts`: export comment)

## 📸 Screenshots/Videos

_N/A_

## 🔍 Code Quality Checklist

- Code follows the project's style guidelines
- Self-review of the code has been performed
- Code is properly commented, particularly in hard-to-understand areas
- No console.log statements or debugging code left in
- TypeScript types are properly defined, no use of "as any"
- No unused imports or variables

## 📋 Breaking Changes

_None._ The on-disk record shape is unchanged. The revision is computed from content at read time, so existing `.seldon/workspaces` files load without migration.

## 🚀 Deployment Notes

Consumers on `@seldon/hari` must restart the MCP process once after upgrading so the running stdio server loads the new `HeadlessHost`. This is a one-time restart; after it, staleness self-heals. No store migration is required.

## 📚 Documentation Updates

_None._

## ⚠️ Additional Notes

The Editor remote-refresh handles the clean-tab case and never clobbers a dirty buffer. A dirty-conflict merge prompt is intentionally left as a follow-up product decision. The `bindings.json` `scannedFiles` count updated as a generated side effect of the new Editor hook.

---

I have read the CLA and I agree to its terms.

Github: AndreiSeldon
Organization: Seldon Digital