### PR TITLE
Enhance export functionality in HeadlessHost and server configuration

### DIFF
--- a/packages/ai/mcp/headless-host.ts
+++ b/packages/ai/mcp/headless-host.ts
@@ -68,7 +68,11 @@ interface CheckpointRecord {
 export interface HeadlessHostOptions {
   /** Directory holding the `<id>.json` workspace files. */
   storeDir: string
-  /** Root the factory reads engine assets from during export. Defaults to cwd. */
+  /**
+   * Root an export writes files into and the factory reads engine assets from.
+   * Defaults to the project root derived from the store directory, so an export
+   * lands in the project even when the process runs from another directory.
+   */
   exportRoot?: string
 }
 
@@ -87,6 +91,22 @@ function findMonorepoRoot(start: string): string | null {
     if (parent === current) return null
     current = parent
   }
+}
+
+/**
+ * Derives the project root an export writes into from the store directory. The
+ * store lives at `<project>/.seldon/workspaces`, so the project is the parent of
+ * the nearest `.seldon` segment. Falls back to the current directory when the
+ * path holds no `.seldon` segment. This keeps writes in the project even when the
+ * MCP process is spawned from another directory, which `process.cwd()` would miss.
+ */
+function deriveExportRoot(storeDir: string): string {
+  const segments = path.resolve(storeDir).split(path.sep)
+  const seldonIndex = segments.lastIndexOf(".seldon")
+
+  if (seldonIndex > 0) return segments.slice(0, seldonIndex).join(path.sep) || path.sep
+
+  return process.cwd()
 }
 
 /** Encodes an exported file's contents as text, base64 for binary assets. */
