### PR TITLE
Fix/font exporter

### DIFF
--- a/packages/ai/mcp/headless-host.ts
+++ b/packages/ai/mcp/headless-host.ts
@@ -7,6 +7,7 @@ import {
   createNodeExportAssetReader,
   createResolvedExportAssetReader,
   exportWorkspace,
+  toExportScopeOptions,
 } from "@seldon/factory"
 
 import { createEmptyWorkspace } from "@seldon/core/workspace/helpers/create-empty-workspace"
@@ -225,6 +226,9 @@ export class HeadlessHost implements McpHost {
         assetPublicPath: "/",
       },
       assetReader,
+      // Scope flags come from the shared descriptors, so an agent export matches
+      // the editor dialog and the CLI. Omitted flags fall back to the defaults.
+      ...toExportScopeOptions(options ?? {}),
     }
 
     const files = await exportWorkspace(state.workspace, exportOptions)

--- a/packages/ai/mcp/server.ts
+++ b/packages/ai/mcp/server.ts
@@ -1,10 +1,12 @@
 import { Server } from "@modelcontextprotocol/sdk/server/index.js"
 import { CallToolRequestSchema, ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js"
+import { EXPORT_FLAGS } from "@seldon/factory"
 
 import { SELDON_TOOLS, SELDON_TOOLS_BY_NAME } from "../tools"
 
 import type { EditSession, SelectionContext, ToolContext } from "../tools"
 import type { Tool } from "@modelcontextprotocol/sdk/types.js"
+import type { ExportScopeFlags } from "@seldon/factory"
 import type { TSchema } from "typebox"
 
 /** One workspace an MCP host can address, with its current routing. */
@@ -21,8 +23,12 @@ export interface ExportedFile {
   contents: string
 }
 
-/** Options a caller may pass to an export. Framework and styles pick the target. */
-export interface McpExportOptions {
+/**
+ * Options a caller may pass to an export. Framework and styles pick the target;
+ * the {@link ExportScopeFlags} choose the scope, matching the editor dialog and
+ * the CLI. An omitted flag falls back to the shared default.
+ */
+export interface McpExportOptions extends Partial<ExportScopeFlags> {
   framework?: string
   styles?: string
   componentsFolder?: string
@@ -129,6 +135,31 @@ interface HostTool {
 }
 
 const OBJECT_SCHEMA: JsonObjectSchema = { type: "object", properties: {}, required: [] }
+
+/**
+ * JSON schema properties for the export scope flags, derived from the shared
+ * export flag descriptors so the `workspace_export` tool matches the editor
+ * dialog and the CLI.
+ */
+const exportScopeFlagSchema: Record<string, { type: "boolean"; description: string }> =
+  Object.fromEntries(
+    EXPORT_FLAGS.map(
+      (flag) => [flag.storeKey, { type: "boolean", description: flag.description }] as const,
+    ),
+  )
+
+/** Reads the boolean export scope flags a caller passed, ignoring the rest. */
+function readExportScopeFlags(args: Record<string, unknown>): Partial<ExportScopeFlags> {
+  const flags: Partial<ExportScopeFlags> = {}
+
+  for (const flag of EXPORT_FLAGS) {
+    const value = args[flag.storeKey]
+
+    if (typeof value === "boolean") flags[flag.storeKey] = value
+  }
+
+  return flags
+}
 
 /**
  * Builds a configured MCP `Server` from a host, transport-agnostic. It registers
@@ -317,6 +348,7 @@ export function createSeldonMcpServer(host: McpHost): Server {
             description:
               "Write the files to disk under the project. Defaults to true. Set false to only list the paths.",
           },
+          ...exportScopeFlagSchema,
         },
         required: [],
       } as unknown as TSchema),
@@ -332,6 +364,7 @@ export function createSeldonMcpServer(host: McpHost): Server {
           componentsFolder: args.componentsFolder as string | undefined,
           outputDir,
           write,
+          ...readExportScopeFlags(args),
         })
 
         if (files.length === 0) return "Export produced no files."

--- a/packages/core/workspace/services/font-collection/font-collection.service.ts
+++ b/packages/core/workspace/services/font-collection/font-collection.service.ts
@@ -3,8 +3,13 @@ import merge from "lodash/merge"
 import { STOCK_FONT_COLLECTIONS_BY_ID } from "../../../font-collections/catalog"
 import { instantiateFontCollection } from "../../../font-collections/compute"
 import { isSelfHostedRemoteOrigin } from "../../../font-collections/constants"
-import { deriveVariantPreset, getEnabledVariants } from "../../../font-collections/helpers"
+import {
+  deriveVariantPreset,
+  getEnabledVariants,
+  isRemoteFontFamily,
+} from "../../../font-collections/helpers"
 import { sortFontVariants } from "../../../helpers/utils/font-variant"
+import { ValueType } from "../../../properties/constants"
 import { isFontCollectionBoard } from "../../model/components"
 import {
   getFontCollectionTemplateCatalogId,
@@ -17,6 +22,7 @@ import type {
   FontCollectionTemplateId,
   FontFamilyEntry,
 } from "../../../font-collections/types"
+import type { Properties } from "../../../properties/types/properties"
 import type { EntryFontCollection } from "../../model/entry-font-collection"
 import type { Workspace } from "../../types"
 
@@ -240,6 +246,39 @@ export class WorkspaceFontCollectionService {
    */
   public collectWorkspaceFamilies(workspace: Workspace): WorkspaceFontFamily[] {
     return this.collectWorkspaceFamilyGroups(workspace).flat()
+  }
+
+  /**
+   * Remote family names set directly on any node's `font.family` facet, scanned
+   * across the base `overrides` and every state bag. A concrete `option` or
+   * `exact` value that names a packaged remote family counts as in use. A
+   * theme-resolved value, such as `@fontFamily.primary` or a `font.preset`
+   * recipe, is not a direct family choice, so it is skipped. Export uses this to
+   * emit font host links for only the families a project actually renders.
+   */
+  public collectUsedRemoteFontFamilies(workspace: Workspace): Set<string> {
+    const used = new Set<string>()
+
+    const scan = (properties: Properties | undefined): void => {
+      const family = properties?.font?.family
+
+      if (!family) return
+      if (family.type !== ValueType.OPTION && family.type !== ValueType.EXACT) return
+      if (typeof family.value !== "string" || !isRemoteFontFamily(family.value)) return
+
+      used.add(family.value)
+    }
+
+    for (const node of Object.values(workspace.nodes)) {
+      if (!node) continue
+      scan(node.overrides)
+
+      for (const stateProperties of Object.values(node.states ?? {})) {
+        scan(stateProperties)
+      }
+    }
+
+    return used
   }
 
   /** Catalog ids of font collections present in the workspace. */

--- a/packages/editor/apps/react/.seldon/workspaces/2347a3e9-93d1-41b5-b1d7-9cd7fe37c7d4.json
+++ b/packages/editor/apps/react/.seldon/workspaces/2347a3e9-93d1-41b5-b1d7-9cd7fe37c7d4.json
@@ -28424,7 +28424,7 @@
           },
           "content": {
             "type": "exact",
-            "value": "All Enabled Fonts"
+            "value": "All Fonts"
           },
           "width": {
             "type": "option",
@@ -49042,6 +49042,6 @@
     },
     "media": {}
   },
-  "updatedAt": "2026-08-13T15:44:49.106Z",
+  "updatedAt": "2026-08-18T13:41:40.702Z",
   "lastEditor": "react"
 }

--- a/packages/editor/apps/react/app/dialogs/export-components/ExportComponentsController.tsx
+++ b/packages/editor/apps/react/app/dialogs/export-components/ExportComponentsController.tsx
@@ -4,6 +4,7 @@ import { MenuController } from "@app/menus/MenuController"
 import { WindowSurface } from "@app/windows/WindowSurface.bespoke"
 import { useDraggableWindow } from "@app/windows/hooks/use-draggable-window"
 import { DialogExportComponent } from "@seldon/components/modules/DialogExportComponent"
+import { EXPORT_FLAGS } from "@seldon/factory/export/options"
 import { useCallback, useMemo, useRef, useState } from "react"
 import { useHotkeys } from "react-hotkeys-hook"
 