@@ -113,7 +133,7 @@ export class HeadlessHost implements McpHost {
 
   constructor(options: HeadlessHostOptions) {
     this.store = new WorkspaceStore(options.storeDir)
-    this.exportRoot = path.resolve(options.exportRoot ?? process.cwd())
+    this.exportRoot = path.resolve(options.exportRoot ?? deriveExportRoot(options.storeDir))
   }
 
   async listTargets(): Promise<WorkspaceTarget[]> {

--- a/packages/ai/mcp/headless-host.ts
+++ b/packages/ai/mcp/headless-host.ts
@@ -189,6 +189,10 @@ export class HeadlessHost implements McpHost {
 
     const exportOptions: ExportOptions = {
       rootDirectory,
+      // Format generated files against the destination project's Prettier config,
+      // so an export lands the way that project formats its own source and a
+      // consumer's format check finds nothing to fix.
+      formatConfigRoot: this.exportRoot,
       target: {
         framework: (options?.framework as ExportOptions["target"]["framework"]) ?? "react",
         styles: (options?.styles as ExportOptions["target"]["styles"]) ?? "css-properties",
@@ -204,6 +208,10 @@ export class HeadlessHost implements McpHost {
     }
 
     const files = await exportWorkspace(state.workspace, exportOptions)
+
+    if (options?.write !== false) {
+      await this.writeExportedFiles(files, options?.outputDir)
+    }
 
     return files.map(toExportedFile)
   }
@@ -384,6 +392,30 @@ export class HeadlessHost implements McpHost {
     this.reseedFromDisk(state, fresh.entry.workspace, fresh.rev, token)
 
     return true
+  }
+
+  /**
+   * Writes exported files to disk under the export root, so an MCP export updates
+   * the consumer project the same way the editor export does. Paths are the
+   * factory's project-relative paths. Text writes as UTF-8; a binary asset, which
+   * the factory returns as an ArrayBuffer, writes as bytes. `outputDir` nests the
+   * whole tree under a subfolder of the export root when set.
+   */
+  private async writeExportedFiles(
+    files: Array<{ path: string; content: string | ArrayBuffer }>,
+    outputDir?: string,
+  ): Promise<void> {
+    const baseDir = outputDir ? path.resolve(this.exportRoot, outputDir) : this.exportRoot
+
+    for (const file of files) {
+      const targetPath = path.join(baseDir, file.path)
+
+      await fs.promises.mkdir(path.dirname(targetPath), { recursive: true })
+      await fs.promises.writeFile(
+        targetPath,
+        typeof file.content === "string" ? file.content : Buffer.from(file.content),
+      )
+    }
   }
 
   /** Serializes work on one target so read-modify-write-persist stays atomic. */

--- a/packages/ai/mcp/server.ts
+++ b/packages/ai/mcp/server.ts
@@ -26,6 +26,8 @@ export interface McpExportOptions {
   framework?: string
   styles?: string
   componentsFolder?: string
+  outputDir?: string
+  write?: boolean
 }
 
 /** One stored checkpoint an agent can restore. */
@@ -295,7 +297,7 @@ export function createSeldonMcpServer(host: McpHost): Server {
     {
       name: "workspace_export",
       description:
-        "Export the target workspace to framework code and return the list of files produced. Pass framework and styles to pick the target.",
+        "Export the target workspace to framework code, write the files into the project, and return the list of files produced. Pass framework and styles to pick the target. Set write to false to list the paths without writing.",
       inputSchema: withHostParams({
         type: "object",
         properties: {
@@ -305,6 +307,16 @@ export function createSeldonMcpServer(host: McpHost): Server {
           },
           styles: { type: "string", description: 'Style output, for example "css-properties".' },
           componentsFolder: { type: "string", description: "Output folder for components." },
+          outputDir: {
+            type: "string",
+            description:
+              "Subfolder of the project to write the export into. Defaults to the project root.",
+          },
+          write: {
+            type: "boolean",
+            description:
+              "Write the files to disk under the project. Defaults to true. Set false to only list the paths.",
+          },
         },
         required: [],
       } as unknown as TSchema),
@@ -312,15 +324,24 @@ export function createSeldonMcpServer(host: McpHost): Server {
         const resolved = await resolveTargetId(args)
 
         if ("directive" in resolved) return resolved.directive
+        const write = args.write !== false
+        const outputDir = args.outputDir as string | undefined
         const files = await host.export(resolved.id, {
           framework: args.framework as string | undefined,
           styles: args.styles as string | undefined,
           componentsFolder: args.componentsFolder as string | undefined,
+          outputDir,
+          write,
         })
 
         if (files.length === 0) return "Export produced no files."
 
-        return `Exported ${files.length} file(s):\n${files.map((f) => `- ${f.path}`).join("\n")}`
+        const location = outputDir ?? "the project root"
+        const header = write
+          ? `Wrote ${files.length} file(s) to ${location}:`
+          : `Exported ${files.length} file(s):`
+
+        return `${header}\n${files.map((f) => `- ${f.path}`).join("\n")}`
       },
     },
     {

--- a/scripts/publish-local.mjs
+++ b/scripts/publish-local.mjs
@@ -10,9 +10,10 @@ import { execFileSync } from "node:child_process"
  *   2. A registry user exists: `npm adduser --registry http://localhost:4873`.
  *   3. The packages are built: `npm run build:packages`.
  *
- * The registry comes from the @seldon scope in .npmrc, so no --registry flag is
- * needed. Republishing an existing version fails; bump the lockstep version
- * first (`npm run changeset` then `npm run version`).
+ * The registry comes from the @seldon scope in .npmrc, but the unpublish and
+ * publish calls pass it explicitly. Each package is unpublished before it
+ * publishes, so re-running on the same version replaces the local copy instead
+ * of failing on the immutable-version 409.
  */
 const REGISTRY = "http://localhost:4873/"
 
@@ -29,6 +30,17 @@ const PACKAGES = [
 
 for (const name of PACKAGES) {
   process.stdout.write(`\nPublishing ${name} to ${REGISTRY}\n`)
+
+  // Local iteration stays on one version, so drop any existing copy first. A
+  // published version is immutable, so republishing the same version fails with
+  // a 409 otherwise. Ignore the error when the package is not yet in the registry.
+  try {
+    execFileSync("npm", ["unpublish", name, "--registry", REGISTRY, "--force"], {
+      stdio: "inherit",
+    })
+  } catch {
+    // Not present in the registry yet; nothing to remove.
+  }
 
   execFileSync("npm", ["publish", "--workspace", name, "--registry", REGISTRY], {
     stdio: "inherit",


### PR DESCRIPTION
## 📝 Description

Make the MCP `workspace_export` tool actually write generated code into the project instead of only returning a list of file paths.

- `HeadlessHost.export` now writes each exported file to disk under the export root via a new `writeExportedFiles` helper (UTF-8 for text, bytes for binary assets), so an MCP export updates the consumer project the same way the editor export does.
- Added `formatConfigRoot: this.exportRoot` to the export options, so generated files are formatted against the destination project's Prettier config and a consumer's format check finds nothing to fix.
- Extended `McpExportOptions` and the `workspace_export` tool with `outputDir` (nest the tree under a subfolder) and `write` (default `true`; set `false` to list paths without writing). The tool reports `Wrote N file(s) to …` or `Exported N file(s):` accordingly.
- Made `scripts/publish-local.mjs` idempotent for local `0.0.0` iteration: each package is unpublished from Verdaccio before it publishes, so re-running `release:local` on the same version replaces the local copy instead of failing on the immutable-version 409.

## 🔗 Related Issues

_None_

## 🧪 Type of Change

- 🐛 Bug fix
- ✨ New feature

## 📦 Affected Packages

- `@seldon/ai` (`packages/ai/mcp/headless-host.ts`, `packages/ai/mcp/server.ts`)
- Repo tooling: `scripts/publish-local.mjs`

## 📸 Screenshots/Videos

_N/A_

## 🔍 Code Quality Checklist

- Code follows the project's style guidelines
- Self-review of the code has been performed
- Code is properly commented, particularly in hard-to-understand areas
- No console.log statements or debugging code left in
- TypeScript types are properly defined, no use of "as any"
- No unused imports or variables

## 📋 Breaking Changes

`workspace_export` now writes files to disk by default. Callers that relied on it only returning a path list must pass `write: false` to keep the list-only behavior.

## 🚀 Deployment Notes

Consumer projects (for example `seldon-photo`) must refresh their installed `@seldon/ai`, `@seldon/hari`, and `@seldon/factory` `dist` bundles and restart the Seldon MCP process to pick up the writing behavior.

## 📚 Documentation Updates

_None_

## ⚠️ Additional Notes

The write is a plain overwrite of resolved paths; it does not prune stale files, so a renamed or removed component leaves its old file behind, matching the editor export.

---

I have read the CLA and I agree to its terms.

Github: AndreiSeldon
Organization: SeldonDigital