@@ -15,7 +16,19 @@ import {
 
 import type { MenuEntry } from "@app/menus/types"
 import type { SeldonRefs } from "@seldon/components/utils/merge-slot"
+import type { ExportFlagDescriptor, ExportScopeFlags } from "@seldon/factory/export/options"
 import type { CSSProperties, ChangeEvent, KeyboardEvent, MouseEvent, PointerEvent } from "react"
+
+/**
+ * Every scope flag keyed by its store name, so the dialog reads its group label
+ * and aria-label from the shared export flag descriptors. This keeps the copy in
+ * step with the CLI and the MCP host, and it means a flag rename lands here
+ * without editing the design.
+ */
+const EXPORT_FLAG = EXPORT_FLAGS.reduce(
+  (lookup, flag) => ({ ...lookup, [flag.storeKey]: flag }),
+  {} as Record<keyof ExportScopeFlags, ExportFlagDescriptor>,
+)
 
 /**
  * Gate for the Export Components dialog. Mounts the dialog only while the
@@ -174,10 +187,10 @@ function ExportComponentsDialog({
   // `.cursor/rules/foundation-editor-jsx.mdc`. Display-only slots turn on with an empty
   // object; behavior rides in per ref.
   const seldonRefs: SeldonRefs = {
-    exportTitle: {},
+    exportTitle: { children: "Export Components" },
 
     exportWorkspaceName: {},
-    exportWorkspaceNameLabel: {},
+    exportWorkspaceNameLabel: { children: "Workspace Name" },
     exportWorkspaceNameField: {
       value: workspaceName,
       placeholder: "Untitled workspace",
@@ -188,7 +201,7 @@ function ExportComponentsDialog({
     },
 
     exportFramework: {},
-    exportFrameworkLabel: {},
+    exportFrameworkLabel: { children: "Framework" },
     exportFrameworkCombobox: {},
     exportFrameworkField: {
       value: frameworkLabel,
@@ -199,7 +212,7 @@ function ExportComponentsDialog({
     },
 
     exportPlatform: {},
-    exportPlatformLabel: {},
+    exportPlatformLabel: { children: "Platform" },
     exportPlatformCombobox: {},
     exportPlatformField: {
       value: platformLabel,
@@ -210,7 +223,7 @@ function ExportComponentsDialog({
     },
 
     exportProjectFolder: {},
-    exportProjectFolderLabel: {},
+    exportProjectFolderLabel: { children: "Project Folder" },
     exportProjectFolderField: {
       value: directoryLabel,
       placeholder: "Choose a folder…",
@@ -220,86 +233,88 @@ function ExportComponentsDialog({
     },
 
     exportFieldset: {},
+    exportFieldsetLabel: { children: "Include" },
 
     // Scope groups. Every key is spelled out, never built in a loop, so the
-    // bindings scanner records each ref. The container holds the radiogroup role,
-    // each row widens the hit area, and each native input holds the group name
-    // plus checked state.
-    exportFontLinks: { role: "radiogroup", "aria-label": "Generate Google Font API Links" },
-    exportFontLinksLabel: {},
+    // bindings scanner records each ref. The container holds the radiogroup role
+    // and its label, each row widens the hit area, and each native input holds
+    // the group name plus checked state. Group label and aria-label come from
+    // the shared export flag descriptors so the copy matches the CLI and MCP.
+    exportFontLinks: { role: "radiogroup", "aria-label": EXPORT_FLAG.fontLinks.ariaLabel },
+    exportFontLinksLabel: { children: EXPORT_FLAG.fontLinks.label },
     exportFontLinksYes: radioRow(() => setFontLinks(true)),
     exportFontLinksYesInput: radioInput("export-font-links", fontLinks, () => setFontLinks(true)),
-    exportFontLinksYesText: {},
+    exportFontLinksYesText: { children: "Yes" },
     exportFontLinksNo: radioRow(() => setFontLinks(false)),
     exportFontLinksNoInput: radioInput("export-font-links", !fontLinks, () => setFontLinks(false)),
-    exportFontLinksNoText: {},
+    exportFontLinksNoText: { children: "No" },
 
-    exportHidden: { role: "radiogroup", "aria-label": "Hidden Components" },
-    exportHiddenLabel: {},
+    exportHidden: { role: "radiogroup", "aria-label": EXPORT_FLAG.includeHidden.ariaLabel },
+    exportHiddenLabel: { children: EXPORT_FLAG.includeHidden.label },
     exportHiddenYes: radioRow(() => setIncludeHidden(true)),
     exportHiddenYesInput: radioInput("export-hidden", includeHidden, () => setIncludeHidden(true)),
-    exportHiddenYesText: {},
+    exportHiddenYesText: { children: "Yes" },
     exportHiddenNo: radioRow(() => setIncludeHidden(false)),
     exportHiddenNoInput: radioInput("export-hidden", !includeHidden, () => setIncludeHidden(false)),
-    exportHiddenNoText: {},
+    exportHiddenNoText: { children: "No" },
 
-    exportAllThemes: { role: "radiogroup", "aria-label": "All Themes" },
-    exportAllThemesLabel: {},
+    exportAllThemes: { role: "radiogroup", "aria-label": EXPORT_FLAG.allThemes.ariaLabel },
+    exportAllThemesLabel: { children: EXPORT_FLAG.allThemes.label },
     exportAllThemesYes: radioRow(() => setAllThemes(true)),
     exportAllThemesYesInput: radioInput("export-all-themes", allThemes, () => setAllThemes(true)),
-    exportAllThemesYesText: {},
+    exportAllThemesYesText: { children: "Yes" },
     exportAllThemesNo: radioRow(() => setAllThemes(false)),
     exportAllThemesNoInput: radioInput("export-all-themes", !allThemes, () => setAllThemes(false)),
-    exportAllThemesNoText: {},
+    exportAllThemesNoText: { children: "No" },
 
-    exportAllFonts: { role: "radiogroup", "aria-label": "All Enabled Fonts" },
-    exportAllFontsLabel: {},
+    exportAllFonts: { role: "radiogroup", "aria-label": EXPORT_FLAG.allFonts.ariaLabel },
+    exportAllFontsLabel: { children: EXPORT_FLAG.allFonts.label },
     exportAllFontsYes: radioRow(() => setAllFonts(true)),
     exportAllFontsYesInput: radioInput("export-all-fonts", allFonts, () => setAllFonts(true)),
-    exportAllFontsYesText: {},
+    exportAllFontsYesText: { children: "Yes" },
     exportAllFontsNo: radioRow(() => setAllFonts(false)),
     exportAllFontsNoInput: radioInput("export-all-fonts", !allFonts, () => setAllFonts(false)),
-    exportAllFontsNoText: {},
+    exportAllFontsNoText: { children: "No" },
 
-    exportAllIcons: { role: "radiogroup", "aria-label": "All Enabled Icons" },
-    exportAllIconsLabel: {},
+    exportAllIcons: { role: "radiogroup", "aria-label": EXPORT_FLAG.allIcons.ariaLabel },
+    exportAllIconsLabel: { children: EXPORT_FLAG.allIcons.label },
     exportAllIconsYes: radioRow(() => setAllIcons(true)),
     exportAllIconsYesInput: radioInput("export-all-icons", allIcons, () => setAllIcons(true)),
-    exportAllIconsYesText: {},
+    exportAllIconsYesText: { children: "Yes" },
     exportAllIconsNo: radioRow(() => setAllIcons(false)),
     exportAllIconsNoInput: radioInput("export-all-icons", !allIcons, () => setAllIcons(false)),
-    exportAllIconsNoText: {},
+    exportAllIconsNoText: { children: "No" },
 
-    exportWorkspace: { role: "radiogroup", "aria-label": "Workspace File" },
-    exportWorkspaceLabel: {},
+    exportWorkspace: { role: "radiogroup", "aria-label": EXPORT_FLAG.savedWorkspace.ariaLabel },
+    exportWorkspaceLabel: { children: EXPORT_FLAG.savedWorkspace.label },
     exportWorkspaceYes: radioRow(() => setSavedWorkspace(true)),
     exportWorkspaceYesInput: radioInput("export-saved-workspace", savedWorkspace, () =>
       setSavedWorkspace(true),
     ),
-    exportWorkspaceYesText: {},
+    exportWorkspaceYesText: { children: "Yes" },
     exportWorkspaceNo: radioRow(() => setSavedWorkspace(false)),
     exportWorkspaceNoInput: radioInput("export-saved-workspace", !savedWorkspace, () =>
       setSavedWorkspace(false),
     ),
-    exportWorkspaceNoText: {},
+    exportWorkspaceNoText: { children: "No" },
 
-    exportScripts: { role: "radiogroup", "aria-label": "CLI Utility Scripts" },
-    exportScriptsLabel: {},
+    exportScripts: { role: "radiogroup", "aria-label": EXPORT_FLAG.includeScripts.ariaLabel },
+    exportScriptsLabel: { children: EXPORT_FLAG.includeScripts.label },
     exportScriptsYes: radioRow(() => setIncludeScripts(true)),
     exportScriptsYesInput: radioInput("export-scripts", includeScripts, () =>
       setIncludeScripts(true),
     ),
-    exportScriptsYesText: {},
+    exportScriptsYesText: { children: "Yes" },
     exportScriptsNo: radioRow(() => setIncludeScripts(false)),
     exportScriptsNoInput: radioInput("export-scripts", !includeScripts, () =>
       setIncludeScripts(false),
     ),
-    exportScriptsNoText: {},
+    exportScriptsNoText: { children: "No" },
 
     exportCancel: { onClick: cancel },
-    exportCancelLabel: {},
+    exportCancelLabel: { children: "Cancel" },
     exportConfirm: { onClick: save, "aria-disabled": exporting, style: confirmStyle },
-    exportConfirmLabel: {},
+    exportConfirmLabel: { children: "Export" },
   }
 
   return (

--- a/packages/editor/apps/react/app/dialogs/export-components/hooks/use-export-options.ts
+++ b/packages/editor/apps/react/app/dialogs/export-components/hooks/use-export-options.ts
@@ -1,3 +1,4 @@
+import { EXPORT_FLAG_DEFAULTS } from "@seldon/factory/export/options"
 import { create } from "zustand"
 import { persist } from "zustand/middleware"
 
@@ -36,13 +37,7 @@ export const useExportOptions = create<ExportOptionsState>()(
     (set) => ({
       platform: "react",
       framework: "none",
-      includeHidden: false,
-      allThemes: false,
-      allFonts: false,
-      fontLinks: false,
-      allIcons: true,
-      savedWorkspace: true,
-      includeScripts: true,
+      ...EXPORT_FLAG_DEFAULTS,
 
       setPlatform: (value) => set({ platform: value }),
       setFramework: (value) => set({ framework: value }),

--- a/packages/editor/apps/react/sdn/refs/bindings.json
+++ b/packages/editor/apps/react/sdn/refs/bindings.json
@@ -1221,10 +1221,19 @@
       {
         "file": "app/dialogs/export-components/ExportComponentsController.tsx",
         "component": "ExportComponentsDialog",
-        "line": 255,
+        "line": 270,
         "conditional": false,
-        "expression": "{ role: \"radiogroup\", \"aria-label\": \"All Enabled Fonts\" }",
-        "inputs": [],
+        "expression": "{ role: \"radiogroup\", \"aria-label\": EXPORT_FLAG.allFonts.ariaLabel }",
+        "inputs": [
+          {
+            "name": "EXPORT_FLAG",
+            "declaredAt": {
+              "line": 28,
+              "kind": "const",
+              "via": "EXPORT_FLAGS.reduce"
+            }
+          }
+        ],
         "props": [
           {
             "key": "role",
@@ -1233,8 +1242,17 @@
           },
           {
             "key": "aria-label",
-            "expression": "\"All Enabled Fonts\"",
-            "inputs": []
+            "expression": "EXPORT_FLAG.allFonts.ariaLabel",
+            "inputs": [
+              {
+                "name": "EXPORT_FLAG",
+                "declaredAt": {
+                  "line": 28,
+                  "kind": "const",
+                  "via": "EXPORT_FLAGS.reduce"
+                }
+              }
+            ]
           }
         ]
       }
@@ -1243,32 +1261,56 @@
       {
         "file": "app/dialogs/export-components/ExportComponentsController.tsx",
         "component": "ExportComponentsDialog",
-        "line": 256,
+        "line": 271,
         "conditional": false,
-        "expression": "{}",
-        "inputs": [],
-        "props": []
+        "expression": "{ children: EXPORT_FLAG.allFonts.label }",
+        "inputs": [
+          {
+            "name": "EXPORT_FLAG",
+            "declaredAt": {
+              "line": 28,
+              "kind": "const",
+              "via": "EXPORT_FLAGS.reduce"
+            }
+          }
+        ],
+        "props": [
+          {
+            "key": "children",
+            "expression": "EXPORT_FLAG.allFonts.label",
+            "inputs": [
+              {
+                "name": "EXPORT_FLAG",
+                "declaredAt": {
+                  "line": 28,
+                  "kind": "const",
+                  "via": "EXPORT_FLAGS.reduce"
+                }
+              }
+            ]
+          }
+        ]
       }
     ],
     "exportAllFontsNo": [
       {
         "file": "app/dialogs/export-components/ExportComponentsController.tsx",
         "component": "ExportComponentsDialog",
-        "line": 260,
+        "line": 275,
         "conditional": false,
         "expression": "radioRow(() => setAllFonts(false))",
         "inputs": [
           {
             "name": "radioRow",
             "declaredAt": {
-              "line": 337,
+              "line": 352,
               "kind": "function"
             }
           },
           {
             "name": "setAllFonts",
             "declaredAt": {
-              "line": 42,
+              "line": 55,
               "kind": "parameter"
             }
           }
@@ -1280,28 +1322,28 @@
       {
         "file": "app/dialogs/export-components/ExportComponentsController.tsx",
         "component": "ExportComponentsDialog",
-        "line": 261,
+        "line": 276,
         "conditional": false,
         "expression": "radioInput(\"export-all-fonts\", !allFonts, () => setAllFonts(false))",
         "inputs": [
           {
             "name": "radioInput",
             "declaredAt": {
-              "line": 342,
+              "line": 357,
               "kind": "function"
             }
           },
           {
             "name": "allFonts",
             "declaredAt": {
-              "line": 42,
+              "line": 55,
               "kind": "parameter"
             }
           },
           {
             "name": "setAllFonts",
             "declaredAt": {
-              "line": 42,
+              "line": 55,
               "kind": "parameter"
             }
           }
@@ -1313,32 +1355,38 @@
       {
         "file": "app/dialogs/export-components/ExportComponentsController.tsx",
         "component": "ExportComponentsDialog",
-        "line": 262,
+        "line": 277,
         "conditional": false,
-        "expression": "{}",
+        "expression": "{ children: \"No\" }",
         "inputs": [],
-        "props": []
+        "props": [
+          {
+            "key": "children",
+            "expression": "\"No\"",
+            "inputs": []
+          }
+        ]
       }
     ],
     "exportAllFontsYes": [
       {
         "file": "app/dialogs/export-components/ExportComponentsController.tsx",
         "component": "ExportComponentsDialog",
-        "line": 257,
+        "line": 272,
         "conditional": false,
         "expression": "radioRow(() => setAllFonts(true))",
         "inputs": [
           {
             "name": "radioRow",
             "declaredAt": {
-              "line": 337,
+              "line": 352,
               "kind": "function"
             }
           },
           {
             "name": "setAllFonts",
             "declaredAt": {
-              "line": 42,
+              "line": 55,
               "kind": "parameter"
             }
           }
@@ -1350,28 +1398,28 @@
       {
         "file": "app/dialogs/export-components/ExportComponentsController.tsx",
         "component": "ExportComponentsDialog",
-        "line": 258,
+        "line": 273,
         "conditional": false,
         "expression": "radioInput(\"export-all-fonts\", allFonts, () => setAllFonts(true))",
         "inputs": [
           {
             "name": "radioInput",
             "declaredAt": {
-              "line": 342,
+              "line": 357,
               "kind": "function"
             }
           },
           {
             "name": "allFonts",
             "declaredAt": {
-              "line": 42,
+              "line": 55,
               "kind": "parameter"
             }
           },
           {
             "name": "setAllFonts",
             "declaredAt": {
-              "line": 42,
+              "line": 55,
               "kind": "parameter"
             }
           }
@@ -1383,21 +1431,36 @@
       {
         "file": "app/dialogs/export-components/ExportComponentsController.tsx",
         "component": "ExportComponentsDialog",
-        "line": 259,
+        "line": 274,
         "conditional": false,
-        "expression": "{}",
+        "expression": "{ children: \"Yes\" }",
         "inputs": [],
-        "props": []
+        "props": [
+          {
+            "key": "children",
+            "expression": "\"Yes\"",
+            "inputs": []
+          }
+        ]
       }
     ],
     "exportAllIcons": [
       {
         "file": "app/dialogs/export-components/ExportComponentsController.tsx",
         "component": "ExportComponentsDialog",
-        "line": 264,
+        "line": 279,
         "conditional": false,
-        "expression": "{ role: \"radiogroup\", \"aria-label\": \"All Enabled Icons\" }",
-        "inputs": [],
+        "expression": "{ role: \"radiogroup\", \"aria-label\": EXPORT_FLAG.allIcons.ariaLabel }",
+        "inputs": [
+          {
+            "name": "EXPORT_FLAG",
+            "declaredAt": {
+              "line": 28,
+              "kind": "const",
+              "via": "EXPORT_FLAGS.reduce"
+            }
+          }
+        ],
         "props": [
           {
             "key": "role",
@@ -1406,8 +1469,17 @@
           },
           {
             "key": "aria-label",
-            "expression": "\"All Enabled Icons\"",
-            "inputs": []
+            "expression": "EXPORT_FLAG.allIcons.ariaLabel",
+            "inputs": [
+              {
+                "name": "EXPORT_FLAG",
+                "declaredAt": {
+                  "line": 28,
+                  "kind": "const",
+                  "via": "EXPORT_FLAGS.reduce"
+                }
+              }
+            ]
           }
         ]
       }
@@ -1416,32 +1488,56 @@
       {
         "file": "app/dialogs/export-components/ExportComponentsController.tsx",
         "component": "ExportComponentsDialog",
-        "line": 265,
+        "line": 280,
         "conditional": false,
-        "expression": "{}",
-        "inputs": [],
-        "props": []
+        "expression": "{ children: EXPORT_FLAG.allIcons.label }",
+        "inputs": [
+          {
+            "name": "EXPORT_FLAG",
+            "declaredAt": {
+              "line": 28,
+              "kind": "const",
+              "via": "EXPORT_FLAGS.reduce"
+            }
+          }
+        ],
+        "props": [
+          {
+            "key": "children",
+            "expression": "EXPORT_FLAG.allIcons.label",
+            "inputs": [
+              {
+                "name": "EXPORT_FLAG",
+                "declaredAt": {
+                  "line": 28,
+                  "kind": "const",
+                  "via": "EXPORT_FLAGS.reduce"
+                }
+              }
+            ]
+          }
+        ]
       }
     ],
     "exportAllIconsNo": [
       {
         "file": "app/dialogs/export-components/ExportComponentsController.tsx",
         "component": "ExportComponentsDialog",
-        "line": 269,
+        "line": 284,
         "conditional": false,
         "expression": "radioRow(() => setAllIcons(false))",
         "inputs": [
           {
             "name": "radioRow",
             "declaredAt": {
-              "line": 337,
+              "line": 352,
               "kind": "function"
             }
           },
           {
             "name": "setAllIcons",
             "declaredAt": {
-              "line": 42,
+              "line": 55,
               "kind": "parameter"
             }
           }
@@ -1453,28 +1549,28 @@
       {
         "file": "app/dialogs/export-components/ExportComponentsController.tsx",
         "component": "ExportComponentsDialog",
-        "line": 270,
+        "line": 285,
         "conditional": false,
         "expression": "radioInput(\"export-all-icons\", !allIcons, () => setAllIcons(false))",
         "inputs": [
           {
             "name": "radioInput",
             "declaredAt": {
-              "line": 342,
+              "line": 357,
               "kind": "function"
             }
           },
           {
             "name": "allIcons",
             "declaredAt": {
-              "line": 42,
+              "line": 55,
               "kind": "parameter"
             }
           },
           {
             "name": "setAllIcons",
             "declaredAt": {
-              "line": 42,
+              "line": 55,
               "kind": "parameter"
             }
           }
@@ -1486,32 +1582,38 @@
       {
         "file": "app/dialogs/export-components/ExportComponentsController.tsx",
         "component": "ExportComponentsDialog",
-        "line": 271,
+        "line": 286,
         "conditional": false,
-        "expression": "{}",
+        "expression": "{ children: \"No\" }",
         "inputs": [],
-        "props": []
+        "props": [
+          {
+            "key": "children",
+            "expression": "\"No\"",
+            "inputs": []
+          }
+        ]
       }
     ],
     "exportAllIconsYes": [
       {
         "file": "app/dialogs/export-components/ExportComponentsController.tsx",
         "component": "ExportComponentsDialog",
-        "line": 266,
+        "line": 281,
         "conditional": false,
         "expression": "radioRow(() => setAllIcons(true))",
         "inputs": [
           {
             "name": "radioRow",
             "declaredAt": {
-              "line": 337,
+              "line": 352,
               "kind": "function"
             }
           },
           {
             "name": "setAllIcons",
             "declaredAt": {
-              "line": 42,
+              "line": 55,
               "kind": "parameter"
             }
           }
@@ -1523,28 +1625,28 @@
       {
         "file": "app/dialogs/export-components/ExportComponentsController.tsx",
         "component": "ExportComponentsDialog",
-        "line": 267,
+        "line": 282,
         "conditional": false,
         "expression": "radioInput(\"export-all-icons\", allIcons, () => setAllIcons(true))",
         "inputs": [
           {
             "name": "radioInput",
             "declaredAt": {
-              "line": 342,
+              "line": 357,
               "kind": "function"
             }
           },
           {
             "name": "allIcons",
             "declaredAt": {
-              "line": 42,
+              "line": 55,
               "kind": "parameter"
             }
           },
           {
             "name": "setAllIcons",
             "declaredAt": {
-              "line": 42,
+              "line": 55,
               "kind": "parameter"
             }
           }
@@ -1556,21 +1658,36 @@
       {
         "file": "app/dialogs/export-components/ExportComponentsController.tsx",
         "component": "ExportComponentsDialog",
-        "line": 268,
+        "line": 283,
         "conditional": false,
-        "expression": "{}",
+        "expression": "{ children: \"Yes\" }",
         "inputs": [],
-        "props": []
+        "props": [
+          {
+            "key": "children",
+            "expression": "\"Yes\"",
+            "inputs": []
+          }
+        ]
       }
     ],
     "exportAllThemes": [
       {
         "file": "app/dialogs/export-components/ExportComponentsController.tsx",
         "component": "ExportComponentsDialog",
-        "line": 246,
+        "line": 261,
         "conditional": false,
-        "expression": "{ role: \"radiogroup\", \"aria-label\": \"All Themes\" }",
-        "inputs": [],
+        "expression": "{ role: \"radiogroup\", \"aria-label\": EXPORT_FLAG.allThemes.ariaLabel }",
+        "inputs": [
+          {
+            "name": "EXPORT_FLAG",
+            "declaredAt": {
+              "line": 28,
+              "kind": "const",
+              "via": "EXPORT_FLAGS.reduce"
+            }
+          }
+        ],
         "props": [
           {
             "key": "role",
@@ -1579,8 +1696,17 @@
           },
           {
             "key": "aria-label",
-            "expression": "\"All Themes\"",
-            "inputs": []
+            "expression": "EXPORT_FLAG.allThemes.ariaLabel",
+            "inputs": [
+              {
+                "name": "EXPORT_FLAG",
+                "declaredAt": {
+                  "line": 28,
+                  "kind": "const",
+                  "via": "EXPORT_FLAGS.reduce"
+                }
+              }
+            ]
           }
         ]
       }
@@ -1589,32 +1715,56 @@
       {
         "file": "app/dialogs/export-components/ExportComponentsController.tsx",
         "component": "ExportComponentsDialog",
-        "line": 247,
+        "line": 262,
         "conditional": false,
-        "expression": "{}",
-        "inputs": [],
-        "props": []
+        "expression": "{ children: EXPORT_FLAG.allThemes.label }",
+        "inputs": [
+          {
+            "name": "EXPORT_FLAG",
+            "declaredAt": {
+              "line": 28,
+              "kind": "const",
+              "via": "EXPORT_FLAGS.reduce"
+            }
+          }
+        ],
+        "props": [
+          {
+            "key": "children",
+            "expression": "EXPORT_FLAG.allThemes.label",
+            "inputs": [
+              {
+                "name": "EXPORT_FLAG",
+                "declaredAt": {
+                  "line": 28,
+                  "kind": "const",
+                  "via": "EXPORT_FLAGS.reduce"
+                }
+              }
+            ]
+          }
+        ]
       }
     ],
     "exportAllThemesNo": [
       {
         "file": "app/dialogs/export-components/ExportComponentsController.tsx",
         "component": "ExportComponentsDialog",
-        "line": 251,
+        "line": 266,
         "conditional": false,
         "expression": "radioRow(() => setAllThemes(false))",
         "inputs": [
           {
             "name": "radioRow",
             "declaredAt": {
-              "line": 337,
+              "line": 352,
               "kind": "function"
             }
           },
           {
             "name": "setAllThemes",
             "declaredAt": {
-              "line": 42,
+              "line": 55,
               "kind": "parameter"
             }
           }
@@ -1626,28 +1776,28 @@
       {
         "file": "app/dialogs/export-components/ExportComponentsController.tsx",
         "component": "ExportComponentsDialog",
-        "line": 252,
+        "line": 267,
         "conditional": false,
         "expression": "radioInput(\"export-all-themes\", !allThemes, () => setAllThemes(false))",
         "inputs": [
           {
             "name": "radioInput",
             "declaredAt": {
-              "line": 342,
+              "line": 357,
               "kind": "function"
             }
           },
           {
             "name": "allThemes",
             "declaredAt": {
-              "line": 42,
+              "line": 55,
               "kind": "parameter"
             }
           },
           {
             "name": "setAllThemes",
             "declaredAt": {
-              "line": 42,
+              "line": 55,
               "kind": "parameter"
             }
           }
@@ -1659,32 +1809,38 @@
       {
         "file": "app/dialogs/export-components/ExportComponentsController.tsx",
         "component": "ExportComponentsDialog",
-        "line": 253,
+        "line": 268,
         "conditional": false,
-        "expression": "{}",
+        "expression": "{ children: \"No\" }",
         "inputs": [],
-        "props": []
+        "props": [
+          {
+            "key": "children",
+            "expression": "\"No\"",
+            "inputs": []
+          }
+        ]
       }
     ],
     "exportAllThemesYes": [
       {
         "file": "app/dialogs/export-components/ExportComponentsController.tsx",
         "component": "ExportComponentsDialog",
-        "line": 248,
+        "line": 263,
         "conditional": false,
         "expression": "radioRow(() => setAllThemes(true))",
         "inputs": [
           {
             "name": "radioRow",
             "declaredAt": {
-              "line": 337,
+              "line": 352,
               "kind": "function"
             }
           },
           {
             "name": "setAllThemes",
             "declaredAt": {
-              "line": 42,
+              "line": 55,
               "kind": "parameter"
             }
           }
@@ -1696,28 +1852,28 @@
       {
         "file": "app/dialogs/export-components/ExportComponentsController.tsx",
         "component": "ExportComponentsDialog",
-        "line": 249,
+        "line": 264,
         "conditional": false,
         "expression": "radioInput(\"export-all-themes\", allThemes, () => setAllThemes(true))",
         "inputs": [
           {
             "name": "radioInput",
             "declaredAt": {
-              "line": 342,
+              "line": 357,
               "kind": "function"
             }
           },
           {
             "name": "allThemes",
             "declaredAt": {
-              "line": 42,
+              "line": 55,
               "kind": "parameter"
             }
           },
           {
             "name": "setAllThemes",
             "declaredAt": {
-              "line": 42,
+              "line": 55,
               "kind": "parameter"
             }
           }
@@ -1729,25 +1885,31 @@
       {
         "file": "app/dialogs/export-components/ExportComponentsController.tsx",
         "component": "ExportComponentsDialog",
-        "line": 250,
+        "line": 265,
         "conditional": false,
-        "expression": "{}",
+        "expression": "{ children: \"Yes\" }",
         "inputs": [],
-        "props": []
+        "props": [
+          {
+            "key": "children",
+            "expression": "\"Yes\"",
+            "inputs": []
+          }
+        ]
       }
     ],
     "exportCancel": [
       {
         "file": "app/dialogs/export-components/ExportComponentsController.tsx",
         "component": "ExportComponentsDialog",
-        "line": 299,
+        "line": 314,
         "conditional": false,
         "expression": "{ onClick: cancel }",
         "inputs": [
           {
             "name": "cancel",
             "declaredAt": {
-              "line": 42,
+              "line": 55,
               "kind": "parameter"
             }
           }
@@ -1760,7 +1922,7 @@
               {
                 "name": "cancel",
                 "declaredAt": {
-                  "line": 42,
+                  "line": 55,
                   "kind": "parameter"
                 }
               }
@@ -1773,39 +1935,45 @@
       {
         "file": "app/dialogs/export-components/ExportComponentsController.tsx",
         "component": "ExportComponentsDialog",
-        "line": 300,
+        "line": 315,
         "conditional": false,
-        "expression": "{}",
+        "expression": "{ children: \"Cancel\" }",
         "inputs": [],
-        "props": []
+        "props": [
+          {
+            "key": "children",
+            "expression": "\"Cancel\"",
+            "inputs": []
+          }
+        ]
       }
     ],
     "exportConfirm": [
       {
         "file": "app/dialogs/export-components/ExportComponentsController.tsx",
         "component": "ExportComponentsDialog",
-        "line": 301,
+        "line": 316,
         "conditional": false,
         "expression": "{ onClick: save, \"aria-disabled\": exporting, style: confirmStyle }",
         "inputs": [
           {
             "name": "save",
             "declaredAt": {
-              "line": 42,
+              "line": 55,
               "kind": "parameter"
             }
           },
           {
             "name": "exporting",
             "declaredAt": {
-              "line": 42,
+              "line": 55,
               "kind": "parameter"
             }
           },
           {
             "name": "confirmStyle",
             "declaredAt": {
-              "line": 163,
+              "line": 176,
               "kind": "const"
             }
           }
@@ -1818,7 +1986,7 @@
               {
                 "name": "save",
                 "declaredAt": {
-                  "line": 42,
+                  "line": 55,
                   "kind": "parameter"
                 }
               }
@@ -1831,7 +1999,7 @@
               {
                 "name": "exporting",
                 "declaredAt": {
-                  "line": 42,
+                  "line": 55,
                   "kind": "parameter"
                 }
               }
@@ -1844,7 +2012,7 @@
               {
                 "name": "confirmStyle",
                 "declaredAt": {
-                  "line": 163,
+                  "line": 176,
                   "kind": "const"
                 }
               }
@@ -1857,32 +2025,64 @@
       {
         "file": "app/dialogs/export-components/ExportComponentsController.tsx",
         "component": "ExportComponentsDialog",
-        "line": 302,
+        "line": 317,
         "conditional": false,
-        "expression": "{}",
+        "expression": "{ children: \"Export\" }",
         "inputs": [],
-        "props": []
+        "props": [
+          {
+            "key": "children",
+            "expression": "\"Export\"",
+            "inputs": []
+          }
+        ]
       }
     ],
     "exportFieldset": [
       {
         "file": "app/dialogs/export-components/ExportComponentsController.tsx",
         "component": "ExportComponentsDialog",
-        "line": 222,
+        "line": 235,
         "conditional": false,
         "expression": "{}",
         "inputs": [],
         "props": []
       }
     ],
+    "exportFieldsetLabel": [
+      {
+        "file": "app/dialogs/export-components/ExportComponentsController.tsx",
+        "component": "ExportComponentsDialog",
+        "line": 236,
+        "conditional": false,
+        "expression": "{ children: \"Include\" }",
+        "inputs": [],
+        "props": [
+          {
+            "key": "children",
+            "expression": "\"Include\"",
+            "inputs": []
+          }
+        ]
+      }
+    ],
     "exportFontLinks": [
       {
         "file": "app/dialogs/export-components/ExportComponentsController.tsx",
         "component": "ExportComponentsDialog",
-        "line": 228,
+        "line": 243,
         "conditional": false,
-        "expression": "{ role: \"radiogroup\", \"aria-label\": \"Generate Google Font API Links\" }",
-        "inputs": [],
+        "expression": "{ role: \"radiogroup\", \"aria-label\": EXPORT_FLAG.fontLinks.ariaLabel }",
+        "inputs": [
+          {
+            "name": "EXPORT_FLAG",
+            "declaredAt": {
+              "line": 28,
+              "kind": "const",
+              "via": "EXPORT_FLAGS.reduce"
+            }
+          }
+        ],
         "props": [
           {
             "key": "role",
@@ -1891,8 +2091,17 @@
           },
           {
             "key": "aria-label",
-            "expression": "\"Generate Google Font API Links\"",
-            "inputs": []
+            "expression": "EXPORT_FLAG.fontLinks.ariaLabel",
+            "inputs": [
+              {
+                "name": "EXPORT_FLAG",
+                "declaredAt": {
+                  "line": 28,
+                  "kind": "const",
+                  "via": "EXPORT_FLAGS.reduce"
+                }
+              }
+            ]
           }
         ]
       }
@@ -1901,32 +2110,56 @@
       {
         "file": "app/dialogs/export-components/ExportComponentsController.tsx",
         "component": "ExportComponentsDialog",
-        "line": 229,
+        "line": 244,
         "conditional": false,
-        "expression": "{}",
-        "inputs": [],
-        "props": []
+        "expression": "{ children: EXPORT_FLAG.fontLinks.label }",
+        "inputs": [
+          {
+            "name": "EXPORT_FLAG",
+            "declaredAt": {
+              "line": 28,
+              "kind": "const",
+              "via": "EXPORT_FLAGS.reduce"
+            }
+          }
+        ],
+        "props": [
+          {
+            "key": "children",
+            "expression": "EXPORT_FLAG.fontLinks.label",
+            "inputs": [
+              {
+                "name": "EXPORT_FLAG",
+                "declaredAt": {
+                  "line": 28,
+                  "kind": "const",
+                  "via": "EXPORT_FLAGS.reduce"
+                }
+              }
+            ]
+          }
+        ]
       }
     ],
     "exportFontLinksNo": [
       {
         "file": "app/dialogs/export-components/ExportComponentsController.tsx",
         "component": "ExportComponentsDialog",
-        "line": 233,
+        "line": 248,
         "conditional": false,
         "expression": "radioRow(() => setFontLinks(false))",
         "inputs": [
           {
             "name": "radioRow",
             "declaredAt": {
-              "line": 337,
+              "line": 352,
               "kind": "function"
             }
           },
           {
             "name": "setFontLinks",
             "declaredAt": {
-              "line": 42,
+              "line": 55,
               "kind": "parameter"
             }
           }
@@ -1938,28 +2171,28 @@
       {
         "file": "app/dialogs/export-components/ExportComponentsController.tsx",
         "component": "ExportComponentsDialog",
-        "line": 234,
+        "line": 249,
         "conditional": false,
         "expression": "radioInput(\"export-font-links\", !fontLinks, () => setFontLinks(false))",
         "inputs": [
           {
             "name": "radioInput",
             "declaredAt": {
-              "line": 342,
+              "line": 357,
               "kind": "function"
             }
           },
           {
             "name": "fontLinks",
             "declaredAt": {
-              "line": 42,
+              "line": 55,
               "kind": "parameter"
             }
           },
           {
             "name": "setFontLinks",
             "declaredAt": {
-              "line": 42,
+              "line": 55,
               "kind": "parameter"
             }
           }
@@ -1971,32 +2204,38 @@
       {
         "file": "app/dialogs/export-components/ExportComponentsController.tsx",
         "component": "ExportComponentsDialog",
-        "line": 235,
+        "line": 250,
         "conditional": false,
-        "expression": "{}",
+        "expression": "{ children: \"No\" }",
         "inputs": [],
-        "props": []
+        "props": [
+          {
+            "key": "children",
+            "expression": "\"No\"",
+            "inputs": []
+          }
+        ]
       }
     ],
     "exportFontLinksYes": [
       {
         "file": "app/dialogs/export-components/ExportComponentsController.tsx",
         "component": "ExportComponentsDialog",
-        "line": 230,
+        "line": 245,
         "conditional": false,
         "expression": "radioRow(() => setFontLinks(true))",
         "inputs": [
           {
             "name": "radioRow",
             "declaredAt": {
-              "line": 337,
+              "line": 352,
               "kind": "function"
             }
           },
           {
             "name": "setFontLinks",
             "declaredAt": {
-              "line": 42,
+              "line": 55,
               "kind": "parameter"
             }
           }
@@ -2008,28 +2247,28 @@
       {
         "file": "app/dialogs/export-components/ExportComponentsController.tsx",
         "component": "ExportComponentsDialog",
-        "line": 231,
+        "line": 246,
         "conditional": false,
         "expression": "radioInput(\"export-font-links\", fontLinks, () => setFontLinks(true))",
         "inputs": [
           {
             "name": "radioInput",
             "declaredAt": {
-              "line": 342,
+              "line": 357,
               "kind": "function"
             }
           },
           {
             "name": "fontLinks",
             "declaredAt": {
-              "line": 42,
+              "line": 55,
               "kind": "parameter"
             }
           },
           {
             "name": "setFontLinks",
             "declaredAt": {
-              "line": 42,
+              "line": 55,
               "kind": "parameter"
             }
           }
@@ -2041,18 +2280,24 @@
       {
         "file": "app/dialogs/export-components/ExportComponentsController.tsx",
         "component": "ExportComponentsDialog",
-        "line": 232,
+        "line": 247,
         "conditional": false,
-        "expression": "{}",
+        "expression": "{ children: \"Yes\" }",
         "inputs": [],
-        "props": []
+        "props": [
+          {
+            "key": "children",
+            "expression": "\"Yes\"",
+            "inputs": []
+          }
+        ]
       }
     ],
     "exportFramework": [
       {
         "file": "app/dialogs/export-components/ExportComponentsController.tsx",
         "component": "ExportComponentsDialog",
-        "line": 190,
+        "line": 203,
         "conditional": false,
         "expression": "{}",
         "inputs": [],
@@ -2063,7 +2308,7 @@
       {
         "file": "app/dialogs/export-components/ExportComponentsController.tsx",
         "component": "ExportComponentsDialog",
-        "line": 192,
+        "line": 205,
         "conditional": false,
         "expression": "{}",
         "inputs": [],
@@ -2074,14 +2319,14 @@
       {
         "file": "app/dialogs/export-components/ExportComponentsController.tsx",
         "component": "ExportComponentsDialog",
-        "line": 193,
+        "line": 206,
         "conditional": false,
         "expression": "{ value: frameworkLabel, readOnly: true, onClick: openFramework, \"aria-expanded\": frameworkOpen, style: styles.opaquePointer, }",
         "inputs": [
           {
             "name": "frameworkLabel",
             "declaredAt": {
-              "line": 123,
+              "line": 136,
               "kind": "const",
               "via": "useMemo"
             }
@@ -2089,7 +2334,7 @@
           {
             "name": "openFramework",
             "declaredAt": {
-              "line": 99,
+              "line": 112,
               "kind": "const",
               "via": "useCallback"
             }
@@ -2097,7 +2342,7 @@
           {
             "name": "frameworkOpen",
             "declaredAt": {
-              "line": 90,
+              "line": 103,
               "kind": "const",
               "via": "useState"
             }
@@ -2105,7 +2350,7 @@
           {
             "name": "styles",
             "declaredAt": {
-              "line": 346,
+              "line": 361,
               "kind": "const"
             }
           }
@@ -2118,7 +2363,7 @@
               {
                 "name": "frameworkLabel",
                 "declaredAt": {
-                  "line": 123,
+                  "line": 136,
                   "kind": "const",
                   "via": "useMemo"
                 }
@@ -2137,7 +2382,7 @@
               {
                 "name": "openFramework",
                 "declaredAt": {
-                  "line": 99,
+                  "line": 112,
                   "kind": "const",
                   "via": "useCallback"
                 }
@@ -2151,7 +2396,7 @@
               {
                 "name": "frameworkOpen",
                 "declaredAt": {
-                  "line": 90,
+                  "line": 103,
                   "kind": "const",
                   "via": "useState"
                 }
@@ -2165,7 +2410,7 @@
               {
                 "name": "styles",
                 "declaredAt": {
-                  "line": 346,
+                  "line": 361,
                   "kind": "const"
                 }
               }
@@ -2178,21 +2423,36 @@
       {
         "file": "app/dialogs/export-components/ExportComponentsController.tsx",
         "component": "ExportComponentsDialog",
-        "line": 191,
+        "line": 204,
         "conditional": false,
-        "expression": "{}",
+        "expression": "{ children: \"Framework\" }",
         "inputs": [],
-        "props": []
+        "props": [
+          {
+            "key": "children",
+            "expression": "\"Framework\"",
+            "inputs": []
+          }
+        ]
       }
     ],
     "exportHidden": [
       {
         "file": "app/dialogs/export-components/ExportComponentsController.tsx",
         "component": "ExportComponentsDialog",
-        "line": 237,
+        "line": 252,
         "conditional": false,
-        "expression": "{ role: \"radiogroup\", \"aria-label\": \"Hidden Components\" }",
-        "inputs": [],
+        "expression": "{ role: \"radiogroup\", \"aria-label\": EXPORT_FLAG.includeHidden.ariaLabel }",
+        "inputs": [
+          {
+            "name": "EXPORT_FLAG",
+            "declaredAt": {
+              "line": 28,
+              "kind": "const",
+              "via": "EXPORT_FLAGS.reduce"
+            }
+          }
+        ],
         "props": [
           {
             "key": "role",
@@ -2201,8 +2461,17 @@
           },
           {
             "key": "aria-label",
-            "expression": "\"Hidden Components\"",
-            "inputs": []
+            "expression": "EXPORT_FLAG.includeHidden.ariaLabel",
+            "inputs": [
+              {
+                "name": "EXPORT_FLAG",
+                "declaredAt": {
+                  "line": 28,
+                  "kind": "const",
+                  "via": "EXPORT_FLAGS.reduce"
+                }
+              }
+            ]
           }
         ]
       }
@@ -2211,32 +2480,56 @@
       {
         "file": "app/dialogs/export-components/ExportComponentsController.tsx",
         "component": "ExportComponentsDialog",
-        "line": 238,
+        "line": 253,
         "conditional": false,
-        "expression": "{}",
-        "inputs": [],
-        "props": []
+        "expression": "{ children: EXPORT_FLAG.includeHidden.label }",
+        "inputs": [
+          {
+            "name": "EXPORT_FLAG",
+            "declaredAt": {
+              "line": 28,
+              "kind": "const",
+              "via": "EXPORT_FLAGS.reduce"
+            }
+          }
+        ],
+        "props": [
+          {
+            "key": "children",
+            "expression": "EXPORT_FLAG.includeHidden.label",
+            "inputs": [
+              {
+                "name": "EXPORT_FLAG",
+                "declaredAt": {
+                  "line": 28,
+                  "kind": "const",
+                  "via": "EXPORT_FLAGS.reduce"
+                }
+              }
+            ]
+          }
+        ]
       }
     ],
     "exportHiddenNo": [
       {
         "file": "app/dialogs/export-components/ExportComponentsController.tsx",
         "component": "ExportComponentsDialog",
-        "line": 242,
+        "line": 257,
         "conditional": false,
         "expression": "radioRow(() => setIncludeHidden(false))",
         "inputs": [
           {
             "name": "radioRow",
             "declaredAt": {
-              "line": 337,
+              "line": 352,
               "kind": "function"
             }
           },
           {
             "name": "setIncludeHidden",
             "declaredAt": {
-              "line": 42,
+              "line": 55,
               "kind": "parameter"
             }
           }
@@ -2248,28 +2541,28 @@
       {
         "file": "app/dialogs/export-components/ExportComponentsController.tsx",
         "component": "ExportComponentsDialog",
-        "line": 243,
+        "line": 258,
         "conditional": false,
         "expression": "radioInput(\"export-hidden\", !includeHidden, () => setIncludeHidden(false))",
         "inputs": [
           {
             "name": "radioInput",
             "declaredAt": {
-              "line": 342,
+              "line": 357,
               "kind": "function"
             }
           },
           {
             "name": "includeHidden",
             "declaredAt": {
-              "line": 42,
+              "line": 55,
               "kind": "parameter"
             }
           },
           {
             "name": "setIncludeHidden",
             "declaredAt": {
-              "line": 42,
+              "line": 55,
               "kind": "parameter"
             }
           }
@@ -2281,32 +2574,38 @@
       {
         "file": "app/dialogs/export-components/ExportComponentsController.tsx",
         "component": "ExportComponentsDialog",
-        "line": 244,
+        "line": 259,
         "conditional": false,
-        "expression": "{}",
+        "expression": "{ children: \"No\" }",
         "inputs": [],
-        "props": []
+        "props": [
+          {
+            "key": "children",
+            "expression": "\"No\"",
+            "inputs": []
+          }
+        ]
       }
     ],
     "exportHiddenYes": [
       {
         "file": "app/dialogs/export-components/ExportComponentsController.tsx",
         "component": "ExportComponentsDialog",
-        "line": 239,
+        "line": 254,
         "conditional": false,
         "expression": "radioRow(() => setIncludeHidden(true))",
         "inputs": [
           {
             "name": "radioRow",
             "declaredAt": {
-              "line": 337,
+              "line": 352,
               "kind": "function"
             }
           },
           {
             "name": "setIncludeHidden",
             "declaredAt": {
-              "line": 42,
+              "line": 55,
               "kind": "parameter"
             }
           }
@@ -2318,28 +2617,28 @@
       {
         "file": "app/dialogs/export-components/ExportComponentsController.tsx",
         "component": "ExportComponentsDialog",
-        "line": 240,
+        "line": 255,
         "conditional": false,
         "expression": "radioInput(\"export-hidden\", includeHidden, () => setIncludeHidden(true))",
         "inputs": [
           {
             "name": "radioInput",
             "declaredAt": {
-              "line": 342,
+              "line": 357,
               "kind": "function"
             }
           },
           {
             "name": "includeHidden",
             "declaredAt": {
-              "line": 42,
+              "line": 55,
               "kind": "parameter"
             }
           },
           {
             "name": "setIncludeHidden",
             "declaredAt": {
-              "line": 42,
+              "line": 55,
               "kind": "parameter"
             }
           }
@@ -2351,18 +2650,24 @@
       {
         "file": "app/dialogs/export-components/ExportComponentsController.tsx",
         "component": "ExportComponentsDialog",
-        "line": 241,
+        "line": 256,
         "conditional": false,
-        "expression": "{}",
+        "expression": "{ children: \"Yes\" }",
         "inputs": [],
-        "props": []
+        "props": [
+          {
+            "key": "children",
+            "expression": "\"Yes\"",
+            "inputs": []
+          }
+        ]
       }
     ],
     "exportPlatform": [
       {
         "file": "app/dialogs/export-components/ExportComponentsController.tsx",
         "component": "ExportComponentsDialog",
-        "line": 201,
+        "line": 214,
         "conditional": false,
         "expression": "{}",
         "inputs": [],
@@ -2373,7 +2678,7 @@
       {
         "file": "app/dialogs/export-components/ExportComponentsController.tsx",
         "component": "ExportComponentsDialog",
-        "line": 203,
+        "line": 216,
         "conditional": false,
         "expression": "{}",
         "inputs": [],
@@ -2384,14 +2689,14 @@
       {
         "file": "app/dialogs/export-components/ExportComponentsController.tsx",
         "component": "ExportComponentsDialog",
-        "line": 204,
+        "line": 217,
         "conditional": false,
         "expression": "{ value: platformLabel, readOnly: true, onClick: openPlatform, \"aria-expanded\": platformOpen, style: styles.opaquePointer, }",
         "inputs": [
           {
             "name": "platformLabel",
             "declaredAt": {
-              "line": 105,
+              "line": 118,
               "kind": "const",
               "via": "useMemo"
             }
@@ -2399,7 +2704,7 @@
           {
             "name": "openPlatform",
             "declaredAt": {
-              "line": 93,
+              "line": 106,
               "kind": "const",
               "via": "useCallback"
             }
@@ -2407,7 +2712,7 @@
           {
             "name": "platformOpen",
             "declaredAt": {
-              "line": 88,
+              "line": 101,
               "kind": "const",
               "via": "useState"
             }
@@ -2415,7 +2720,7 @@
           {
             "name": "styles",
             "declaredAt": {
-              "line": 346,
+              "line": 361,
               "kind": "const"
             }
           }
@@ -2428,7 +2733,7 @@
               {
                 "name": "platformLabel",
                 "declaredAt": {
-                  "line": 105,
+                  "line": 118,
                   "kind": "const",
                   "via": "useMemo"
                 }
@@ -2447,7 +2752,7 @@
               {
                 "name": "openPlatform",
                 "declaredAt": {
-                  "line": 93,
+                  "line": 106,
                   "kind": "const",
                   "via": "useCallback"
                 }
@@ -2461,7 +2766,7 @@
               {
                 "name": "platformOpen",
                 "declaredAt": {
-                  "line": 88,
+                  "line": 101,
                   "kind": "const",
                   "via": "useState"
                 }
@@ -2475,7 +2780,7 @@
               {
                 "name": "styles",
                 "declaredAt": {
-                  "line": 346,
+                  "line": 361,
                   "kind": "const"
                 }
               }
@@ -2488,18 +2793,24 @@
       {
         "file": "app/dialogs/export-components/ExportComponentsController.tsx",
         "component": "ExportComponentsDialog",
-        "line": 202,
+        "line": 215,
         "conditional": false,
-        "expression": "{}",
+        "expression": "{ children: \"Platform\" }",
         "inputs": [],
-        "props": []
+        "props": [
+          {
+            "key": "children",
+            "expression": "\"Platform\"",
+            "inputs": []
+          }
+        ]
       }
     ],
     "exportProjectFolder": [
       {
         "file": "app/dialogs/export-components/ExportComponentsController.tsx",
         "component": "ExportComponentsDialog",
-        "line": 212,
+        "line": 225,
         "conditional": false,
         "expression": "{}",
         "inputs": [],
@@ -2510,28 +2821,28 @@
       {
         "file": "app/dialogs/export-components/ExportComponentsController.tsx",
         "component": "ExportComponentsDialog",
-        "line": 214,
+        "line": 227,
         "conditional": false,
         "expression": "{ value: directoryLabel, placeholder: \"Choose a folder…\", readOnly: true, onClick: chooseDirectory, style: styles.opaquePointer, }",
         "inputs": [
           {
             "name": "directoryLabel",
             "declaredAt": {
-              "line": 158,
+              "line": 171,
               "kind": "const"
             }
           },
           {
             "name": "chooseDirectory",
             "declaredAt": {
-              "line": 42,
+              "line": 55,
               "kind": "parameter"
             }
           },
           {
             "name": "styles",
             "declaredAt": {
-              "line": 346,
+              "line": 361,
               "kind": "const"
             }
           }
@@ -2544,7 +2855,7 @@
               {
                 "name": "directoryLabel",
                 "declaredAt": {
-                  "line": 158,
+                  "line": 171,
                   "kind": "const"
                 }
               }
@@ -2567,7 +2878,7 @@
               {
                 "name": "chooseDirectory",
                 "declaredAt": {
-                  "line": 42,
+                  "line": 55,
                   "kind": "parameter"
                 }
               }
@@ -2580,7 +2891,7 @@
               {
                 "name": "styles",
                 "declaredAt": {
-                  "line": 346,
+                  "line": 361,
                   "kind": "const"
                 }
               }
@@ -2593,21 +2904,36 @@
       {
         "file": "app/dialogs/export-components/ExportComponentsController.tsx",
         "component": "ExportComponentsDialog",
-        "line": 213,
+        "line": 226,
         "conditional": false,
-        "expression": "{}",
+        "expression": "{ children: \"Project Folder\" }",
         "inputs": [],
-        "props": []
+        "props": [
+          {
+            "key": "children",
+            "expression": "\"Project Folder\"",
+            "inputs": []
+          }
+        ]
       }
     ],
     "exportScripts": [
       {
         "file": "app/dialogs/export-components/ExportComponentsController.tsx",
         "component": "ExportComponentsDialog",
-        "line": 286,
+        "line": 301,
         "conditional": false,
-        "expression": "{ role: \"radiogroup\", \"aria-label\": \"CLI Utility Scripts\" }",
-        "inputs": [],
+        "expression": "{ role: \"radiogroup\", \"aria-label\": EXPORT_FLAG.includeScripts.ariaLabel }",
+        "inputs": [
+          {
+            "name": "EXPORT_FLAG",
+            "declaredAt": {
+              "line": 28,
+              "kind": "const",
+              "via": "EXPORT_FLAGS.reduce"
+            }
+          }
+        ],
         "props": [
           {
             "key": "role",
@@ -2616,8 +2942,17 @@
           },
           {
             "key": "aria-label",
-            "expression": "\"CLI Utility Scripts\"",
-            "inputs": []
+            "expression": "EXPORT_FLAG.includeScripts.ariaLabel",
+            "inputs": [
+              {
+                "name": "EXPORT_FLAG",
+                "declaredAt": {
+                  "line": 28,
+                  "kind": "const",
+                  "via": "EXPORT_FLAGS.reduce"
+                }
+              }
+            ]
           }
         ]
       }
@@ -2626,32 +2961,56 @@
       {
         "file": "app/dialogs/export-components/ExportComponentsController.tsx",
         "component": "ExportComponentsDialog",
-        "line": 287,
+        "line": 302,
         "conditional": false,
-        "expression": "{}",
-        "inputs": [],
-        "props": []
+        "expression": "{ children: EXPORT_FLAG.includeScripts.label }",
+        "inputs": [
+          {
+            "name": "EXPORT_FLAG",
+            "declaredAt": {
+              "line": 28,
+              "kind": "const",
+              "via": "EXPORT_FLAGS.reduce"
+            }
+          }
+        ],
+        "props": [
+          {
+            "key": "children",
+            "expression": "EXPORT_FLAG.includeScripts.label",
+            "inputs": [
+              {
+                "name": "EXPORT_FLAG",
+                "declaredAt": {
+                  "line": 28,
+                  "kind": "const",
+                  "via": "EXPORT_FLAGS.reduce"
+                }
+              }
+            ]
+          }
+        ]
       }
     ],
     "exportScriptsNo": [
       {
         "file": "app/dialogs/export-components/ExportComponentsController.tsx",
         "component": "ExportComponentsDialog",
-        "line": 293,
+        "line": 308,
         "conditional": false,
         "expression": "radioRow(() => setIncludeScripts(false))",
         "inputs": [
           {
             "name": "radioRow",
             "declaredAt": {
-              "line": 337,
+              "line": 352,
               "kind": "function"
             }
           },
           {
             "name": "setIncludeScripts",
             "declaredAt": {
-              "line": 42,
+              "line": 55,
               "kind": "parameter"
             }
           }
@@ -2663,28 +3022,28 @@
       {
         "file": "app/dialogs/export-components/ExportComponentsController.tsx",
         "component": "ExportComponentsDialog",
-        "line": 294,
+        "line": 309,
         "conditional": false,
         "expression": "radioInput(\"export-scripts\", !includeScripts, () => setIncludeScripts(false), )",
         "inputs": [
           {
             "name": "radioInput",
             "declaredAt": {
-              "line": 342,
+              "line": 357,
               "kind": "function"
             }
           },
           {
             "name": "includeScripts",
             "declaredAt": {
-              "line": 42,
+              "line": 55,
               "kind": "parameter"
             }
           },
           {
             "name": "setIncludeScripts",
             "declaredAt": {
-              "line": 42,
+              "line": 55,
               "kind": "parameter"
             }
           }
@@ -2696,32 +3055,38 @@
       {
         "file": "app/dialogs/export-components/ExportComponentsController.tsx",
         "component": "ExportComponentsDialog",
-        "line": 297,
+        "line": 312,
         "conditional": false,
-        "expression": "{}",
+        "expression": "{ children: \"No\" }",
         "inputs": [],
-        "props": []
+        "props": [
+          {
+            "key": "children",
+            "expression": "\"No\"",
+            "inputs": []
+          }
+        ]
       }
     ],
     "exportScriptsYes": [
       {
         "file": "app/dialogs/export-components/ExportComponentsController.tsx",
         "component": "ExportComponentsDialog",
-        "line": 288,
+        "line": 303,
         "conditional": false,
         "expression": "radioRow(() => setIncludeScripts(true))",
         "inputs": [
           {
             "name": "radioRow",
             "declaredAt": {
-              "line": 337,
+              "line": 352,
               "kind": "function"
             }
           },
           {
             "name": "setIncludeScripts",
             "declaredAt": {
-              "line": 42,
+              "line": 55,
               "kind": "parameter"
             }
           }
@@ -2733,28 +3098,28 @@
       {
         "file": "app/dialogs/export-components/ExportComponentsController.tsx",
         "component": "ExportComponentsDialog",
-        "line": 289,
+        "line": 304,
         "conditional": false,
         "expression": "radioInput(\"export-scripts\", includeScripts, () => setIncludeScripts(true), )",
         "inputs": [
           {
             "name": "radioInput",
             "declaredAt": {
-              "line": 342,
+              "line": 357,
               "kind": "function"
             }
           },
           {
             "name": "includeScripts",
             "declaredAt": {
-              "line": 42,
+              "line": 55,
               "kind": "parameter"
             }
           },
           {
             "name": "setIncludeScripts",
             "declaredAt": {
-              "line": 42,
+              "line": 55,
               "kind": "parameter"
             }
           }
@@ -2766,32 +3131,53 @@
       {
         "file": "app/dialogs/export-components/ExportComponentsController.tsx",
         "component": "ExportComponentsDialog",
-        "line": 292,
+        "line": 307,
         "conditional": false,
-        "expression": "{}",
+        "expression": "{ children: \"Yes\" }",
         "inputs": [],
-        "props": []
+        "props": [
+          {
+            "key": "children",
+            "expression": "\"Yes\"",
+            "inputs": []
+          }
+        ]
       }
     ],
     "exportTitle": [
       {
         "file": "app/dialogs/export-components/ExportComponentsController.tsx",
         "component": "ExportComponentsDialog",
-        "line": 177,
+        "line": 190,
         "conditional": false,
-        "expression": "{}",
+        "expression": "{ children: \"Export Components\" }",
         "inputs": [],
-        "props": []
+        "props": [
+          {
+            "key": "children",
+            "expression": "\"Export Components\"",
+            "inputs": []
+          }
+        ]
       }
     ],
     "exportWorkspace": [
       {
         "file": "app/dialogs/export-components/ExportComponentsController.tsx",
         "component": "ExportComponentsDialog",
-        "line": 273,
+        "line": 288,
         "conditional": false,
-        "expression": "{ role: \"radiogroup\", \"aria-label\": \"Workspace File\" }",
-        "inputs": [],
+        "expression": "{ role: \"radiogroup\", \"aria-label\": EXPORT_FLAG.savedWorkspace.ariaLabel }",
+        "inputs": [
+          {
+            "name": "EXPORT_FLAG",
+            "declaredAt": {
+              "line": 28,
+              "kind": "const",
+              "via": "EXPORT_FLAGS.reduce"
+            }
+          }
+        ],
         "props": [
           {
             "key": "role",
@@ -2800,8 +3186,17 @@
           },
           {
             "key": "aria-label",
-            "expression": "\"Workspace File\"",
-            "inputs": []
+            "expression": "EXPORT_FLAG.savedWorkspace.ariaLabel",
+            "inputs": [
+              {
+                "name": "EXPORT_FLAG",
+                "declaredAt": {
+                  "line": 28,
+                  "kind": "const",
+                  "via": "EXPORT_FLAGS.reduce"
+                }
+              }
+            ]
           }
         ]
       }
@@ -2810,18 +3205,42 @@
       {
         "file": "app/dialogs/export-components/ExportComponentsController.tsx",
         "component": "ExportComponentsDialog",
-        "line": 274,
+        "line": 289,
         "conditional": false,
-        "expression": "{}",
-        "inputs": [],
-        "props": []
+        "expression": "{ children: EXPORT_FLAG.savedWorkspace.label }",
+        "inputs": [
+          {
+            "name": "EXPORT_FLAG",
+            "declaredAt": {
+              "line": 28,
+              "kind": "const",
+              "via": "EXPORT_FLAGS.reduce"
+            }
+          }
+        ],
+        "props": [
+          {
+            "key": "children",
+            "expression": "EXPORT_FLAG.savedWorkspace.label",
+            "inputs": [
+              {
+                "name": "EXPORT_FLAG",
+                "declaredAt": {
+                  "line": 28,
+                  "kind": "const",
+                  "via": "EXPORT_FLAGS.reduce"
+                }
+              }
+            ]
+          }
+        ]
       }
     ],
     "exportWorkspaceName": [
       {
         "file": "app/dialogs/export-components/ExportComponentsController.tsx",
         "component": "ExportComponentsDialog",
-        "line": 179,
+        "line": 192,
         "conditional": false,
         "expression": "{}",
         "inputs": [],
@@ -2832,21 +3251,21 @@
       {
         "file": "app/dialogs/export-components/ExportComponentsController.tsx",
         "component": "ExportComponentsDialog",
-        "line": 181,
+        "line": 194,
         "conditional": false,
         "expression": "{ value: workspaceName, placeholder: \"Untitled workspace\", onChange: changeWorkspaceName, onBlur: commitWorkspaceName, onKeyDown: commitNameOnEnter, style: styl...",
         "inputs": [
           {
             "name": "workspaceName",
             "declaredAt": {
-              "line": 42,
+              "line": 55,
               "kind": "parameter"
             }
           },
           {
             "name": "changeWorkspaceName",
             "declaredAt": {
-              "line": 141,
+              "line": 154,
               "kind": "const",
               "via": "useCallback"
             }
@@ -2854,14 +3273,14 @@
           {
             "name": "commitWorkspaceName",
             "declaredAt": {
-              "line": 42,
+              "line": 55,
               "kind": "parameter"
             }
           },
           {
             "name": "commitNameOnEnter",
             "declaredAt": {
-              "line": 148,
+              "line": 161,
               "kind": "const",
               "via": "useCallback"
             }
@@ -2869,7 +3288,7 @@
           {
             "name": "styles",
             "declaredAt": {
-              "line": 346,
+              "line": 361,
               "kind": "const"
             }
           }
@@ -2882,7 +3301,7 @@
               {
                 "name": "workspaceName",
                 "declaredAt": {
-                  "line": 42,
+                  "line": 55,
                   "kind": "parameter"
                 }
               }
@@ -2900,7 +3319,7 @@
               {
                 "name": "changeWorkspaceName",
                 "declaredAt": {
-                  "line": 141,
+                  "line": 154,
                   "kind": "const",
                   "via": "useCallback"
                 }
@@ -2914,7 +3333,7 @@
               {
                 "name": "commitWorkspaceName",
                 "declaredAt": {
-                  "line": 42,
+                  "line": 55,
                   "kind": "parameter"
                 }
               }
@@ -2927,7 +3346,7 @@
               {
                 "name": "commitNameOnEnter",
                 "declaredAt": {
-                  "line": 148,
+                  "line": 161,
                   "kind": "const",
                   "via": "useCallback"
                 }
@@ -2941,7 +3360,7 @@
               {
                 "name": "styles",
                 "declaredAt": {
-                  "line": 346,
+                  "line": 361,
                   "kind": "const"
                 }
               }
@@ -2954,32 +3373,38 @@
       {
         "file": "app/dialogs/export-components/ExportComponentsController.tsx",
         "component": "ExportComponentsDialog",
-        "line": 180,
+        "line": 193,
         "conditional": false,
-        "expression": "{}",
+        "expression": "{ children: \"Workspace Name\" }",
         "inputs": [],
-        "props": []
+        "props": [
+          {
+            "key": "children",
+            "expression": "\"Workspace Name\"",
+            "inputs": []
+          }
+        ]
       }
     ],
     "exportWorkspaceNo": [
       {
         "file": "app/dialogs/export-components/ExportComponentsController.tsx",
         "component": "ExportComponentsDialog",
-        "line": 280,
+        "line": 295,
         "conditional": false,
         "expression": "radioRow(() => setSavedWorkspace(false))",
         "inputs": [
           {
             "name": "radioRow",
             "declaredAt": {
-              "line": 337,
+              "line": 352,
               "kind": "function"
             }
           },
           {
             "name": "setSavedWorkspace",
             "declaredAt": {
-              "line": 42,
+              "line": 55,
               "kind": "parameter"
             }
           }
@@ -2991,28 +3416,28 @@
       {
         "file": "app/dialogs/export-components/ExportComponentsController.tsx",
         "component": "ExportComponentsDialog",
-        "line": 281,
+        "line": 296,
         "conditional": false,
         "expression": "radioInput(\"export-saved-workspace\", !savedWorkspace, () => setSavedWorkspace(false), )",
         "inputs": [
           {
             "name": "radioInput",
             "declaredAt": {
-              "line": 342,
+              "line": 357,
               "kind": "function"
             }
           },
           {
             "name": "savedWorkspace",
             "declaredAt": {
-              "line": 42,
+              "line": 55,
               "kind": "parameter"
             }
           },
           {
             "name": "setSavedWorkspace",
             "declaredAt": {
-              "line": 42,
+              "line": 55,
               "kind": "parameter"
             }
           }
@@ -3024,32 +3449,38 @@
       {
         "file": "app/dialogs/export-components/ExportComponentsController.tsx",
         "component": "ExportComponentsDialog",
-        "line": 284,
+        "line": 299,
         "conditional": false,
-        "expression": "{}",
+        "expression": "{ children: \"No\" }",
         "inputs": [],
-        "props": []
+        "props": [
+          {
+            "key": "children",
+            "expression": "\"No\"",
+            "inputs": []
+          }
+        ]
       }
     ],
     "exportWorkspaceYes": [
       {
         "file": "app/dialogs/export-components/ExportComponentsController.tsx",
         "component": "ExportComponentsDialog",
-        "line": 275,
+        "line": 290,
         "conditional": false,
         "expression": "radioRow(() => setSavedWorkspace(true))",
         "inputs": [
           {
             "name": "radioRow",
             "declaredAt": {
-              "line": 337,
+              "line": 352,
               "kind": "function"
             }
           },
           {
             "name": "setSavedWorkspace",
             "declaredAt": {
-              "line": 42,
+              "line": 55,
               "kind": "parameter"
             }
           }
@@ -3061,28 +3492,28 @@
       {
         "file": "app/dialogs/export-components/ExportComponentsController.tsx",
         "component": "ExportComponentsDialog",
-        "line": 276,
+        "line": 291,
         "conditional": false,
         "expression": "radioInput(\"export-saved-workspace\", savedWorkspace, () => setSavedWorkspace(true), )",
         "inputs": [
           {
             "name": "radioInput",
             "declaredAt": {
-              "line": 342,
+              "line": 357,
               "kind": "function"
             }
           },
           {
             "name": "savedWorkspace",
             "declaredAt": {
-              "line": 42,
+              "line": 55,
               "kind": "parameter"
             }
           },
           {
             "name": "setSavedWorkspace",
             "declaredAt": {
-              "line": 42,
+              "line": 55,
               "kind": "parameter"
             }
           }
@@ -3094,11 +3525,17 @@
       {
         "file": "app/dialogs/export-components/ExportComponentsController.tsx",
         "component": "ExportComponentsDialog",
-        "line": 279,
+        "line": 294,
         "conditional": false,
-        "expression": "{}",
+        "expression": "{ children: \"Yes\" }",
         "inputs": [],
-        "props": []
+        "props": [
+          {
+            "key": "children",
+            "expression": "\"Yes\"",
+            "inputs": []
+          }
+        ]
       }
     ],
     "filterField": [
@@ -11895,13 +12332,13 @@
         {
           "file": "app/dialogs/export-components/ExportComponentsController.tsx",
           "component": "ExportComponentsDialog",
-          "line": 317,
+          "line": 332,
           "expression": "barHandle",
           "inputs": [
             {
               "name": "barHandle",
               "declaredAt": {
-                "line": 165,
+                "line": 178,
                 "kind": "const",
                 "via": "useMemo"
               }

--- a/packages/editor/apps/vue/app/dialogs/ExportDialog.vue
+++ b/packages/editor/apps/vue/app/dialogs/ExportDialog.vue
@@ -13,6 +13,7 @@ import { useWorkspace } from "@app/workspace/use-workspace"
 import DialogExportComponent from "@seldon/components/modules/DialogExportComponent.vue"
 import { pickExportDirectory } from "@seldon/editor/lib/export/write-export-to-directory"
 import { getExportTarget, saveExportTarget } from "@seldon/editor/lib/storage/export-target-store"
+import { EXPORT_FLAGS } from "@seldon/factory/export/options"
 import { PLATFORM_LIST } from "@seldon/factory/export/platforms/registry"
 import { FRAMEWORK_IDS, resolveOutputLayout } from "@seldon/factory/export/presets"
 import { storeToRefs } from "pinia"
@@ -20,11 +21,23 @@ import { computed, ref, watch } from "vue"
 
 import type { MenuEntry } from "@app/menus/types"
 import type { LocalExportOptions } from "@seldon/editor/lib/export/run-local-export"
+import type { ExportFlagDescriptor, ExportScopeFlags } from "@seldon/factory/export/options"
 import type { FrameworkId } from "@seldon/factory/export/presets"
 import type { CSSProperties } from "vue"
 
 /** Upper bound on a workspace name, matching the inline project rename. */
 const MAX_WORKSPACE_NAME_LENGTH = 200
+
+/**
+ * Every scope flag keyed by its store name, so the dialog reads its group label
+ * and aria-label from the shared export flag descriptors. This keeps the copy in
+ * step with the CLI and the MCP host, and a flag rename lands here without
+ * editing the design.
+ */
+const EXPORT_FLAG = EXPORT_FLAGS.reduce(
+  (lookup, flag) => ({ ...lookup, [flag.storeKey]: flag }),
+  {} as Record<keyof ExportScopeFlags, ExportFlagDescriptor>,
+)
 
 const EXPORT_PLATFORM_OPTIONS = PLATFORM_LIST.map((platform) => ({
   id: platform.id,
@@ -307,10 +320,10 @@ const barHandle = computed(() => ({
 // so the bindings scanner reads every ref; see `.cursor/rules/foundation-editor-jsx.mdc`.
 // Display-only slots turn on with an empty object; behavior rides in per ref.
 const seldonRefs = computed<Record<string, Record<string, unknown>>>(() => ({
-  exportTitle: {},
+  exportTitle: { children: "Export Components" },
 
   exportWorkspaceName: {},
-  exportWorkspaceNameLabel: {},
+  exportWorkspaceNameLabel: { children: "Workspace Name" },
   exportWorkspaceNameField: {
     value: workspaceName.value,
     placeholder: "Untitled workspace",
@@ -321,7 +334,7 @@ const seldonRefs = computed<Record<string, Record<string, unknown>>>(() => ({
   },
 
   exportFramework: {},
-  exportFrameworkLabel: {},
+  exportFrameworkLabel: { children: "Framework" },
   exportFrameworkCombobox: {},
   exportFrameworkField: {
     value: frameworkLabel.value,
@@ -332,7 +345,7 @@ const seldonRefs = computed<Record<string, Record<string, unknown>>>(() => ({
   },
 
   exportPlatform: {},
-  exportPlatformLabel: {},
+  exportPlatformLabel: { children: "Platform" },
   exportPlatformCombobox: {},
   exportPlatformField: {
     value: platformLabel.value,
@@ -343,7 +356,7 @@ const seldonRefs = computed<Record<string, Record<string, unknown>>>(() => ({
   },
 
   exportProjectFolder: {},
-  exportProjectFolderLabel: {},
+  exportProjectFolderLabel: { children: "Project Folder" },
   exportProjectFolderField: {
     value: directoryLabel.value,
     placeholder: "Choose a folder…",
@@ -353,138 +366,139 @@ const seldonRefs = computed<Record<string, Record<string, unknown>>>(() => ({
   },
 
   exportFieldset: {},
+  exportFieldsetLabel: { children: "Include" },
 
   // Scope groups. Every key is spelled out, never built in a loop, so the
   // bindings scanner records each ref. The container holds the radiogroup role,
   // each row widens the hit area, and each native input holds the group name plus
   // checked state.
-  exportFontLinks: { role: "radiogroup", "aria-label": "Generate Google Font API Links" },
-  exportFontLinksLabel: {},
+  exportFontLinks: { role: "radiogroup", "aria-label": EXPORT_FLAG.fontLinks.ariaLabel },
+  exportFontLinksLabel: { children: EXPORT_FLAG.fontLinks.label },
   exportFontLinksYes: radioRow(() => (fontLinks.value = true)),
   exportFontLinksYesInput: radioInput(
     "export-font-links",
     fontLinks.value,
     () => (fontLinks.value = true),
   ),
-  exportFontLinksYesText: {},
+  exportFontLinksYesText: { children: "Yes" },
   exportFontLinksNo: radioRow(() => (fontLinks.value = false)),
   exportFontLinksNoInput: radioInput(
     "export-font-links",
     !fontLinks.value,
     () => (fontLinks.value = false),
   ),
-  exportFontLinksNoText: {},
+  exportFontLinksNoText: { children: "No" },
 
-  exportHidden: { role: "radiogroup", "aria-label": "Hidden Components" },
-  exportHiddenLabel: {},
+  exportHidden: { role: "radiogroup", "aria-label": EXPORT_FLAG.includeHidden.ariaLabel },
+  exportHiddenLabel: { children: EXPORT_FLAG.includeHidden.label },
   exportHiddenYes: radioRow(() => (includeHidden.value = true)),
   exportHiddenYesInput: radioInput(
     "export-hidden",
     includeHidden.value,
     () => (includeHidden.value = true),
   ),
-  exportHiddenYesText: {},
+  exportHiddenYesText: { children: "Yes" },
   exportHiddenNo: radioRow(() => (includeHidden.value = false)),
   exportHiddenNoInput: radioInput(
     "export-hidden",
     !includeHidden.value,
     () => (includeHidden.value = false),
   ),
-  exportHiddenNoText: {},
+  exportHiddenNoText: { children: "No" },
 
-  exportAllThemes: { role: "radiogroup", "aria-label": "All Themes" },
-  exportAllThemesLabel: {},
+  exportAllThemes: { role: "radiogroup", "aria-label": EXPORT_FLAG.allThemes.ariaLabel },
+  exportAllThemesLabel: { children: EXPORT_FLAG.allThemes.label },
   exportAllThemesYes: radioRow(() => (allThemes.value = true)),
   exportAllThemesYesInput: radioInput(
     "export-all-themes",
     allThemes.value,
     () => (allThemes.value = true),
   ),
-  exportAllThemesYesText: {},
+  exportAllThemesYesText: { children: "Yes" },
   exportAllThemesNo: radioRow(() => (allThemes.value = false)),
   exportAllThemesNoInput: radioInput(
     "export-all-themes",
     !allThemes.value,
     () => (allThemes.value = false),
   ),
-  exportAllThemesNoText: {},
+  exportAllThemesNoText: { children: "No" },
 
-  exportAllFonts: { role: "radiogroup", "aria-label": "All Enabled Fonts" },
-  exportAllFontsLabel: {},
+  exportAllFonts: { role: "radiogroup", "aria-label": EXPORT_FLAG.allFonts.ariaLabel },
+  exportAllFontsLabel: { children: EXPORT_FLAG.allFonts.label },
   exportAllFontsYes: radioRow(() => (allFonts.value = true)),
   exportAllFontsYesInput: radioInput(
     "export-all-fonts",
     allFonts.value,
     () => (allFonts.value = true),
   ),
-  exportAllFontsYesText: {},
+  exportAllFontsYesText: { children: "Yes" },
   exportAllFontsNo: radioRow(() => (allFonts.value = false)),
   exportAllFontsNoInput: radioInput(
     "export-all-fonts",
     !allFonts.value,
     () => (allFonts.value = false),
   ),
-  exportAllFontsNoText: {},
+  exportAllFontsNoText: { children: "No" },
 
-  exportAllIcons: { role: "radiogroup", "aria-label": "All Enabled Icons" },
-  exportAllIconsLabel: {},
+  exportAllIcons: { role: "radiogroup", "aria-label": EXPORT_FLAG.allIcons.ariaLabel },
+  exportAllIconsLabel: { children: EXPORT_FLAG.allIcons.label },
   exportAllIconsYes: radioRow(() => (allIcons.value = true)),
   exportAllIconsYesInput: radioInput(
     "export-all-icons",
     allIcons.value,
     () => (allIcons.value = true),
   ),
-  exportAllIconsYesText: {},
+  exportAllIconsYesText: { children: "Yes" },
   exportAllIconsNo: radioRow(() => (allIcons.value = false)),
   exportAllIconsNoInput: radioInput(
     "export-all-icons",
     !allIcons.value,
     () => (allIcons.value = false),
   ),
-  exportAllIconsNoText: {},
+  exportAllIconsNoText: { children: "No" },
 
-  exportWorkspace: { role: "radiogroup", "aria-label": "Workspace File" },
-  exportWorkspaceLabel: {},
+  exportWorkspace: { role: "radiogroup", "aria-label": EXPORT_FLAG.savedWorkspace.ariaLabel },
+  exportWorkspaceLabel: { children: EXPORT_FLAG.savedWorkspace.label },
   exportWorkspaceYes: radioRow(() => (savedWorkspace.value = true)),
   exportWorkspaceYesInput: radioInput(
     "export-saved-workspace",
     savedWorkspace.value,
     () => (savedWorkspace.value = true),
   ),
-  exportWorkspaceYesText: {},
+  exportWorkspaceYesText: { children: "Yes" },
   exportWorkspaceNo: radioRow(() => (savedWorkspace.value = false)),
   exportWorkspaceNoInput: radioInput(
     "export-saved-workspace",
     !savedWorkspace.value,
     () => (savedWorkspace.value = false),
   ),
-  exportWorkspaceNoText: {},
+  exportWorkspaceNoText: { children: "No" },
 
-  exportScripts: { role: "radiogroup", "aria-label": "CLI Utility Scripts" },
-  exportScriptsLabel: {},
+  exportScripts: { role: "radiogroup", "aria-label": EXPORT_FLAG.includeScripts.ariaLabel },
+  exportScriptsLabel: { children: EXPORT_FLAG.includeScripts.label },
   exportScriptsYes: radioRow(() => (includeScripts.value = true)),
   exportScriptsYesInput: radioInput(
     "export-scripts",
     includeScripts.value,
     () => (includeScripts.value = true),
   ),
-  exportScriptsYesText: {},
+  exportScriptsYesText: { children: "Yes" },
   exportScriptsNo: radioRow(() => (includeScripts.value = false)),
   exportScriptsNoInput: radioInput(
     "export-scripts",
     !includeScripts.value,
     () => (includeScripts.value = false),
   ),
-  exportScriptsNoText: {},
+  exportScriptsNoText: { children: "No" },
 
   exportCancel: { onClick: cancel },
-  exportCancelLabel: {},
+  exportCancelLabel: { children: "Cancel" },
   exportConfirm: {
     onClick: runExport,
     "aria-disabled": isExporting.value,
     style: isExporting.value ? styles.busy : undefined,
   },
-  exportConfirmLabel: {},
+  exportConfirmLabel: { children: "Export" },
 }))
 </script>
 

--- a/packages/editor/apps/vue/app/dialogs/export-options-store.ts
+++ b/packages/editor/apps/vue/app/dialogs/export-options-store.ts
@@ -1,3 +1,4 @@
+import { EXPORT_FLAG_DEFAULTS } from "@seldon/factory/export/options"
 import { defineStore } from "pinia"
 import { ref, watch } from "vue"
 
@@ -41,13 +42,13 @@ export const useExportOptionsStore = defineStore("export-options", () => {
 
   const platform = ref<PlatformId>(persisted.platform ?? "vue")
   const framework = ref<FrameworkId>(persisted.framework ?? "none")
-  const includeHidden = ref(persisted.includeHidden ?? false)
-  const allThemes = ref(persisted.allThemes ?? false)
-  const allFonts = ref(persisted.allFonts ?? false)
-  const fontLinks = ref(persisted.fontLinks ?? false)
-  const allIcons = ref(persisted.allIcons ?? true)
-  const savedWorkspace = ref(persisted.savedWorkspace ?? true)
-  const includeScripts = ref(persisted.includeScripts ?? true)
+  const includeHidden = ref(persisted.includeHidden ?? EXPORT_FLAG_DEFAULTS.includeHidden)
+  const allThemes = ref(persisted.allThemes ?? EXPORT_FLAG_DEFAULTS.allThemes)
+  const allFonts = ref(persisted.allFonts ?? EXPORT_FLAG_DEFAULTS.allFonts)
+  const fontLinks = ref(persisted.fontLinks ?? EXPORT_FLAG_DEFAULTS.fontLinks)
+  const allIcons = ref(persisted.allIcons ?? EXPORT_FLAG_DEFAULTS.allIcons)
+  const savedWorkspace = ref(persisted.savedWorkspace ?? EXPORT_FLAG_DEFAULTS.savedWorkspace)
+  const includeScripts = ref(persisted.includeScripts ?? EXPORT_FLAG_DEFAULTS.includeScripts)
 
   watch(
     [

--- a/packages/editor/apps/vue/sdn/refs/bindings.json
+++ b/packages/editor/apps/vue/sdn/refs/bindings.json
@@ -1043,10 +1043,19 @@
       {
         "file": "app/dialogs/ExportDialog.vue",
         "component": "ExportDialog",
-        "line": 412,
+        "line": 426,
         "conditional": false,
-        "expression": "{ role: \"radiogroup\", \"aria-label\": \"All Enabled Fonts\" }",
-        "inputs": [],
+        "expression": "{ role: \"radiogroup\", \"aria-label\": EXPORT_FLAG.allFonts.ariaLabel }",
+        "inputs": [
+          {
+            "name": "EXPORT_FLAG",
+            "declaredAt": {
+              "line": 37,
+              "kind": "const",
+              "via": "EXPORT_FLAGS.reduce"
+            }
+          }
+        ],
         "props": [
           {
             "key": "role",
@@ -1055,8 +1064,17 @@
           },
           {
             "key": "aria-label",
-            "expression": "\"All Enabled Fonts\"",
-            "inputs": []
+            "expression": "EXPORT_FLAG.allFonts.ariaLabel",
+            "inputs": [
+              {
+                "name": "EXPORT_FLAG",
+                "declaredAt": {
+                  "line": 37,
+                  "kind": "const",
+                  "via": "EXPORT_FLAGS.reduce"
+                }
+              }
+            ]
           }
         ]
       }
@@ -1065,32 +1083,56 @@
       {
         "file": "app/dialogs/ExportDialog.vue",
         "component": "ExportDialog",
-        "line": 413,
+        "line": 427,
         "conditional": false,
-        "expression": "{}",
-        "inputs": [],
-        "props": []
+        "expression": "{ children: EXPORT_FLAG.allFonts.label }",
+        "inputs": [
+          {
+            "name": "EXPORT_FLAG",
+            "declaredAt": {
+              "line": 37,
+              "kind": "const",
+              "via": "EXPORT_FLAGS.reduce"
+            }
+          }
+        ],
+        "props": [
+          {
+            "key": "children",
+            "expression": "EXPORT_FLAG.allFonts.label",
+            "inputs": [
+              {
+                "name": "EXPORT_FLAG",
+                "declaredAt": {
+                  "line": 37,
+                  "kind": "const",
+                  "via": "EXPORT_FLAGS.reduce"
+                }
+              }
+            ]
+          }
+        ]
       }
     ],
     "exportAllFontsNo": [
       {
         "file": "app/dialogs/ExportDialog.vue",
         "component": "ExportDialog",
-        "line": 421,
+        "line": 435,
         "conditional": false,
         "expression": "radioRow(() => (allFonts.value = false))",
         "inputs": [
           {
             "name": "radioRow",
             "declaredAt": {
-              "line": 290,
+              "line": 303,
               "kind": "function"
             }
           },
           {
             "name": "allFonts",
             "declaredAt": {
-              "line": 74,
+              "line": 87,
               "kind": "const",
               "via": "storeToRefs"
             }
@@ -1103,21 +1145,21 @@
       {
         "file": "app/dialogs/ExportDialog.vue",
         "component": "ExportDialog",
-        "line": 422,
+        "line": 436,
         "conditional": false,
         "expression": "radioInput( \"export-all-fonts\", !allFonts.value, () => (allFonts.value = false), )",
         "inputs": [
           {
             "name": "radioInput",
             "declaredAt": {
-              "line": 295,
+              "line": 308,
               "kind": "function"
             }
           },
           {
             "name": "allFonts",
             "declaredAt": {
-              "line": 74,
+              "line": 87,
               "kind": "const",
               "via": "storeToRefs"
             }
@@ -1130,32 +1172,38 @@
       {
         "file": "app/dialogs/ExportDialog.vue",
         "component": "ExportDialog",
-        "line": 427,
+        "line": 441,
         "conditional": false,
-        "expression": "{}",
+        "expression": "{ children: \"No\" }",
         "inputs": [],
-        "props": []
+        "props": [
+          {
+            "key": "children",
+            "expression": "\"No\"",
+            "inputs": []
+          }
+        ]
       }
     ],
     "exportAllFontsYes": [
       {
         "file": "app/dialogs/ExportDialog.vue",
         "component": "ExportDialog",
-        "line": 414,
+        "line": 428,
         "conditional": false,
         "expression": "radioRow(() => (allFonts.value = true))",
         "inputs": [
           {
             "name": "radioRow",
             "declaredAt": {
-              "line": 290,
+              "line": 303,
               "kind": "function"
             }
           },
           {
             "name": "allFonts",
             "declaredAt": {
-              "line": 74,
+              "line": 87,
               "kind": "const",
               "via": "storeToRefs"
             }
@@ -1168,21 +1216,21 @@
       {
         "file": "app/dialogs/ExportDialog.vue",
         "component": "ExportDialog",
-        "line": 415,
+        "line": 429,
         "conditional": false,
         "expression": "radioInput( \"export-all-fonts\", allFonts.value, () => (allFonts.value = true), )",
         "inputs": [
           {
             "name": "radioInput",
             "declaredAt": {
-              "line": 295,
+              "line": 308,
               "kind": "function"
             }
           },
           {
             "name": "allFonts",
             "declaredAt": {
-              "line": 74,
+              "line": 87,
               "kind": "const",
               "via": "storeToRefs"
             }
@@ -1195,21 +1243,36 @@
       {
         "file": "app/dialogs/ExportDialog.vue",
         "component": "ExportDialog",
-        "line": 420,
+        "line": 434,
         "conditional": false,
-        "expression": "{}",
+        "expression": "{ children: \"Yes\" }",
         "inputs": [],
-        "props": []
+        "props": [
+          {
+            "key": "children",
+            "expression": "\"Yes\"",
+            "inputs": []
+          }
+        ]
       }
     ],
     "exportAllIcons": [
       {
         "file": "app/dialogs/ExportDialog.vue",
         "component": "ExportDialog",
-        "line": 429,
+        "line": 443,
         "conditional": false,
-        "expression": "{ role: \"radiogroup\", \"aria-label\": \"All Enabled Icons\" }",
-        "inputs": [],
+        "expression": "{ role: \"radiogroup\", \"aria-label\": EXPORT_FLAG.allIcons.ariaLabel }",
+        "inputs": [
+          {
+            "name": "EXPORT_FLAG",
+            "declaredAt": {
+              "line": 37,
+              "kind": "const",
+              "via": "EXPORT_FLAGS.reduce"
+            }
+          }
+        ],
         "props": [
           {
             "key": "role",
@@ -1218,8 +1281,17 @@
           },
           {
             "key": "aria-label",
-            "expression": "\"All Enabled Icons\"",
-            "inputs": []
+            "expression": "EXPORT_FLAG.allIcons.ariaLabel",
+            "inputs": [
+              {
+                "name": "EXPORT_FLAG",
+                "declaredAt": {
+                  "line": 37,
+                  "kind": "const",
+                  "via": "EXPORT_FLAGS.reduce"
+                }
+              }
+            ]
           }
         ]
       }
@@ -1228,32 +1300,56 @@
       {
         "file": "app/dialogs/ExportDialog.vue",
         "component": "ExportDialog",
-        "line": 430,
+        "line": 444,
         "conditional": false,
-        "expression": "{}",
-        "inputs": [],
-        "props": []
+        "expression": "{ children: EXPORT_FLAG.allIcons.label }",
+        "inputs": [
+          {
+            "name": "EXPORT_FLAG",
+            "declaredAt": {
+              "line": 37,
+              "kind": "const",
+              "via": "EXPORT_FLAGS.reduce"
+            }
+          }
+        ],
+        "props": [
+          {
+            "key": "children",
+            "expression": "EXPORT_FLAG.allIcons.label",
+            "inputs": [
+              {
+                "name": "EXPORT_FLAG",
+                "declaredAt": {
+                  "line": 37,
+                  "kind": "const",
+                  "via": "EXPORT_FLAGS.reduce"
+                }
+              }
+            ]
+          }
+        ]
       }
     ],
     "exportAllIconsNo": [
       {
         "file": "app/dialogs/ExportDialog.vue",
         "component": "ExportDialog",
-        "line": 438,
+        "line": 452,
         "conditional": false,
         "expression": "radioRow(() => (allIcons.value = false))",
         "inputs": [
           {
             "name": "radioRow",
             "declaredAt": {
-              "line": 290,
+              "line": 303,
               "kind": "function"
             }
           },
           {
             "name": "allIcons",
             "declaredAt": {
-              "line": 74,
+              "line": 87,
               "kind": "const",
               "via": "storeToRefs"
             }
@@ -1266,21 +1362,21 @@
       {
         "file": "app/dialogs/ExportDialog.vue",
         "component": "ExportDialog",
-        "line": 439,
+        "line": 453,
         "conditional": false,
         "expression": "radioInput( \"export-all-icons\", !allIcons.value, () => (allIcons.value = false), )",
         "inputs": [
           {
             "name": "radioInput",
             "declaredAt": {
-              "line": 295,
+              "line": 308,
               "kind": "function"
             }
           },
           {
             "name": "allIcons",
             "declaredAt": {
-              "line": 74,
+              "line": 87,
               "kind": "const",
               "via": "storeToRefs"
             }
@@ -1293,32 +1389,38 @@
       {
         "file": "app/dialogs/ExportDialog.vue",
         "component": "ExportDialog",
-        "line": 444,
+        "line": 458,
         "conditional": false,
-        "expression": "{}",
+        "expression": "{ children: \"No\" }",
         "inputs": [],
-        "props": []
+        "props": [
+          {
+            "key": "children",
+            "expression": "\"No\"",
+            "inputs": []
+          }
+        ]
       }
     ],
     "exportAllIconsYes": [
       {
         "file": "app/dialogs/ExportDialog.vue",
         "component": "ExportDialog",
-        "line": 431,
+        "line": 445,
         "conditional": false,
         "expression": "radioRow(() => (allIcons.value = true))",
         "inputs": [
           {
             "name": "radioRow",
             "declaredAt": {
-              "line": 290,
+              "line": 303,
               "kind": "function"
             }
           },
           {
             "name": "allIcons",
             "declaredAt": {
-              "line": 74,
+              "line": 87,
               "kind": "const",
               "via": "storeToRefs"
             }
@@ -1331,21 +1433,21 @@
       {
         "file": "app/dialogs/ExportDialog.vue",
         "component": "ExportDialog",
-        "line": 432,
+        "line": 446,
         "conditional": false,
         "expression": "radioInput( \"export-all-icons\", allIcons.value, () => (allIcons.value = true), )",
         "inputs": [
           {
             "name": "radioInput",
             "declaredAt": {
-              "line": 295,
+              "line": 308,
               "kind": "function"
             }
           },
           {
             "name": "allIcons",
             "declaredAt": {
-              "line": 74,
+              "line": 87,
               "kind": "const",
               "via": "storeToRefs"
             }
@@ -1358,21 +1460,36 @@
       {
         "file": "app/dialogs/ExportDialog.vue",
         "component": "ExportDialog",
-        "line": 437,
+        "line": 451,
         "conditional": false,
-        "expression": "{}",
+        "expression": "{ children: \"Yes\" }",
         "inputs": [],
-        "props": []
+        "props": [
+          {
+            "key": "children",
+            "expression": "\"Yes\"",
+            "inputs": []
+          }
+        ]
       }
     ],
     "exportAllThemes": [
       {
         "file": "app/dialogs/ExportDialog.vue",
         "component": "ExportDialog",
-        "line": 395,
+        "line": 409,
         "conditional": false,
-        "expression": "{ role: \"radiogroup\", \"aria-label\": \"All Themes\" }",
-        "inputs": [],
+        "expression": "{ role: \"radiogroup\", \"aria-label\": EXPORT_FLAG.allThemes.ariaLabel }",
+        "inputs": [
+          {
+            "name": "EXPORT_FLAG",
+            "declaredAt": {
+              "line": 37,
+              "kind": "const",
+              "via": "EXPORT_FLAGS.reduce"
+            }
+          }
+        ],
         "props": [
           {
             "key": "role",
@@ -1381,8 +1498,17 @@
           },
           {
             "key": "aria-label",
-            "expression": "\"All Themes\"",
-            "inputs": []
+            "expression": "EXPORT_FLAG.allThemes.ariaLabel",
+            "inputs": [
+              {
+                "name": "EXPORT_FLAG",
+                "declaredAt": {
+                  "line": 37,
+                  "kind": "const",
+                  "via": "EXPORT_FLAGS.reduce"
+                }
+              }
+            ]
           }
         ]
       }
@@ -1391,32 +1517,56 @@
       {
         "file": "app/dialogs/ExportDialog.vue",
         "component": "ExportDialog",
-        "line": 396,
+        "line": 410,
         "conditional": false,
-        "expression": "{}",
-        "inputs": [],
-        "props": []
+        "expression": "{ children: EXPORT_FLAG.allThemes.label }",
+        "inputs": [
+          {
+            "name": "EXPORT_FLAG",
+            "declaredAt": {
+              "line": 37,
+              "kind": "const",
+              "via": "EXPORT_FLAGS.reduce"
+            }
+          }
+        ],
+        "props": [
+          {
+            "key": "children",
+            "expression": "EXPORT_FLAG.allThemes.label",
+            "inputs": [
+              {
+                "name": "EXPORT_FLAG",
+                "declaredAt": {
+                  "line": 37,
+                  "kind": "const",
+                  "via": "EXPORT_FLAGS.reduce"
+                }
+              }
+            ]
+          }
+        ]
       }
     ],
     "exportAllThemesNo": [
       {
         "file": "app/dialogs/ExportDialog.vue",
         "component": "ExportDialog",
-        "line": 404,
+        "line": 418,
         "conditional": false,
         "expression": "radioRow(() => (allThemes.value = false))",
         "inputs": [
           {
             "name": "radioRow",
             "declaredAt": {
-              "line": 290,
+              "line": 303,
               "kind": "function"
             }
           },
           {
             "name": "allThemes",
             "declaredAt": {
-              "line": 74,
+              "line": 87,
               "kind": "const",
               "via": "storeToRefs"
             }
@@ -1429,21 +1579,21 @@
       {
         "file": "app/dialogs/ExportDialog.vue",
         "component": "ExportDialog",
-        "line": 405,
+        "line": 419,
         "conditional": false,
         "expression": "radioInput( \"export-all-themes\", !allThemes.value, () => (allThemes.value = false), )",
         "inputs": [
           {
             "name": "radioInput",
             "declaredAt": {
-              "line": 295,
+              "line": 308,
               "kind": "function"
             }
           },
           {
             "name": "allThemes",
             "declaredAt": {
-              "line": 74,
+              "line": 87,
               "kind": "const",
               "via": "storeToRefs"
             }
@@ -1456,32 +1606,38 @@
       {
         "file": "app/dialogs/ExportDialog.vue",
         "component": "ExportDialog",
-        "line": 410,
+        "line": 424,
         "conditional": false,
-        "expression": "{}",
+        "expression": "{ children: \"No\" }",
         "inputs": [],
-        "props": []
+        "props": [
+          {
+            "key": "children",
+            "expression": "\"No\"",
+            "inputs": []
+          }
+        ]
       }
     ],
     "exportAllThemesYes": [
       {
         "file": "app/dialogs/ExportDialog.vue",
         "component": "ExportDialog",
-        "line": 397,
+        "line": 411,
         "conditional": false,
         "expression": "radioRow(() => (allThemes.value = true))",
         "inputs": [
           {
             "name": "radioRow",
             "declaredAt": {
-              "line": 290,
+              "line": 303,
               "kind": "function"
             }
           },
           {
             "name": "allThemes",
             "declaredAt": {
-              "line": 74,
+              "line": 87,
               "kind": "const",
               "via": "storeToRefs"
             }
@@ -1494,21 +1650,21 @@
       {
         "file": "app/dialogs/ExportDialog.vue",
         "component": "ExportDialog",
-        "line": 398,
+        "line": 412,
         "conditional": false,
         "expression": "radioInput( \"export-all-themes\", allThemes.value, () => (allThemes.value = true), )",
         "inputs": [
           {
             "name": "radioInput",
             "declaredAt": {
-              "line": 295,
+              "line": 308,
               "kind": "function"
             }
           },
           {
             "name": "allThemes",
             "declaredAt": {
-              "line": 74,
+              "line": 87,
               "kind": "const",
               "via": "storeToRefs"
             }
@@ -1521,25 +1677,31 @@
       {
         "file": "app/dialogs/ExportDialog.vue",
         "component": "ExportDialog",
-        "line": 403,
+        "line": 417,
         "conditional": false,
-        "expression": "{}",
+        "expression": "{ children: \"Yes\" }",
         "inputs": [],
-        "props": []
+        "props": [
+          {
+            "key": "children",
+            "expression": "\"Yes\"",
+            "inputs": []
+          }
+        ]
       }
     ],
     "exportCancel": [
       {
         "file": "app/dialogs/ExportDialog.vue",
         "component": "ExportDialog",
-        "line": 480,
+        "line": 494,
         "conditional": false,
         "expression": "{ onClick: cancel }",
         "inputs": [
           {
             "name": "cancel",
             "declaredAt": {
-              "line": 225,
+              "line": 238,
               "kind": "function"
             }
           }
@@ -1552,7 +1714,7 @@
               {
                 "name": "cancel",
                 "declaredAt": {
-                  "line": 225,
+                  "line": 238,
                   "kind": "function"
                 }
               }
@@ -1565,32 +1727,38 @@
       {
         "file": "app/dialogs/ExportDialog.vue",
         "component": "ExportDialog",
-        "line": 481,
+        "line": 495,
         "conditional": false,
-        "expression": "{}",
+        "expression": "{ children: \"Cancel\" }",
         "inputs": [],
-        "props": []
+        "props": [
+          {
+            "key": "children",
+            "expression": "\"Cancel\"",
+            "inputs": []
+          }
+        ]
       }
     ],
     "exportConfirm": [
       {
         "file": "app/dialogs/ExportDialog.vue",
         "component": "ExportDialog",
-        "line": 482,
+        "line": 496,
         "conditional": false,
         "expression": "{ onClick: runExport, \"aria-disabled\": isExporting.value, style: isExporting.value ? styles.busy : undefined, }",
         "inputs": [
           {
             "name": "runExport",
             "declaredAt": {
-              "line": 202,
+              "line": 215,
               "kind": "function"
             }
           },
           {
             "name": "isExporting",
             "declaredAt": {
-              "line": 65,
+              "line": 78,
               "kind": "const",
               "via": "storeToRefs"
             }
@@ -1598,7 +1766,7 @@
           {
             "name": "styles",
             "declaredAt": {
-              "line": 272,
+              "line": 285,
               "kind": "const"
             }
           }
@@ -1611,7 +1779,7 @@
               {
                 "name": "runExport",
                 "declaredAt": {
-                  "line": 202,
+                  "line": 215,
                   "kind": "function"
                 }
               }
@@ -1624,7 +1792,7 @@
               {
                 "name": "isExporting",
                 "declaredAt": {
-                  "line": 65,
+                  "line": 78,
                   "kind": "const",
                   "via": "storeToRefs"
                 }
@@ -1638,7 +1806,7 @@
               {
                 "name": "isExporting",
                 "declaredAt": {
-                  "line": 65,
+                  "line": 78,
                   "kind": "const",
                   "via": "storeToRefs"
                 }
@@ -1646,7 +1814,7 @@
               {
                 "name": "styles",
                 "declaredAt": {
-                  "line": 272,
+                  "line": 285,
                   "kind": "const"
                 }
               }
@@ -1659,32 +1827,64 @@
       {
         "file": "app/dialogs/ExportDialog.vue",
         "component": "ExportDialog",
-        "line": 487,
+        "line": 501,
         "conditional": false,
-        "expression": "{}",
+        "expression": "{ children: \"Export\" }",
         "inputs": [],
-        "props": []
+        "props": [
+          {
+            "key": "children",
+            "expression": "\"Export\"",
+            "inputs": []
+          }
+        ]
       }
     ],
     "exportFieldset": [
       {
         "file": "app/dialogs/ExportDialog.vue",
         "component": "ExportDialog",
-        "line": 355,
+        "line": 368,
         "conditional": false,
         "expression": "{}",
         "inputs": [],
         "props": []
       }
     ],
+    "exportFieldsetLabel": [
+      {
+        "file": "app/dialogs/ExportDialog.vue",
+        "component": "ExportDialog",
+        "line": 369,
+        "conditional": false,
+        "expression": "{ children: \"Include\" }",
+        "inputs": [],
+        "props": [
+          {
+            "key": "children",
+            "expression": "\"Include\"",
+            "inputs": []
+          }
+        ]
+      }
+    ],
     "exportFontLinks": [
       {
         "file": "app/dialogs/ExportDialog.vue",
         "component": "ExportDialog",
-        "line": 361,
+        "line": 375,
         "conditional": false,
-        "expression": "{ role: \"radiogroup\", \"aria-label\": \"Generate Google Font API Links\" }",
-        "inputs": [],
+        "expression": "{ role: \"radiogroup\", \"aria-label\": EXPORT_FLAG.fontLinks.ariaLabel }",
+        "inputs": [
+          {
+            "name": "EXPORT_FLAG",
+            "declaredAt": {
+              "line": 37,
+              "kind": "const",
+              "via": "EXPORT_FLAGS.reduce"
+            }
+          }
+        ],
         "props": [
           {
             "key": "role",
@@ -1693,8 +1893,17 @@
           },
           {
             "key": "aria-label",
-            "expression": "\"Generate Google Font API Links\"",
-            "inputs": []
+            "expression": "EXPORT_FLAG.fontLinks.ariaLabel",
+            "inputs": [
+              {
+                "name": "EXPORT_FLAG",
+                "declaredAt": {
+                  "line": 37,
+                  "kind": "const",
+                  "via": "EXPORT_FLAGS.reduce"
+                }
+              }
+            ]
           }
         ]
       }
@@ -1703,32 +1912,56 @@
       {
         "file": "app/dialogs/ExportDialog.vue",
         "component": "ExportDialog",
-        "line": 362,
+        "line": 376,
         "conditional": false,
-        "expression": "{}",
-        "inputs": [],
-        "props": []
+        "expression": "{ children: EXPORT_FLAG.fontLinks.label }",
+        "inputs": [
+          {
+            "name": "EXPORT_FLAG",
+            "declaredAt": {
+              "line": 37,
+              "kind": "const",
+              "via": "EXPORT_FLAGS.reduce"
+            }
+          }
+        ],
+        "props": [
+          {
+            "key": "children",
+            "expression": "EXPORT_FLAG.fontLinks.label",
+            "inputs": [
+              {
+                "name": "EXPORT_FLAG",
+                "declaredAt": {
+                  "line": 37,
+                  "kind": "const",
+                  "via": "EXPORT_FLAGS.reduce"
+                }
+              }
+            ]
+          }
+        ]
       }
     ],
     "exportFontLinksNo": [
       {
         "file": "app/dialogs/ExportDialog.vue",
         "component": "ExportDialog",
-        "line": 370,
+        "line": 384,
         "conditional": false,
         "expression": "radioRow(() => (fontLinks.value = false))",
         "inputs": [
           {
             "name": "radioRow",
             "declaredAt": {
-              "line": 290,
+              "line": 303,
               "kind": "function"
             }
           },
           {
             "name": "fontLinks",
             "declaredAt": {
-              "line": 74,
+              "line": 87,
               "kind": "const",
               "via": "storeToRefs"
             }
@@ -1741,21 +1974,21 @@
       {
         "file": "app/dialogs/ExportDialog.vue",
         "component": "ExportDialog",
-        "line": 371,
+        "line": 385,
         "conditional": false,
         "expression": "radioInput( \"export-font-links\", !fontLinks.value, () => (fontLinks.value = false), )",
         "inputs": [
           {
             "name": "radioInput",
             "declaredAt": {
-              "line": 295,
+              "line": 308,
               "kind": "function"
             }
           },
           {
             "name": "fontLinks",
             "declaredAt": {
-              "line": 74,
+              "line": 87,
               "kind": "const",
               "via": "storeToRefs"
             }
@@ -1768,32 +2001,38 @@
       {
         "file": "app/dialogs/ExportDialog.vue",
         "component": "ExportDialog",
-        "line": 376,
+        "line": 390,
         "conditional": false,
-        "expression": "{}",
+        "expression": "{ children: \"No\" }",
         "inputs": [],
-        "props": []
+        "props": [
+          {
+            "key": "children",
+            "expression": "\"No\"",
+            "inputs": []
+          }
+        ]
       }
     ],
     "exportFontLinksYes": [
       {
         "file": "app/dialogs/ExportDialog.vue",
         "component": "ExportDialog",
-        "line": 363,
+        "line": 377,
         "conditional": false,
         "expression": "radioRow(() => (fontLinks.value = true))",
         "inputs": [
           {
             "name": "radioRow",
             "declaredAt": {
-              "line": 290,
+              "line": 303,
               "kind": "function"
             }
           },
           {
             "name": "fontLinks",
             "declaredAt": {
-              "line": 74,
+              "line": 87,
               "kind": "const",
               "via": "storeToRefs"
             }
@@ -1806,21 +2045,21 @@
       {
         "file": "app/dialogs/ExportDialog.vue",
         "component": "ExportDialog",
-        "line": 364,
+        "line": 378,
         "conditional": false,
         "expression": "radioInput( \"export-font-links\", fontLinks.value, () => (fontLinks.value = true), )",
         "inputs": [
           {
             "name": "radioInput",
             "declaredAt": {
-              "line": 295,
+              "line": 308,
               "kind": "function"
             }
           },
           {
             "name": "fontLinks",
             "declaredAt": {
-              "line": 74,
+              "line": 87,
               "kind": "const",
               "via": "storeToRefs"
             }
@@ -1833,18 +2072,24 @@
       {
         "file": "app/dialogs/ExportDialog.vue",
         "component": "ExportDialog",
-        "line": 369,
+        "line": 383,
         "conditional": false,
-        "expression": "{}",
+        "expression": "{ children: \"Yes\" }",
         "inputs": [],
-        "props": []
+        "props": [
+          {
+            "key": "children",
+            "expression": "\"Yes\"",
+            "inputs": []
+          }
+        ]
       }
     ],
     "exportFramework": [
       {
         "file": "app/dialogs/ExportDialog.vue",
         "component": "ExportDialog",
-        "line": 323,
+        "line": 336,
         "conditional": false,
         "expression": "{}",
         "inputs": [],
@@ -1855,7 +2100,7 @@
       {
         "file": "app/dialogs/ExportDialog.vue",
         "component": "ExportDialog",
-        "line": 325,
+        "line": 338,
         "conditional": false,
         "expression": "{}",
         "inputs": [],
@@ -1866,14 +2111,14 @@
       {
         "file": "app/dialogs/ExportDialog.vue",
         "component": "ExportDialog",
-        "line": 326,
+        "line": 339,
         "conditional": false,
         "expression": "{ value: frameworkLabel.value, readonly: true, onClick: openFramework, \"aria-expanded\": frameworkOpen.value, style: styles.opaquePointer, }",
         "inputs": [
           {
             "name": "frameworkLabel",
             "declaredAt": {
-              "line": 97,
+              "line": 110,
               "kind": "const",
               "via": "computed"
             }
@@ -1881,14 +2126,14 @@
           {
             "name": "openFramework",
             "declaredAt": {
-              "line": 150,
+              "line": 163,
               "kind": "function"
             }
           },
           {
             "name": "frameworkOpen",
             "declaredAt": {
-              "line": 109,
+              "line": 122,
               "kind": "const",
               "via": "ref"
             }
@@ -1896,7 +2141,7 @@
           {
             "name": "styles",
             "declaredAt": {
-              "line": 272,
+              "line": 285,
               "kind": "const"
             }
           }
@@ -1909,7 +2154,7 @@
               {
                 "name": "frameworkLabel",
                 "declaredAt": {
-                  "line": 97,
+                  "line": 110,
                   "kind": "const",
                   "via": "computed"
                 }
@@ -1928,7 +2173,7 @@
               {
                 "name": "openFramework",
                 "declaredAt": {
-                  "line": 150,
+                  "line": 163,
                   "kind": "function"
                 }
               }
@@ -1941,7 +2186,7 @@
               {
                 "name": "frameworkOpen",
                 "declaredAt": {
-                  "line": 109,
+                  "line": 122,
                   "kind": "const",
                   "via": "ref"
                 }
@@ -1955,7 +2200,7 @@
               {
                 "name": "styles",
                 "declaredAt": {
-                  "line": 272,
+                  "line": 285,
                   "kind": "const"
                 }
               }
@@ -1968,21 +2213,36 @@
       {
         "file": "app/dialogs/ExportDialog.vue",
         "component": "ExportDialog",
-        "line": 324,
+        "line": 337,
         "conditional": false,
-        "expression": "{}",
+        "expression": "{ children: \"Framework\" }",
         "inputs": [],
-        "props": []
+        "props": [
+          {
+            "key": "children",
+            "expression": "\"Framework\"",
+            "inputs": []
+          }
+        ]
       }
     ],
     "exportHidden": [
       {
         "file": "app/dialogs/ExportDialog.vue",
         "component": "ExportDialog",
-        "line": 378,
+        "line": 392,
         "conditional": false,
-        "expression": "{ role: \"radiogroup\", \"aria-label\": \"Hidden Components\" }",
-        "inputs": [],
+        "expression": "{ role: \"radiogroup\", \"aria-label\": EXPORT_FLAG.includeHidden.ariaLabel }",
+        "inputs": [
+          {
+            "name": "EXPORT_FLAG",
+            "declaredAt": {
+              "line": 37,
+              "kind": "const",
+              "via": "EXPORT_FLAGS.reduce"
+            }
+          }
+        ],
         "props": [
           {
             "key": "role",
@@ -1991,8 +2251,17 @@
           },
           {
             "key": "aria-label",
-            "expression": "\"Hidden Components\"",
-            "inputs": []
+            "expression": "EXPORT_FLAG.includeHidden.ariaLabel",
+            "inputs": [
+              {
+                "name": "EXPORT_FLAG",
+                "declaredAt": {
+                  "line": 37,
+                  "kind": "const",
+                  "via": "EXPORT_FLAGS.reduce"
+                }
+              }
+            ]
           }
         ]
       }
@@ -2001,32 +2270,56 @@
       {
         "file": "app/dialogs/ExportDialog.vue",
         "component": "ExportDialog",
-        "line": 379,
+        "line": 393,
         "conditional": false,
-        "expression": "{}",
-        "inputs": [],
-        "props": []
+        "expression": "{ children: EXPORT_FLAG.includeHidden.label }",
+        "inputs": [
+          {
+            "name": "EXPORT_FLAG",
+            "declaredAt": {
+              "line": 37,
+              "kind": "const",
+              "via": "EXPORT_FLAGS.reduce"
+            }
+          }
+        ],
+        "props": [
+          {
+            "key": "children",
+            "expression": "EXPORT_FLAG.includeHidden.label",
+            "inputs": [
+              {
+                "name": "EXPORT_FLAG",
+                "declaredAt": {
+                  "line": 37,
+                  "kind": "const",
+                  "via": "EXPORT_FLAGS.reduce"
+                }
+              }
+            ]
+          }
+        ]
       }
     ],
     "exportHiddenNo": [
       {
         "file": "app/dialogs/ExportDialog.vue",
         "component": "ExportDialog",
-        "line": 387,
+        "line": 401,
         "conditional": false,
         "expression": "radioRow(() => (includeHidden.value = false))",
         "inputs": [
           {
             "name": "radioRow",
             "declaredAt": {
-              "line": 290,
+              "line": 303,
               "kind": "function"
             }
           },
           {
             "name": "includeHidden",
             "declaredAt": {
-              "line": 74,
+              "line": 87,
               "kind": "const",
               "via": "storeToRefs"
             }
@@ -2039,21 +2332,21 @@
       {
         "file": "app/dialogs/ExportDialog.vue",
         "component": "ExportDialog",
-        "line": 388,
+        "line": 402,
         "conditional": false,
         "expression": "radioInput( \"export-hidden\", !includeHidden.value, () => (includeHidden.value = false), )",
         "inputs": [
           {
             "name": "radioInput",
             "declaredAt": {
-              "line": 295,
+              "line": 308,
               "kind": "function"
             }
           },
           {
             "name": "includeHidden",
             "declaredAt": {
-              "line": 74,
+              "line": 87,
               "kind": "const",
               "via": "storeToRefs"
             }
@@ -2066,32 +2359,38 @@
       {
         "file": "app/dialogs/ExportDialog.vue",
         "component": "ExportDialog",
-        "line": 393,
+        "line": 407,
         "conditional": false,
-        "expression": "{}",
+        "expression": "{ children: \"No\" }",
         "inputs": [],
-        "props": []
+        "props": [
+          {
+            "key": "children",
+            "expression": "\"No\"",
+            "inputs": []
+          }
+        ]
       }
     ],
     "exportHiddenYes": [
       {
         "file": "app/dialogs/ExportDialog.vue",
         "component": "ExportDialog",
-        "line": 380,
+        "line": 394,
         "conditional": false,
         "expression": "radioRow(() => (includeHidden.value = true))",
         "inputs": [
           {
             "name": "radioRow",
             "declaredAt": {
-              "line": 290,
+              "line": 303,
               "kind": "function"
             }
           },
           {
             "name": "includeHidden",
             "declaredAt": {
-              "line": 74,
+              "line": 87,
               "kind": "const",
               "via": "storeToRefs"
             }
@@ -2104,21 +2403,21 @@
       {
         "file": "app/dialogs/ExportDialog.vue",
         "component": "ExportDialog",
-        "line": 381,
+        "line": 395,
         "conditional": false,
         "expression": "radioInput( \"export-hidden\", includeHidden.value, () => (includeHidden.value = true), )",
         "inputs": [
           {
             "name": "radioInput",
             "declaredAt": {
-              "line": 295,
+              "line": 308,
               "kind": "function"
             }
           },
           {
             "name": "includeHidden",
             "declaredAt": {
-              "line": 74,
+              "line": 87,
               "kind": "const",
               "via": "storeToRefs"
             }
@@ -2131,18 +2430,24 @@
       {
         "file": "app/dialogs/ExportDialog.vue",
         "component": "ExportDialog",
-        "line": 386,
+        "line": 400,
         "conditional": false,
-        "expression": "{}",
+        "expression": "{ children: \"Yes\" }",
         "inputs": [],
-        "props": []
+        "props": [
+          {
+            "key": "children",
+            "expression": "\"Yes\"",
+            "inputs": []
+          }
+        ]
       }
     ],
     "exportPlatform": [
       {
         "file": "app/dialogs/ExportDialog.vue",
         "component": "ExportDialog",
-        "line": 334,
+        "line": 347,
         "conditional": false,
         "expression": "{}",
         "inputs": [],
@@ -2153,7 +2458,7 @@
       {
         "file": "app/dialogs/ExportDialog.vue",
         "component": "ExportDialog",
-        "line": 336,
+        "line": 349,
         "conditional": false,
         "expression": "{}",
         "inputs": [],
@@ -2164,14 +2469,14 @@
       {
         "file": "app/dialogs/ExportDialog.vue",
         "component": "ExportDialog",
-        "line": 337,
+        "line": 350,
         "conditional": false,
         "expression": "{ value: platformLabel.value, readonly: true, onClick: openPlatform, \"aria-expanded\": platformOpen.value, style: styles.opaquePointer, }",
         "inputs": [
           {
             "name": "platformLabel",
             "declaredAt": {
-              "line": 94,
+              "line": 107,
               "kind": "const",
               "via": "computed"
             }
@@ -2179,14 +2484,14 @@
           {
             "name": "openPlatform",
             "declaredAt": {
-              "line": 143,
+              "line": 156,
               "kind": "function"
             }
           },
           {
             "name": "platformOpen",
             "declaredAt": {
-              "line": 107,
+              "line": 120,
               "kind": "const",
               "via": "ref"
             }
@@ -2194,7 +2499,7 @@
           {
             "name": "styles",
             "declaredAt": {
-              "line": 272,
+              "line": 285,
               "kind": "const"
             }
           }
@@ -2207,7 +2512,7 @@
               {
                 "name": "platformLabel",
                 "declaredAt": {
-                  "line": 94,
+                  "line": 107,
                   "kind": "const",
                   "via": "computed"
                 }
@@ -2226,7 +2531,7 @@
               {
                 "name": "openPlatform",
                 "declaredAt": {
-                  "line": 143,
+                  "line": 156,
                   "kind": "function"
                 }
               }
@@ -2239,7 +2544,7 @@
               {
                 "name": "platformOpen",
                 "declaredAt": {
-                  "line": 107,
+                  "line": 120,
                   "kind": "const",
                   "via": "ref"
                 }
@@ -2253,7 +2558,7 @@
               {
                 "name": "styles",
                 "declaredAt": {
-                  "line": 272,
+                  "line": 285,
                   "kind": "const"
                 }
               }
@@ -2266,18 +2571,24 @@
       {
         "file": "app/dialogs/ExportDialog.vue",
         "component": "ExportDialog",
-        "line": 335,
+        "line": 348,
         "conditional": false,
-        "expression": "{}",
+        "expression": "{ children: \"Platform\" }",
         "inputs": [],
-        "props": []
+        "props": [
+          {
+            "key": "children",
+            "expression": "\"Platform\"",
+            "inputs": []
+          }
+        ]
       }
     ],
     "exportProjectFolder": [
       {
         "file": "app/dialogs/ExportDialog.vue",
         "component": "ExportDialog",
-        "line": 345,
+        "line": 358,
         "conditional": false,
         "expression": "{}",
         "inputs": [],
@@ -2288,14 +2599,14 @@
       {
         "file": "app/dialogs/ExportDialog.vue",
         "component": "ExportDialog",
-        "line": 347,
+        "line": 360,
         "conditional": false,
         "expression": "{ value: directoryLabel.value, placeholder: \"Choose a folder…\", readonly: true, onClick: chooseDirectory, style: styles.opaquePointer, }",
         "inputs": [
           {
             "name": "directoryLabel",
             "declaredAt": {
-              "line": 93,
+              "line": 106,
               "kind": "const",
               "via": "computed"
             }
@@ -2303,14 +2614,14 @@
           {
             "name": "chooseDirectory",
             "declaredAt": {
-              "line": 183,
+              "line": 196,
               "kind": "function"
             }
           },
           {
             "name": "styles",
             "declaredAt": {
-              "line": 272,
+              "line": 285,
               "kind": "const"
             }
           }
@@ -2323,7 +2634,7 @@
               {
                 "name": "directoryLabel",
                 "declaredAt": {
-                  "line": 93,
+                  "line": 106,
                   "kind": "const",
                   "via": "computed"
                 }
@@ -2347,7 +2658,7 @@
               {
                 "name": "chooseDirectory",
                 "declaredAt": {
-                  "line": 183,
+                  "line": 196,
                   "kind": "function"
                 }
               }
@@ -2360,7 +2671,7 @@
               {
                 "name": "styles",
                 "declaredAt": {
-                  "line": 272,
+                  "line": 285,
                   "kind": "const"
                 }
               }
@@ -2373,21 +2684,36 @@
       {
         "file": "app/dialogs/ExportDialog.vue",
         "component": "ExportDialog",
-        "line": 346,
+        "line": 359,
         "conditional": false,
-        "expression": "{}",
+        "expression": "{ children: \"Project Folder\" }",
         "inputs": [],
-        "props": []
+        "props": [
+          {
+            "key": "children",
+            "expression": "\"Project Folder\"",
+            "inputs": []
+          }
+        ]
       }
     ],
     "exportScripts": [
       {
         "file": "app/dialogs/ExportDialog.vue",
         "component": "ExportDialog",
-        "line": 463,
+        "line": 477,
         "conditional": false,
-        "expression": "{ role: \"radiogroup\", \"aria-label\": \"CLI Utility Scripts\" }",
-        "inputs": [],
+        "expression": "{ role: \"radiogroup\", \"aria-label\": EXPORT_FLAG.includeScripts.ariaLabel }",
+        "inputs": [
+          {
+            "name": "EXPORT_FLAG",
+            "declaredAt": {
+              "line": 37,
+              "kind": "const",
+              "via": "EXPORT_FLAGS.reduce"
+            }
+          }
+        ],
         "props": [
           {
             "key": "role",
@@ -2396,8 +2722,17 @@
           },
           {
             "key": "aria-label",
-            "expression": "\"CLI Utility Scripts\"",
-            "inputs": []
+            "expression": "EXPORT_FLAG.includeScripts.ariaLabel",
+            "inputs": [
+              {
+                "name": "EXPORT_FLAG",
+                "declaredAt": {
+                  "line": 37,
+                  "kind": "const",
+                  "via": "EXPORT_FLAGS.reduce"
+                }
+              }
+            ]
           }
         ]
       }
@@ -2406,32 +2741,56 @@
       {
         "file": "app/dialogs/ExportDialog.vue",
         "component": "ExportDialog",
-        "line": 464,
+        "line": 478,
         "conditional": false,
-        "expression": "{}",
-        "inputs": [],
-        "props": []
+        "expression": "{ children: EXPORT_FLAG.includeScripts.label }",
+        "inputs": [
+          {
+            "name": "EXPORT_FLAG",
+            "declaredAt": {
+              "line": 37,
+              "kind": "const",
+              "via": "EXPORT_FLAGS.reduce"
+            }
+          }
+        ],
+        "props": [
+          {
+            "key": "children",
+            "expression": "EXPORT_FLAG.includeScripts.label",
+            "inputs": [
+              {
+                "name": "EXPORT_FLAG",
+                "declaredAt": {
+                  "line": 37,
+                  "kind": "const",
+                  "via": "EXPORT_FLAGS.reduce"
+                }
+              }
+            ]
+          }
+        ]
       }
     ],
     "exportScriptsNo": [
       {
         "file": "app/dialogs/ExportDialog.vue",
         "component": "ExportDialog",
-        "line": 472,
+        "line": 486,
         "conditional": false,
         "expression": "radioRow(() => (includeScripts.value = false))",
         "inputs": [
           {
             "name": "radioRow",
             "declaredAt": {
-              "line": 290,
+              "line": 303,
               "kind": "function"
             }
           },
           {
             "name": "includeScripts",
             "declaredAt": {
-              "line": 74,
+              "line": 87,
               "kind": "const",
               "via": "storeToRefs"
             }
@@ -2444,21 +2803,21 @@
       {
         "file": "app/dialogs/ExportDialog.vue",
         "component": "ExportDialog",
-        "line": 473,
+        "line": 487,
         "conditional": false,
         "expression": "radioInput( \"export-scripts\", !includeScripts.value, () => (includeScripts.value = false), )",
         "inputs": [
           {
             "name": "radioInput",
             "declaredAt": {
-              "line": 295,
+              "line": 308,
               "kind": "function"
             }
           },
           {
             "name": "includeScripts",
             "declaredAt": {
-              "line": 74,
+              "line": 87,
               "kind": "const",
               "via": "storeToRefs"
             }
@@ -2471,32 +2830,38 @@
       {
         "file": "app/dialogs/ExportDialog.vue",
         "component": "ExportDialog",
-        "line": 478,
+        "line": 492,
         "conditional": false,
-        "expression": "{}",
+        "expression": "{ children: \"No\" }",
         "inputs": [],
-        "props": []
+        "props": [
+          {
+            "key": "children",
+            "expression": "\"No\"",
+            "inputs": []
+          }
+        ]
       }
     ],
     "exportScriptsYes": [
       {
         "file": "app/dialogs/ExportDialog.vue",
         "component": "ExportDialog",
-        "line": 465,
+        "line": 479,
         "conditional": false,
         "expression": "radioRow(() => (includeScripts.value = true))",
         "inputs": [
           {
             "name": "radioRow",
             "declaredAt": {
-              "line": 290,
+              "line": 303,
               "kind": "function"
             }
           },
           {
             "name": "includeScripts",
             "declaredAt": {
-              "line": 74,
+              "line": 87,
               "kind": "const",
               "via": "storeToRefs"
             }
@@ -2509,21 +2874,21 @@
       {
         "file": "app/dialogs/ExportDialog.vue",
         "component": "ExportDialog",
-        "line": 466,
+        "line": 480,
         "conditional": false,
         "expression": "radioInput( \"export-scripts\", includeScripts.value, () => (includeScripts.value = true), )",
         "inputs": [
           {
             "name": "radioInput",
             "declaredAt": {
-              "line": 295,
+              "line": 308,
               "kind": "function"
             }
           },
           {
             "name": "includeScripts",
             "declaredAt": {
-              "line": 74,
+              "line": 87,
               "kind": "const",
               "via": "storeToRefs"
             }
@@ -2536,32 +2901,53 @@
       {
         "file": "app/dialogs/ExportDialog.vue",
         "component": "ExportDialog",
-        "line": 471,
+        "line": 485,
         "conditional": false,
-        "expression": "{}",
+        "expression": "{ children: \"Yes\" }",
         "inputs": [],
-        "props": []
+        "props": [
+          {
+            "key": "children",
+            "expression": "\"Yes\"",
+            "inputs": []
+          }
+        ]
       }
     ],
     "exportTitle": [
       {
         "file": "app/dialogs/ExportDialog.vue",
         "component": "ExportDialog",
-        "line": 310,
+        "line": 323,
         "conditional": false,
-        "expression": "{}",
+        "expression": "{ children: \"Export Components\" }",
         "inputs": [],
-        "props": []
+        "props": [
+          {
+            "key": "children",
+            "expression": "\"Export Components\"",
+            "inputs": []
+          }
+        ]
       }
     ],
     "exportWorkspace": [
       {
         "file": "app/dialogs/ExportDialog.vue",
         "component": "ExportDialog",
-        "line": 446,
+        "line": 460,
         "conditional": false,
-        "expression": "{ role: \"radiogroup\", \"aria-label\": \"Workspace File\" }",
-        "inputs": [],
+        "expression": "{ role: \"radiogroup\", \"aria-label\": EXPORT_FLAG.savedWorkspace.ariaLabel }",
+        "inputs": [
+          {
+            "name": "EXPORT_FLAG",
+            "declaredAt": {
+              "line": 37,
+              "kind": "const",
+              "via": "EXPORT_FLAGS.reduce"
+            }
+          }
+        ],
         "props": [
           {
             "key": "role",
@@ -2570,8 +2956,17 @@
           },
           {
             "key": "aria-label",
-            "expression": "\"Workspace File\"",
-            "inputs": []
+            "expression": "EXPORT_FLAG.savedWorkspace.ariaLabel",
+            "inputs": [
+              {
+                "name": "EXPORT_FLAG",
+                "declaredAt": {
+                  "line": 37,
+                  "kind": "const",
+                  "via": "EXPORT_FLAGS.reduce"
+                }
+              }
+            ]
           }
         ]
       }
@@ -2580,18 +2975,42 @@
       {
         "file": "app/dialogs/ExportDialog.vue",
         "component": "ExportDialog",
-        "line": 447,
+        "line": 461,
         "conditional": false,
-        "expression": "{}",
-        "inputs": [],
-        "props": []
+        "expression": "{ children: EXPORT_FLAG.savedWorkspace.label }",
+        "inputs": [
+          {
+            "name": "EXPORT_FLAG",
+            "declaredAt": {
+              "line": 37,
+              "kind": "const",
+              "via": "EXPORT_FLAGS.reduce"
+            }
+          }
+        ],
+        "props": [
+          {
+            "key": "children",
+            "expression": "EXPORT_FLAG.savedWorkspace.label",
+            "inputs": [
+              {
+                "name": "EXPORT_FLAG",
+                "declaredAt": {
+                  "line": 37,
+                  "kind": "const",
+                  "via": "EXPORT_FLAGS.reduce"
+                }
+              }
+            ]
+          }
+        ]
       }
     ],
     "exportWorkspaceName": [
       {
         "file": "app/dialogs/ExportDialog.vue",
         "component": "ExportDialog",
-        "line": 312,
+        "line": 325,
         "conditional": false,
         "expression": "{}",
         "inputs": [],
@@ -2602,14 +3021,14 @@
       {
         "file": "app/dialogs/ExportDialog.vue",
         "component": "ExportDialog",
-        "line": 314,
+        "line": 327,
         "conditional": false,
         "expression": "{ value: workspaceName.value, placeholder: \"Untitled workspace\", onInput: onNameInput, onBlur: commitName, onKeydown: commitNameOnEnter, style: styles.opaque, }",
         "inputs": [
           {
             "name": "workspaceName",
             "declaredAt": {
-              "line": 91,
+              "line": 104,
               "kind": "const",
               "via": "computed"
             }
@@ -2617,28 +3036,28 @@
           {
             "name": "onNameInput",
             "declaredAt": {
-              "line": 159,
+              "line": 172,
               "kind": "function"
             }
           },
           {
             "name": "commitName",
             "declaredAt": {
-              "line": 166,
+              "line": 179,
               "kind": "function"
             }
           },
           {
             "name": "commitNameOnEnter",
             "declaredAt": {
-              "line": 174,
+              "line": 187,
               "kind": "function"
             }
           },
           {
             "name": "styles",
             "declaredAt": {
-              "line": 272,
+              "line": 285,
               "kind": "const"
             }
           }
@@ -2651,7 +3070,7 @@
               {
                 "name": "workspaceName",
                 "declaredAt": {
-                  "line": 91,
+                  "line": 104,
                   "kind": "const",
                   "via": "computed"
                 }
@@ -2670,7 +3089,7 @@
               {
                 "name": "onNameInput",
                 "declaredAt": {
-                  "line": 159,
+                  "line": 172,
                   "kind": "function"
                 }
               }
@@ -2683,7 +3102,7 @@
               {
                 "name": "commitName",
                 "declaredAt": {
-                  "line": 166,
+                  "line": 179,
                   "kind": "function"
                 }
               }
@@ -2696,7 +3115,7 @@
               {
                 "name": "commitNameOnEnter",
                 "declaredAt": {
-                  "line": 174,
+                  "line": 187,
                   "kind": "function"
                 }
               }
@@ -2709,7 +3128,7 @@
               {
                 "name": "styles",
                 "declaredAt": {
-                  "line": 272,
+                  "line": 285,
                   "kind": "const"
                 }
               }
@@ -2722,32 +3141,38 @@
       {
         "file": "app/dialogs/ExportDialog.vue",
         "component": "ExportDialog",
-        "line": 313,
+        "line": 326,
         "conditional": false,
-        "expression": "{}",
+        "expression": "{ children: \"Workspace Name\" }",
         "inputs": [],
-        "props": []
+        "props": [
+          {
+            "key": "children",
+            "expression": "\"Workspace Name\"",
+            "inputs": []
+          }
+        ]
       }
     ],
     "exportWorkspaceNo": [
       {
         "file": "app/dialogs/ExportDialog.vue",
         "component": "ExportDialog",
-        "line": 455,
+        "line": 469,
         "conditional": false,
         "expression": "radioRow(() => (savedWorkspace.value = false))",
         "inputs": [
           {
             "name": "radioRow",
             "declaredAt": {
-              "line": 290,
+              "line": 303,
               "kind": "function"
             }
           },
           {
             "name": "savedWorkspace",
             "declaredAt": {
-              "line": 74,
+              "line": 87,
               "kind": "const",
               "via": "storeToRefs"
             }
@@ -2760,21 +3185,21 @@
       {
         "file": "app/dialogs/ExportDialog.vue",
         "component": "ExportDialog",
-        "line": 456,
+        "line": 470,
         "conditional": false,
         "expression": "radioInput( \"export-saved-workspace\", !savedWorkspace.value, () => (savedWorkspace.value = false), )",
         "inputs": [
           {
             "name": "radioInput",
             "declaredAt": {
-              "line": 295,
+              "line": 308,
               "kind": "function"
             }
           },
           {
             "name": "savedWorkspace",
             "declaredAt": {
-              "line": 74,
+              "line": 87,
               "kind": "const",
               "via": "storeToRefs"
             }
@@ -2787,32 +3212,38 @@
       {
         "file": "app/dialogs/ExportDialog.vue",
         "component": "ExportDialog",
-        "line": 461,
+        "line": 475,
         "conditional": false,
-        "expression": "{}",
+        "expression": "{ children: \"No\" }",
         "inputs": [],
-        "props": []
+        "props": [
+          {
+            "key": "children",
+            "expression": "\"No\"",
+            "inputs": []
+          }
+        ]
       }
     ],
     "exportWorkspaceYes": [
       {
         "file": "app/dialogs/ExportDialog.vue",
         "component": "ExportDialog",
-        "line": 448,
+        "line": 462,
         "conditional": false,
         "expression": "radioRow(() => (savedWorkspace.value = true))",
         "inputs": [
           {
             "name": "radioRow",
             "declaredAt": {
-              "line": 290,
+              "line": 303,
               "kind": "function"
             }
           },
           {
             "name": "savedWorkspace",
             "declaredAt": {
-              "line": 74,
+              "line": 87,
               "kind": "const",
               "via": "storeToRefs"
             }
@@ -2825,21 +3256,21 @@
       {
         "file": "app/dialogs/ExportDialog.vue",
         "component": "ExportDialog",
-        "line": 449,
+        "line": 463,
         "conditional": false,
         "expression": "radioInput( \"export-saved-workspace\", savedWorkspace.value, () => (savedWorkspace.value = true), )",
         "inputs": [
           {
             "name": "radioInput",
             "declaredAt": {
-              "line": 295,
+              "line": 308,
               "kind": "function"
             }
           },
           {
             "name": "savedWorkspace",
             "declaredAt": {
-              "line": 74,
+              "line": 87,
               "kind": "const",
               "via": "storeToRefs"
             }
@@ -2852,11 +3283,17 @@
       {
         "file": "app/dialogs/ExportDialog.vue",
         "component": "ExportDialog",
-        "line": 454,
+        "line": 468,
         "conditional": false,
-        "expression": "{}",
+        "expression": "{ children: \"Yes\" }",
         "inputs": [],
-        "props": []
+        "props": [
+          {
+            "key": "children",
+            "expression": "\"Yes\"",
+            "inputs": []
+          }
+        ]
       }
     ],
     "filterField": [
@@ -10914,13 +11351,13 @@
         {
           "file": "app/dialogs/ExportDialog.vue",
           "component": "ExportDialog",
-          "line": 503,
+          "line": 517,
           "expression": "isExporting",
           "inputs": [
             {
               "name": "isExporting",
               "declaredAt": {
-                "line": 65,
+                "line": 78,
                 "kind": "const",
                 "via": "storeToRefs"
               }
@@ -10933,13 +11370,13 @@
         {
           "file": "app/dialogs/ExportDialog.vue",
           "component": "ExportDialog",
-          "line": 504,
+          "line": 518,
           "expression": "barHandle",
           "inputs": [
             {
               "name": "barHandle",
               "declaredAt": {
-                "line": 299,
+                "line": 312,
                 "kind": "const",
                 "via": "computed"
               }
@@ -10952,7 +11389,7 @@
         {
           "file": "app/dialogs/ExportDialog.vue",
           "component": "ExportDialog",
-          "line": 502,
+          "line": 516,
           "expression": "\"export-components-dialog\"",
           "inputs": [],
           "spread": false

--- a/packages/editor/shared/scripts/export-seldon.mjs
+++ b/packages/editor/shared/scripts/export-seldon.mjs
@@ -58,40 +58,15 @@ const COMPONENTS_FOLDER = "sdn"
 /** Editor apps this script can export, each a folder under `apps/`. */
 const PLATFORMS = ["react", "vue"]
 
-/** Built-in scope defaults, matching the editor Export dialog defaults. */
-const DEFAULT_CONFIG = {
-  includeHidden: false,
-  allThemes: false,
-  allFonts: false,
-  fontLinks: false,
-  allIcons: true,
-  savedWorkspace: true,
-  includeScripts: true,
-}
-
-/**
- * Maps each boolean flag name to the config key it sets. Each maps to `--name`
- * (true) and `--no-name` (false).
- */
-const BOOLEAN_FLAGS = {
-  hidden: "includeHidden",
-  "all-themes": "allThemes",
-  "all-fonts": "allFonts",
-  "font-links": "fontLinks",
-  "all-icons": "allIcons",
-  "saved-workspace": "savedWorkspace",
-  scripts: "includeScripts",
-}
-
-function printHelp() {
+function printHelp(booleanFlags) {
   const lines = [
     "Usage: node ../../shared/scripts/export-seldon.mjs --platform <react|vue> [flags]",
     "",
-    "Exports the selected editor's own component library. Scope defaults are built",
-    "in and shared by both editors; flags override per run.",
+    "Exports the selected editor's own component library. Scope defaults are shared",
+    "with the editor dialog, the CLI, and the MCP host; flags override per run.",
     "",
     `  --platform <${PLATFORMS.join("|")}>   editor to export (required)`,
-    ...Object.keys(BOOLEAN_FLAGS).map((name) => `  --${name} / --no-${name}`),
+    ...Object.keys(booleanFlags).map((name) => `  --${name} / --no-${name}`),
     "  --use-committed                    skip the live .seldon copy, use the committed snapshot",
     "  --help                             show this message",
   ]
@@ -115,11 +90,12 @@ function resolveEditor(platform) {
 }
 
 /**
- * Layers flag overrides over the built-in defaults. Unknown flags stop the run
- * so a typo cannot silently export the wrong scope. Returns the platform
- * separately from the scope config.
+ * Layers flag overrides over the shared defaults. Unknown flags stop the run so
+ * a typo cannot silently export the wrong scope. Returns the platform separately
+ * from the scope config. `defaults` and `booleanFlags` come from the shared
+ * export flag descriptors the handler re-exports.
  */
-function resolveArgs(argv) {
+function resolveArgs(argv, defaults, booleanFlags) {
   let platform
   let useCommitted = false
   const overrides = {}
@@ -128,7 +104,7 @@ function resolveArgs(argv) {
     const arg = argv[index]
 
     if (arg === "--help" || arg === "-h") {
-      printHelp()
+      printHelp(booleanFlags)
       process.exit(0)
     }
 
@@ -143,7 +119,7 @@ function resolveArgs(argv) {
     }
 
     const name = arg.replace(/^--(no-)?/, "")
-    const key = BOOLEAN_FLAGS[name]
+    const key = booleanFlags[name]
 
     if (!arg.startsWith("--") || !key) {
       throw new Error(`Unknown flag "${arg}". Run with --help to list flags.`)
@@ -153,7 +129,7 @@ function resolveArgs(argv) {
   }
 
   const editor = resolveEditor(platform)
-  const config = { ...DEFAULT_CONFIG, ...overrides }
+  const config = { ...defaults, ...overrides }
 
   return { platform, useCommitted, config, editor }
 }
@@ -262,9 +238,22 @@ async function resolveInputWorkspaceText(workspaceFile, useCommittedFlag) {
 }
 
 async function main() {
-  const { platform, useCommitted, config, editor } = resolveArgs(process.argv.slice(2))
+  // Load the handler first so the shared export flag descriptors it re-exports
+  // drive argument parsing, keeping this script in step with the editor, CLI,
+  // and MCP host.
+  const {
+    runExport,
+    loadWorkspace,
+    EXPORT_FLAG_DEFAULTS,
+    EXPORT_FLAG_BY_CLI_NAME,
+    toExportScopeOptions,
+  } = await loadHandler()
+  const { platform, useCommitted, config, editor } = resolveArgs(
+    process.argv.slice(2),
+    EXPORT_FLAG_DEFAULTS,
+    EXPORT_FLAG_BY_CLI_NAME,
+  )
   const { editorRoot, workspaceFile } = editor
-  const { runExport, loadWorkspace } = await loadHandler()
   // Read through Core so the file is migrated and verified before it is exported.
   const workspace = loadWorkspace(await resolveInputWorkspaceText(workspaceFile, useCommitted))
 
@@ -278,17 +267,10 @@ async function main() {
         componentsFolder: COMPONENTS_FOLDER,
       },
 
-      includeHiddenComponents: config.includeHidden,
-      exportAllThemes: config.allThemes,
-      exportAllFontCollections: config.allFonts,
-      enableRemoteFonts: config.fontLinks,
-      exportAllIconSetIcons: config.allIcons,
-      includeWorkspace: config.savedWorkspace,
-
       // With `includeScripts` on, this editor keeps the bindings scanner it
       // hands to any other project. `npm run bindings` runs it to write
       // `sdn/refs/bindings.json`, which the connections overlay reads.
-      includeScripts: config.includeScripts,
+      ...toExportScopeOptions(config),
     },
   }
 

--- a/packages/editor/shared/vite/export-handler.ts
+++ b/packages/editor/shared/vite/export-handler.ts
@@ -3,6 +3,7 @@ import path from "node:path"
 import { pathToFileURL } from "node:url"
 import { createNodeExportAssetReader } from "@seldon/factory/export/asset-reader"
 import { exportWorkspace } from "@seldon/factory/export/export-workspace"
+import { EXPORT_FLAG_DEFAULTS, toExportScopeOptions } from "@seldon/factory/export/options"
 import { createResolvedExportAssetReader } from "@seldon/factory/export/resolved-asset-reader"
 import { loadWorkspace } from "@seldon/core/workspace/reducers/load-workspace"
 import { DEFAULT_COMPONENTS_FOLDER } from "../lib/export/constants"
@@ -12,8 +13,15 @@ import type { ExportAssetReader } from "@seldon/factory/export/asset-reader"
 import type { ExportOptions, FileToExport } from "@seldon/factory/export/types"
 
 // Re-exported so the `export-seldon` scripts, which bundle this module to reach
-// `runExport`, can read a workspace file through Core instead of `JSON.parse`.
+// `runExport`, can read a workspace file through Core instead of `JSON.parse`
+// and derive their scope flags from the shared export flag descriptors.
 export { loadWorkspace }
+export {
+  EXPORT_FLAG_BY_CLI_NAME,
+  EXPORT_FLAG_DEFAULTS,
+  EXPORT_FLAGS,
+  toExportScopeOptions,
+} from "@seldon/factory/export/options"
 
 export type WireFile = {
   path: string
@@ -127,12 +135,10 @@ export async function runExport(
       assetPublicPath: "/",
     },
     assetReader,
-    // Default off so exports stay request-free. Flip to true (or override via
-    // body.options once the export options UI exists) to emit Google font links.
-    enableRemoteFonts: false,
-    // Default on so the export ships every icon enabled in the workspace's icon
-    // sets. Override via body.options to tree-shake to only icons components use.
-    exportAllIconSetIcons: true,
+    // Scope defaults come from the shared export flag descriptors, so this
+    // handler stays in step with the editor dialog, the CLI, and the MCP host.
+    // `body.options` overrides them per request.
+    ...toExportScopeOptions(EXPORT_FLAG_DEFAULTS),
     ...body.options,
   }
 

--- a/packages/factory/README.md
+++ b/packages/factory/README.md
@@ -111,7 +111,7 @@ type ExportOptions = {
 
 `enableRemoteFonts` is off by default. The default keeps exports request-free. Set it to `true` to emit remote font host links in the generated `Fonts.tsx`.
 
-`exportAllIconSetIcons`, `exportAllThemes`, and `exportAllFontCollections` are on by default, so an export ships complete icon sets, themes, and font families. Set one to `false` to emit only what a component or theme references.
+`exportAllIconSetIcons`, `exportAllThemes`, and `exportAllFontCollections` are on by default, so an export ships complete icon sets, themes, and font families. Set `exportAllIconSetIcons` or `exportAllThemes` to `false` to emit only what a component or theme references. Set `exportAllFontCollections` to `false` to emit only the font families a node renders through a direct `font.family` choice.
 
 `includeHiddenComponents`, `includeWorkspace`, and `includeScripts` are off by default.
 

--- a/packages/factory/export/cli/run.ts
+++ b/packages/factory/export/cli/run.ts
@@ -12,63 +12,55 @@ import {
   hasExportCollisions,
   parseExportManifest,
 } from "../manifest"
+import {
+  EXPORT_FLAGS,
+  EXPORT_FLAG_BY_CLI_NAME,
+  EXPORT_FLAG_DEFAULTS,
+  toExportScopeOptions,
+} from "../options"
 import { PLATFORMS } from "../platforms/registry"
 import { FRAMEWORK_IDS, resolveOutputLayout } from "../presets"
 import { createResolvedExportAssetReader } from "../resolved-asset-reader"
 
 import type { ExportManifest } from "../manifest"
+import type { ExportScopeFlags } from "../options"
 import type { FrameworkId } from "../presets"
 import type { FileToExport, PlatformId } from "../types"
 
 const PLATFORM_IDS = Object.keys(PLATFORMS) as PlatformId[]
 
 /**
- * Maps each boolean flag to the {@link CliConfig} key it sets and the option it
- * feeds. Every flag accepts `--name` (true) and `--no-name` (false).
+ * Maps each `--kebab` flag to the {@link CliConfig} key it sets. Every flag
+ * accepts `--name` (true) and `--no-name` (false). Derived from the shared
+ * export flag descriptors so the CLI cannot drift from the editor and MCP.
  */
-const BOOLEAN_FLAGS: Record<string, keyof CliConfig> = {
-  hidden: "includeHidden",
-  "all-themes": "allThemes",
-  "all-fonts": "allFonts",
-  "font-links": "fontLinks",
-  "all-icons": "allIcons",
-  "saved-workspace": "savedWorkspace",
-  scripts: "includeScripts",
-}
+const BOOLEAN_FLAGS: Record<string, keyof ExportScopeFlags> = EXPORT_FLAG_BY_CLI_NAME
 
-interface CliConfig {
+interface CliConfig extends ExportScopeFlags {
   platform: PlatformId
   framework: FrameworkId
   input: string
   out: string
-  includeHidden: boolean
-  allThemes: boolean
-  allFonts: boolean
-  fontLinks: boolean
-  allIcons: boolean
-  savedWorkspace: boolean
-  includeScripts: boolean
   overwrite: boolean
   componentsFolder?: string
   assetsFolder?: string
   assetPublicPath?: string
 }
 
-/** Defaults match the editor's export dialog defaults. */
+/** Defaults match the editor's export dialog defaults, from the shared source. */
 const DEFAULT_CONFIG: CliConfig = {
+  ...EXPORT_FLAG_DEFAULTS,
   platform: "react",
   framework: "none",
   input: "",
   out: process.cwd(),
-  includeHidden: false,
-  allThemes: false,
-  allFonts: false,
-  fontLinks: false,
-  allIcons: true,
-  savedWorkspace: true,
-  includeScripts: true,
   overwrite: false,
 }
+
+/** One aligned `--flag  description` help line per scope flag. */
+const SCOPE_FLAG_HELP = EXPORT_FLAGS.map(
+  (flag) => `      --${flag.cliName.padEnd(17)}${flag.description}`,
+).join("\n")
 
 const HELP = `seldon-export - export a Seldon workspace to framework components
 
@@ -91,13 +83,7 @@ Layout overrides (advanced, override the framework layout):
       --asset-public-path <url>
 
 Scope flags (each also has a --no- form):
-      --hidden               Include components hidden in the editor.
-      --all-themes           Export every workspace theme.
-      --all-fonts            Emit links for every enabled font family.
-      --font-links           Emit remote font host links.
-      --all-icons            Export every enabled icon (default on).
-      --saved-workspace      Emit a copy of the workspace (default on).
-      --scripts              Emit the bindings scanner scripts (default on).
+${SCOPE_FLAG_HELP}
 
 Overwrite:
   -y, --yes, --force         Overwrite an export another workspace owns in the
@@ -223,13 +209,7 @@ export async function runExportCli(argv: string[]): Promise<void> {
       assetsFolder: config.assetsFolder ?? layout.assetsFolder,
       assetPublicPath: config.assetPublicPath ?? layout.assetPublicPath,
     },
-    includeHiddenComponents: config.includeHidden,
-    exportAllThemes: config.allThemes,
-    exportAllFontCollections: config.allFonts,
-    enableRemoteFonts: config.fontLinks,
-    exportAllIconSetIcons: config.allIcons,
-    includeWorkspace: config.savedWorkspace,
-    includeScripts: config.includeScripts,
+    ...toExportScopeOptions(config),
   })
 
   await guardExportCollisions(files, outRoot, config.overwrite)

--- a/packages/factory/export/options.ts
+++ b/packages/factory/export/options.ts
@@ -83,8 +83,8 @@ export const EXPORT_FLAGS = [
     optionKey: "exportAllFontCollections",
     cliName: "all-fonts",
     default: false,
-    label: "All Used Fonts",
-    ariaLabel: "All Used Fonts",
+    label: "All Fonts",
+    ariaLabel: "All Fonts",
     description: "On emits links for every enabled font family; off emits only fonts a node uses.",
   },
   {
@@ -92,9 +92,9 @@ export const EXPORT_FLAGS = [
     optionKey: "exportAllIconSetIcons",
     cliName: "all-icons",
     default: true,
-    label: "All Enabled Icons",
-    ariaLabel: "All Enabled Icons",
-    description: "Export every enabled icon.",
+    label: "All Icons",
+    ariaLabel: "All Icons",
+    description: "On exports every enabled icon; off exports only icons a component uses.",
   },
   {
     storeKey: "savedWorkspace",

--- a/packages/factory/export/options.ts
+++ b/packages/factory/export/options.ts
@@ -1,0 +1,142 @@
+import type { ExportOptions } from "./types"
+
+/**
+ * The boolean scope toggles an export exposes, keyed the way the editor dialog
+ * and the CLI name them. Framework, layout, and folders are separate; these are
+ * only the scope flags. One definition every surface reads, so the editor, the
+ * CLI, the dev-server handler, and the MCP host cannot drift on which flags
+ * exist or what they default to.
+ */
+export interface ExportScopeFlags {
+  fontLinks: boolean
+  includeHidden: boolean
+  allThemes: boolean
+  allFonts: boolean
+  allIcons: boolean
+  savedWorkspace: boolean
+  includeScripts: boolean
+}
+
+/** The subset of {@link ExportOptions} the scope flags drive. */
+export type ExportScopeOptions = Pick<
+  ExportOptions,
+  | "enableRemoteFonts"
+  | "includeHiddenComponents"
+  | "exportAllThemes"
+  | "exportAllFontCollections"
+  | "exportAllIconSetIcons"
+  | "includeWorkspace"
+  | "includeScripts"
+>
+
+/**
+ * One export scope flag, described once for every surface. `storeKey` names it
+ * in the dialog store and the CLI config, `optionKey` names the
+ * {@link ExportOptions} field it drives, `cliName` is its `--kebab` flag,
+ * `label` and `ariaLabel` are the dialog copy, and `description` is the CLI help
+ * line.
+ */
+export interface ExportFlagDescriptor {
+  storeKey: keyof ExportScopeFlags
+  optionKey: keyof ExportScopeOptions
+  cliName: string
+  default: boolean
+  label: string
+  ariaLabel: string
+  description: string
+}
+
+/**
+ * Every export scope flag, in dialog display order. This is the single source
+ * for flag names, defaults, dialog copy, and CLI help across every surface.
+ */
+export const EXPORT_FLAGS = [
+  {
+    storeKey: "fontLinks",
+    optionKey: "enableRemoteFonts",
+    cliName: "font-links",
+    default: false,
+    label: "Generate Google Font API Links",
+    ariaLabel: "Generate Google Font API Links",
+    description: "Emit remote font host links.",
+  },
+  {
+    storeKey: "includeHidden",
+    optionKey: "includeHiddenComponents",
+    cliName: "hidden",
+    default: false,
+    label: "Hidden Components",
+    ariaLabel: "Hidden Components",
+    description: "Include components hidden in the editor.",
+  },
+  {
+    storeKey: "allThemes",
+    optionKey: "exportAllThemes",
+    cliName: "all-themes",
+    default: false,
+    label: "All Themes",
+    ariaLabel: "All Themes",
+    description: "Export every workspace theme.",
+  },
+  {
+    storeKey: "allFonts",
+    optionKey: "exportAllFontCollections",
+    cliName: "all-fonts",
+    default: false,
+    label: "All Used Fonts",
+    ariaLabel: "All Used Fonts",
+    description: "On emits links for every enabled font family; off emits only fonts a node uses.",
+  },
+  {
+    storeKey: "allIcons",
+    optionKey: "exportAllIconSetIcons",
+    cliName: "all-icons",
+    default: true,
+    label: "All Enabled Icons",
+    ariaLabel: "All Enabled Icons",
+    description: "Export every enabled icon.",
+  },
+  {
+    storeKey: "savedWorkspace",
+    optionKey: "includeWorkspace",
+    cliName: "saved-workspace",
+    default: true,
+    label: "Workspace File",
+    ariaLabel: "Workspace File",
+    description: "Emit a copy of the workspace.",
+  },
+  {
+    storeKey: "includeScripts",
+    optionKey: "includeScripts",
+    cliName: "scripts",
+    default: true,
+    label: "CLI Utility Scripts",
+    ariaLabel: "CLI Utility Scripts",
+    description: "Emit the bindings scanner scripts.",
+  },
+] as const satisfies readonly ExportFlagDescriptor[]
+
+/** Default value for every scope flag, keyed by `storeKey`. Derived from {@link EXPORT_FLAGS}. */
+export const EXPORT_FLAG_DEFAULTS: ExportScopeFlags = EXPORT_FLAGS.reduce(
+  (defaults, flag) => ({ ...defaults, [flag.storeKey]: flag.default }),
+  {} as ExportScopeFlags,
+)
+
+/** Maps `cliName` to its `storeKey`, for CLI and script argument parsing. */
+export const EXPORT_FLAG_BY_CLI_NAME: Record<string, keyof ExportScopeFlags> = Object.fromEntries(
+  EXPORT_FLAGS.map((flag) => [flag.cliName, flag.storeKey] as const),
+)
+
+/**
+ * Maps the scope flags to the {@link ExportOptions} fields the factory reads.
+ * Missing flags fall back to {@link EXPORT_FLAG_DEFAULTS}, so a caller may pass
+ * only the flags it changes.
+ */
+export function toExportScopeOptions(flags: Partial<ExportScopeFlags>): ExportScopeOptions {
+  const resolved = { ...EXPORT_FLAG_DEFAULTS, ...flags }
+
+  return EXPORT_FLAGS.reduce(
+    (options, flag) => ({ ...options, [flag.optionKey]: resolved[flag.storeKey] }),
+    {} as ExportScopeOptions,
+  )
+}

--- a/packages/factory/export/react/README.md
+++ b/packages/factory/export/react/README.md
@@ -144,7 +144,7 @@ Two predicates classify a component for the `Type` line in the generated JSDoc. 
 | `assets/get-files-to-export-from-images-to-export.ts` | Reads image files for export |
 | `assets/get-icons.ts` | Reads the icon component file for each used icon id. It resolves each id to a catalog file with `resolveIconExport`, skips ids that do not resolve with a warning, and generates the `IconDefault` component for the default icon |
 | `assets/generate-icon-index.ts` | Writes the icon index file. It writes an export line only for icons that resolve to a catalog file and deduplicates by component name, so the index never references files that were not emitted |
-| `assets/get-fonts-component.ts` | Writes the `Fonts` component. It emits font host links for remote families only when `options.enableRemoteFonts` is set |
+| `assets/get-fonts-component.ts` | Writes the `Fonts` component. It emits font host links for remote families only when `options.enableRemoteFonts` is set. With `exportAllFontCollections` on it links every enabled remote family; with it off it links only families a node renders through a direct `font.family` choice |
 
 The refs registry is shared with the Vue target and lives in [export/shared/generate-refs-registry.ts](../shared/generate-refs-registry.ts). It writes `refs/index.ts` and `refs/registry.json` from the slot data each target collects, and returns an empty list when no node carries a ref, so neither file is emitted unless it has content. See the [factory README](../../README.md) for the emitted shape.
 

--- a/packages/factory/export/react/assets/get-fonts-component.ts
+++ b/packages/factory/export/react/assets/get-fonts-component.ts
@@ -1,8 +1,5 @@
-import { getRemoteFontUrl, isRemoteFontFamily } from "@seldon/core"
-import {
-  workspaceFontCollectionService,
-  workspaceThemeService,
-} from "@seldon/core/workspace/services"
+import { getRemoteFontUrl } from "@seldon/core"
+import { workspaceFontCollectionService } from "@seldon/core/workspace/services"
 
 import { format } from "../format"
 
@@ -10,14 +7,14 @@ import type { ExportOptions, FileToExport } from "../../types"
 import type { Workspace } from "@seldon/core"
 
 /**
- * Builds the exported `Fonts` component from the workspace's font collections
- * and themes.
+ * Builds the exported `Fonts` component from the workspace's font collections.
  *
  * Local and system families need no network request, so they emit nothing here.
  * Remote families only emit a font host link when `options.enableRemoteFonts` is
- * set. Links come from two sources: enabled remote families on font collection
- * boards, and remote families referenced by a theme's font slots (so a Google
- * font used only through a theme still loads).
+ * set. `exportAllFontCollections` then selects the family scope: on, every
+ * enabled remote family on a font collection board emits a link, whether or not
+ * the project uses it; off, only the families a node actually renders through a
+ * direct `font.family` choice emit a link.
  */
 export async function getFontsComponent(
   workspace: Workspace,
@@ -42,13 +39,10 @@ export async function getFontsComponent(
       links.push(`    <link rel="stylesheet" href="${url}" />`)
     }
 
-    // 1. Enabled remote families on font collection boards. On by default; when
-    //    `exportAllFontCollections` is off, skip this source so only families a
-    //    theme references (source 2) emit a link.
     if (options.exportAllFontCollections !== false) {
-      const families = workspaceFontCollectionService.collectWorkspaceFamilies(workspace)
-
-      for (const family of families) {
+      // Every enabled remote family on a font collection board, whether or not
+      // the project uses it.
+      for (const family of workspaceFontCollectionService.collectWorkspaceFamilies(workspace)) {
         if (family.origin === "local") continue
         const enabled = enabledByFamily[family.name]
 
@@ -56,23 +50,12 @@ export async function getFontsComponent(
         if (enabled && enabled.length === 0) continue
         pushFamily(family.name, enabled)
       }
-    }
-
-    // 2. Remote families referenced by a theme's font slots. These load even when
-    //    the family is not an enabled board family, so themed text renders.
-    //    Board-enabled variants are used when known; otherwise every weight loads.
-    for (const themeId of Object.keys(workspace.themes ?? {})) {
-      const theme = workspaceThemeService.getTheme(themeId, workspace)
-
-      if (!theme?.fontFamily) continue
-
-      for (const slot of [
-        theme.fontFamily.parameters.primary,
-        theme.fontFamily.parameters.secondary,
-      ]) {
-        const familyName = typeof slot?.parameters === "string" ? slot.parameters : undefined
-
-        if (!familyName || !isRemoteFontFamily(familyName)) continue
+    } else {
+      // Only the remote families a node renders through a direct `font.family`
+      // choice, so an export scoped to used fonts stays request-minimal.
+      for (const familyName of workspaceFontCollectionService.collectUsedRemoteFontFamilies(
+        workspace,
+      )) {
         pushFamily(familyName, enabledByFamily[familyName])
       }
     }

--- a/packages/factory/export/types.ts
+++ b/packages/factory/export/types.ts
@@ -50,8 +50,9 @@ export type ExportOptions = {
   exportAllThemes?: boolean
   /**
    * Emit remote font links for every enabled font collection family, even when
-   * no theme references it. On by default. Set to `false` to emit only families
-   * referenced by a theme. Only has an effect when `enableRemoteFonts` is on.
+   * no node uses it. On by default. Set to `false` to emit only the families a
+   * node renders through a direct `font.family` choice. Only has an effect when
+   * `enableRemoteFonts` is on.
    */
   exportAllFontCollections?: boolean
   /**

--- a/packages/factory/index.ts
+++ b/packages/factory/index.ts
@@ -1,10 +1,17 @@
 export { createNodeExportAssetReader } from "./export/asset-reader"
 export { exportWorkspace } from "./export/export-workspace"
+export {
+  EXPORT_FLAG_BY_CLI_NAME,
+  EXPORT_FLAG_DEFAULTS,
+  EXPORT_FLAGS,
+  toExportScopeOptions,
+} from "./export/options"
 export { PLATFORM_LIST, PLATFORMS, getPlatform } from "./export/platforms/registry"
 export { createResolvedExportAssetReader } from "./export/resolved-asset-reader"
 
 export type { ExportAssetReader, IconExportSource } from "./export/asset-reader"
 export type { ExportWorkspaceInput } from "./export/export-workspace"
+export type { ExportFlagDescriptor, ExportScopeFlags, ExportScopeOptions } from "./export/options"
 export type { PlatformDefinition } from "./export/platforms/registry"
 export type {
   ExportOptions,


### PR DESCRIPTION
## 📝 Description

Fixes the font exporter and unifies export options across every surface.

**Font export bug (option C).** `Fonts.tsx` now respects the export flags regardless of stale editor stores. Remote font links only emit when `enableRemoteFonts` is on (off by default for GDPR). When `All Fonts` is off, only the families a node renders through a direct `font.family` choice are emitted (theme-resolved families are ignored); when on, every enabled collection family emits. Added `collectUsedRemoteFontFamilies` to `WorkspaceFontCollectionService`, scanning each node's `overrides` and state bags.

**One source of truth for export flags.** New `packages/factory/export/options.ts` defines the scope flags, defaults, CLI names, dialog labels/aria-labels, and descriptions once. The CLI, the dogfood export script, the React and Vue stores, the dev-server handler, and the MCP host all derive from it, so the editor, CLI, and MCP can no longer drift.

**MCP parity.** `McpExportOptions`, the `workspace_export` tool schema, and `HeadlessHost.export` now accept the scope flags and map them via `toExportScopeOptions`, defaulting from the shared source. Previously MCP exposed none of them.

**Dialog labels via the controller.** All dialog label copy is passed through `seldonRefs` from the controller/view-model rather than baked into the generated components. Scope-group labels and aria-labels come from the shared descriptors, so React and Vue stay identical and a rename lands in one place. Renamed `All Used Fonts` → `All Fonts` and `All Enabled Icons` → `All Icons`. Icons already tree-shake to only used icons when off, matching fonts.

## 🔗 Related Issues

_None_

## 🧪 Type of Change

- 🐛 Bug fix
- ✨ New feature
- 📚 Documentation update

## 📦 Affected Packages

- `@seldon/core`
- `@seldon/factory`
- `@seldon/editor`
- `@seldon/ai` (MCP export options and host)

## 📸 Screenshots/Videos

_N/A_

## 🔍 Code Quality Checklist

- Code follows the project's style guidelines
- Self-review of the code has been performed
- Code is properly commented, particularly in hard-to-understand areas
- No console.log statements or debugging code left in
- TypeScript types are properly defined, no use of "as any"
- No unused imports or variables

## 📋 Breaking Changes

_None_ to the public export API. Default scope for the dev-server handler and MCP exports now matches the editor dialog (themes off, fonts off, workspace copy on, scripts on, icons on), where previously the headless paths fell through to factory defaults. Callers passing explicit options are unaffected.

## 🚀 Deployment Notes

_None._ No migrations. `enableRemoteFonts` remains off by default across every surface.

## 📚 Documentation Updates

- Updated `packages/factory/README.md`, `packages/factory/export/react/README.md`, and the `ExportOptions` JSDoc in `packages/factory/export/types.ts` to describe the "used fonts" semantics and the shared flag source.

## ⚠️ Additional Notes

- No design-tool edit or `sdn/` re-export was required: every dialog label already carried a `data-seldon-ref`, and `mergeSlot` merges ref `children` over the baked text.
- Verified with `npm run build:packages`, `npm run typecheck:all`, `npm run lint:all`, and `npm run format:check`.

---

I have read the CLA and I agree to its terms.

Github: AndreiSeldon
Organization: SeldonDigital