### PR TITLE
Fix/hide component

### DIFF
--- a/packages/core/properties/values/layout/display.ts
+++ b/packages/core/properties/values/layout/display.ts
@@ -7,13 +7,13 @@ import type { EmptyValue } from "../shared/empty/empty"
  * slot, shows only while authoring, or drops out of the tree.
  *
  * - `SHOW`: shown on the canvas and emitted by the factory.
- * - `HIDE`: hidden on the canvas and emitted by the factory as `visibility:
- *   hidden`, so it still occupies layout space.
+ * - `HIDE`: removed from the canvas layout; emitted as an opt-in slot that
+ *   renders nothing by default and can be populated by a caller.
  * - `STUB`: shown on the canvas; emitted as an opt-in slot that renders nothing
  *   by default and can be populated by a caller.
  * - `MOCK`: shown on the canvas but not emitted by the factory, so it exists
  *   only while authoring.
- * - `EXCLUDE`: hidden on the canvas and not emitted by the factory.
+ * - `EXCLUDE`: removed from the canvas layout and not emitted by the factory.
  */
 export enum Display {
   SHOW = "show",

--- a/packages/editor/apps/react/.seldon/seldon-editor.react.json
+++ b/packages/editor/apps/react/.seldon/seldon-editor.react.json
@@ -28422,7 +28422,7 @@
         },
         "content": {
           "type": "exact",
-          "value": "All Enabled Fonts"
+          "value": "All Fonts"
         },
         "width": {
           "type": "option",

--- a/packages/editor/apps/react/.seldon/workspaces/2347a3e9-93d1-41b5-b1d7-9cd7fe37c7d4.json
+++ b/packages/editor/apps/react/.seldon/workspaces/2347a3e9-93d1-41b5-b1d7-9cd7fe37c7d4.json
@@ -49042,6 +49042,6 @@
     },
     "media": {}
   },
-  "updatedAt": "2026-08-18T13:41:40.702Z",
+  "updatedAt": "2026-08-18T15:36:39.991Z",
   "lastEditor": "react"
 }

--- a/packages/editor/apps/react/app/canvas/CanvasNode.tsx
+++ b/packages/editor/apps/react/app/canvas/CanvasNode.tsx
@@ -116,8 +116,12 @@ export const CanvasNode = memo(function CanvasNode({
 
   const nodeProperties = getNodeProperties(node, workspace)
 
-  // Don't render the node at all if it's set to be hidden
-  if (nodeProperties?.display?.value === Display.EXCLUDE) {
+  // Don't render the node at all when it's removed from the canvas layout.
+  // `HIDE` drops from layout but still exports as an opt-in slot; `EXCLUDE`
+  // drops from layout and is not exported.
+  const displayValue = nodeProperties?.display?.value
+
+  if (displayValue === Display.HIDE || displayValue === Display.EXCLUDE) {
     return null
   }
 

--- a/packages/editor/apps/react/app/canvas/ComponentRenderer.tsx
+++ b/packages/editor/apps/react/app/canvas/ComponentRenderer.tsx
@@ -148,7 +148,7 @@ export const ComponentRenderer = ({
     [computeContext, properties, className],
   )
 
-  if (properties.display && properties.display.value === Display.EXCLUDE) {
+  if (properties.display?.value === Display.HIDE || properties.display?.value === Display.EXCLUDE) {
     return null
   }
 

--- a/packages/editor/apps/react/app/canvas/boards/BoardPreviewNode.tsx
+++ b/packages/editor/apps/react/app/canvas/boards/BoardPreviewNode.tsx
@@ -65,7 +65,10 @@ export function BoardPreviewNode({
 
   const nodeProperties = getNodeProperties(node, workspace)
 
-  if (nodeProperties?.display?.value === Display.EXCLUDE) {
+  if (
+    nodeProperties?.display?.value === Display.HIDE ||
+    nodeProperties?.display?.value === Display.EXCLUDE
+  ) {
     return null
   }
 

--- a/packages/editor/apps/react/sdn/Fonts.tsx
+++ b/packages/editor/apps/react/sdn/Fonts.tsx
@@ -152,10 +152,6 @@ export function Fonts() {
         rel="stylesheet"
         href="https://fonts.googleapis.com/css2?family=Work+Sans%3Aital%2Cwght%400%2C100%3B0%2C200%3B0%2C300%3B0%2C400%3B0%2C500%3B0%2C600%3B0%2C700%3B0%2C800%3B0%2C900%3B1%2C100%3B1%2C200%3B1%2C300%3B1%2C400%3B1%2C500%3B1%2C600%3B1%2C700%3B1%2C800%3B1%2C900&display=swap"
       />
-      <link
-        rel="stylesheet"
-        href="https://fonts.googleapis.com/css2?family=Roboto%3Aital%2Cwght%400%2C100%3B0%2C200%3B0%2C300%3B0%2C400%3B0%2C500%3B0%2C600%3B0%2C700%3B0%2C800%3B0%2C900%3B1%2C100%3B1%2C200%3B1%2C300%3B1%2C400%3B1%2C500%3B1%2C600%3B1%2C700%3B1%2C800%3B1%2C900&display=swap"
-      />
     </>
   )
 }

--- a/packages/editor/apps/react/sdn/modules/Dialog.tsx
+++ b/packages/editor/apps/react/sdn/modules/Dialog.tsx
@@ -131,7 +131,7 @@ const sdn: DialogProps = {
     className: "sdn-text-label sdn-text-label--wxqf",
   },
   button2: {
-    className: "sdn-button sdn-button--ls8f",
+    className: "sdn-button sdn-button--wjtm",
   },
   icon4: {
     icon: "seldon-component",
@@ -145,7 +145,7 @@ const sdn: DialogProps = {
     className: "sdn-text-label sdn-text-label--wxqf",
   },
   button3: {
-    className: "sdn-button sdn-button--ls8f",
+    className: "sdn-button sdn-button--wjtm",
   },
   icon5: {
     icon: "seldon-component",
@@ -305,10 +305,10 @@ export function Dialog({
   const icon3Props = mergeOptionalSlot(sdn.icon3, icon3, seldonRefs)
   const textLabelProps = mergeOptionalSlot(sdn.textLabel, textLabel, seldonRefs)
   const button2Props = mergeOptionalSlot(sdn.button2, button2, seldonRefs)
-  const icon4Props = mergeSlot(sdn.icon4, icon4, seldonRefs)
+  const icon4Props = mergeOptionalSlot(sdn.icon4, icon4, seldonRefs)
   const textLabel2Props = mergeOptionalSlot(sdn.textLabel2, textLabel2, seldonRefs)
   const button3Props = mergeOptionalSlot(sdn.button3, button3, seldonRefs)
-  const icon5Props = mergeSlot(sdn.icon5, icon5, seldonRefs)
+  const icon5Props = mergeOptionalSlot(sdn.icon5, icon5, seldonRefs)
   const textLabel3Props = mergeOptionalSlot(sdn.textLabel3, textLabel3, seldonRefs)
   const frame3Props = mergeSlot(sdn.frame3, frame3, seldonRefs)
   const button4Props = mergeOptionalSlot(sdn.button4, button4, seldonRefs)

--- a/packages/editor/apps/react/sdn/modules/DialogExportComponent.tsx
+++ b/packages/editor/apps/react/sdn/modules/DialogExportComponent.tsx
@@ -441,7 +441,7 @@ const sdn: DialogExportComponentProps = {
     "data-seldon-ref": "exportAllFonts",
   },
   textLabel14: {
-    children: "All Enabled Fonts",
+    children: "All Fonts",
     htmlElement: "label",
     "aria-hidden": "false",
     className: "sdn-text-label sdn-text-label--s1qr",

--- a/packages/editor/apps/react/sdn/modules/PanelDialog.tsx
+++ b/packages/editor/apps/react/sdn/modules/PanelDialog.tsx
@@ -133,11 +133,10 @@ const sdn: PanelDialogProps = {
     className: "sdn-text-label sdn-text-label--wxqf",
   },
   button2: {
-    className: "sdn-button sdn-button--ls8f",
+    className: "sdn-button sdn-button--wjtm",
   },
   icon4: {
     icon: "seldon-component",
-    "aria-hidden": "true",
     className: "sdn-icon sdn-icon--gh8m",
   },
   textLabel2: {
@@ -145,11 +144,10 @@ const sdn: PanelDialogProps = {
     className: "sdn-text-label sdn-text-label--wxqf",
   },
   button3: {
-    className: "sdn-button sdn-button--ls8f",
+    className: "sdn-button sdn-button--wjtm",
   },
   icon5: {
     icon: "seldon-component",
-    "aria-hidden": "true",
     className: "sdn-icon sdn-icon--gh8m",
   },
   textLabel3: {
@@ -289,10 +287,10 @@ export function PanelDialog({
   const icon3Props = mergeOptionalSlot(sdn.icon3, icon3, seldonRefs)
   const textLabelProps = mergeOptionalSlot(sdn.textLabel, textLabel, seldonRefs)
   const button2Props = mergeOptionalSlot(sdn.button2, button2, seldonRefs)
-  const icon4Props = mergeSlot(sdn.icon4, icon4, seldonRefs)
+  const icon4Props = mergeOptionalSlot(sdn.icon4, icon4, seldonRefs)
   const textLabel2Props = mergeOptionalSlot(sdn.textLabel2, textLabel2, seldonRefs)
   const button3Props = mergeOptionalSlot(sdn.button3, button3, seldonRefs)
-  const icon5Props = mergeSlot(sdn.icon5, icon5, seldonRefs)
+  const icon5Props = mergeOptionalSlot(sdn.icon5, icon5, seldonRefs)
   const textLabel3Props = mergeOptionalSlot(sdn.textLabel3, textLabel3, seldonRefs)
   const frame3Props = mergeSlot(sdn.frame3, frame3, seldonRefs)
   const button4Props = mergeOptionalSlot(sdn.button4, button4, seldonRefs)

--- a/packages/editor/apps/react/sdn/styles.css
+++ b/packages/editor/apps/react/sdn/styles.css
@@ -2093,15 +2093,6 @@ body {
   border-radius: var(--sdn-corners-tight);
 }
 
-.sdn-button--ls8f {
-  visibility: hidden;
-  padding-top: var(--sdn-cmp-optical-padding-vertical-small);
-  padding-inline-end: var(--sdn-cmp-optical-padding-right-small);
-  padding-bottom: var(--sdn-cmp-optical-padding-vertical-small);
-  padding-inline-start: var(--sdn-cmp-optical-padding-left-small);
-  font-size: var(--sdn-font-size-small);
-}
-
 .sdn-button--rurb {
   padding-top: unset;
   padding-inline-end: unset;
@@ -2531,7 +2522,6 @@ body {
 .sdn-frame--4cb4 {
   align-self: unset;
   flex: unset;
-  visibility: hidden;
   background-color: color-mix(in srgb, var(--sdn-swatch-offBlack) 50%, transparent);
   position: absolute;
   inset: -4px;
@@ -2541,7 +2531,6 @@ body {
 .sdn-frame--5puw {
   align-self: unset;
   flex: unset;
-  visibility: hidden;
   background-color: color-mix(in srgb, var(--sdn-swatch-offBlack) 50%, transparent);
   position: absolute;
   inset: -32px;
@@ -2552,7 +2541,6 @@ body {
 .sdn-frame--5wjq {
   align-self: unset;
   flex: unset;
-  visibility: hidden;
   background-color: color-mix(in srgb, var(--sdn-swatch-offBlack) 50%, transparent);
   position: absolute;
   inset: -16px;
@@ -2719,7 +2707,6 @@ body {
 .sdn-frame--hog9 {
   align-self: unset;
   flex: unset;
-  visibility: hidden;
   background-color: color-mix(in srgb, var(--sdn-swatch-primary) 50%, transparent);
   position: absolute;
   inset: -8px;
@@ -2883,7 +2870,6 @@ body {
 .sdn-frame--nbi9 {
   align-self: unset;
   flex: unset;
-  visibility: hidden;
   background-color: color-mix(in srgb, var(--sdn-swatch-offBlack) 50%, transparent);
   position: absolute;
   inset: -64px;
@@ -2929,7 +2915,6 @@ body {
 .sdn-frame--ozrx {
   align-self: unset;
   flex: unset;
-  visibility: hidden;
   background-color: color-mix(in srgb, var(--sdn-swatch-primary) 50%, transparent);
   position: absolute;
   inset: -64px;
@@ -2982,7 +2967,6 @@ body {
 .sdn-frame--puja {
   align-self: unset;
   flex: unset;
-  visibility: hidden;
   background-color: color-mix(in srgb, var(--sdn-swatch-primary) 50%, transparent);
   position: absolute;
   inset: -16px;
@@ -3145,7 +3129,6 @@ body {
 .sdn-frame--ud2b {
   align-self: unset;
   flex: unset;
-  visibility: hidden;
   background-color: color-mix(in srgb, var(--sdn-swatch-primary) 50%, transparent);
   position: absolute;
   inset: -4px;
@@ -3312,7 +3295,6 @@ body {
 }
 
 .sdn-icon--2nwn {
-  visibility: hidden;
   transform: rotate(0deg);
   font-size: var(--sdn-sizes-small);
   color: var(--sdn-hc-on-offBlack);

--- a/packages/editor/apps/vue/app/canvas/CanvasNode.vue
+++ b/packages/editor/apps/vue/app/canvas/CanvasNode.vue
@@ -47,7 +47,13 @@ const nodeProperties = computed(() =>
   node.value ? getNodeProperties(node.value, props.workspace) : undefined,
 )
 
-const excluded = computed(() => nodeProperties.value?.display?.value === Display.EXCLUDE)
+// Removed from the canvas layout. `HIDE` drops from layout but still exports as
+// an opt-in slot; `EXCLUDE` drops from layout and is not exported.
+const excluded = computed(() => {
+  const display = nodeProperties.value?.display?.value
+
+  return display === Display.HIDE || display === Display.EXCLUDE
+})
 
 const selfPath = computed(() => props.rootPath ?? props.nodeId)
 

--- a/packages/editor/apps/vue/sdn/refs/bindings.json
+++ b/packages/editor/apps/vue/sdn/refs/bindings.json
@@ -11447,13 +11447,13 @@
         {
           "file": "app/canvas/CanvasNode.vue",
           "component": "CanvasNode",
-          "line": 139,
+          "line": 145,
           "expression": "iconSymbol",
           "inputs": [
             {
               "name": "iconSymbol",
               "declaredAt": {
-                "line": 90,
+                "line": 96,
                 "kind": "const",
                 "via": "computed"
               }

--- a/packages/factory/export/react/discovery/get-json-tree-from-children.ts
+++ b/packages/factory/export/react/discovery/get-json-tree-from-children.ts
@@ -31,6 +31,16 @@ function isExportableCompositionBoard(board: Board): boolean {
   return isComponentBoard(board) || isAuthoredBoard(board)
 }
 
+/**
+ * Display states emitted as an opt-in slot: the node ships in the component but
+ * renders nothing until a caller passes props for it. `STUB` stays visible on
+ * the canvas; `HIDE` is removed from the canvas layout. Both export the same
+ * way, through `mergeOptionalSlot`.
+ */
+function isOptInSlotDisplay(display: unknown): boolean {
+  return display === Display.STUB || display === Display.HIDE
+}
+
 export function getJsonTreeFromChildren(
   variant: EntryNode & { type: "default" | "variant" | "authored" },
   workspace: Workspace,
@@ -45,7 +55,7 @@ export function getJsonTreeFromChildren(
 
   const name = getComponentName(variant, workspace)
   const variantProperties = getNodeProperties(variant, workspace)
-  const variantIsStub = variantProperties.display?.value === Display.STUB
+  const variantIsStub = isOptInSlotDisplay(variantProperties.display?.value)
 
   const childIds = getChildrenIds(board, variant.id)
   const referenceMap: Record<string, string[]> = {}
@@ -130,7 +140,7 @@ export function getJsonTreeFromChildren(
       }
     }
 
-    const isStub = inheritedStub || nodeProperties.display?.value === Display.STUB
+    const isStub = inheritedStub || isOptInSlotDisplay(nodeProperties.display?.value)
 
     const name = getComponentName(node, workspace)
     const catalogId = getNodeCatalogId(node, workspace) ?? node.id

--- a/packages/factory/styles/css-properties/get-css-from-properties.test.ts
+++ b/packages/factory/styles/css-properties/get-css-from-properties.test.ts
@@ -46,11 +46,9 @@ describe("getCssFromProperties", () => {
 
   it("scopes the output to the provided class name", () => {
     const props = {
-      display: { type: ValueType.OPTION, value: Display.HIDE },
+      display: { type: ValueType.OPTION, value: Display.EXCLUDE },
     } as unknown as Properties
 
-    expect(getCssFromProperties(props, context(props), "my-node")).toBe(
-      ".my-node {visibility: hidden;}",
-    )
+    expect(getCssFromProperties(props, context(props), "my-node")).toBe(".my-node {display: none;}")
   })
 })

--- a/packages/factory/styles/css-properties/get-display-styles.test.ts
+++ b/packages/factory/styles/css-properties/get-display-styles.test.ts
@@ -16,10 +16,8 @@ describe("getDisplayStyles", () => {
     })
   })
 
-  it("maps HIDE to visibility hidden", () => {
-    expect(getDisplayStyles({ properties: display(Display.HIDE) })).toEqual({
-      visibility: "hidden",
-    })
+  it("emits no styles for HIDE, which exports as an opt-in slot", () => {
+    expect(getDisplayStyles({ properties: display(Display.HIDE) })).toEqual({})
   })
 
   it("returns no styles for SHOW", () => {

--- a/packages/factory/styles/css-properties/get-display-styles.ts
+++ b/packages/factory/styles/css-properties/get-display-styles.ts
@@ -6,10 +6,12 @@ import type { Properties } from "@seldon/core"
 export function getDisplayStyles({ properties }: { properties: Properties }): CSSObject {
   const styles: CSSObject = {}
 
+  // `HIDE` and `EXCLUDE` are handled upstream: `HIDE` exports as an opt-in slot
+  // that renders nothing until a caller opts in, and `EXCLUDE` is not emitted at
+  // all. Neither needs a display rule here. `EXCLUDE` keeps `display: none` for
+  // any consumer that renders its CSS directly.
   if (properties.display?.value === Display.EXCLUDE) {
     styles.display = "none"
-  } else if (properties.display?.value === Display.HIDE) {
-    styles.visibility = "hidden"
   }
 
   return styles


### PR DESCRIPTION
## 📝 Description

Fixes the **Hide** display state so it removes a node from the canvas layout instead of leaving an invisible box behind, and redefines how `HIDE` and `EXCLUDE` export:

- `HIDE` — removed from the canvas layout and exported as an **opt-in slot** (`mergeOptionalSlot`), so it renders nothing by default and a caller can pass props to show it. Previously it emitted `visibility: hidden`, which kept its layout box on the canvas.
- `EXCLUDE` — unchanged. Still removed from the canvas and not emitted by the factory, while staying in the workspace so the component isn't recreated.

Changes span the factory export tree, the shared display CSS, the `Display` enum docs, and both the React and Vue editor canvases so all consumers behave consistently. The `Display` doc comment was updated to describe the new `HIDE`/`EXCLUDE` semantics, and the display CSS tests were updated to match.

This branch also carries a small bundled editor change: the export dialog label "All Enabled Fonts" was renamed to "All Fonts", and the editor's generated `sdn/` output was re-exported (dropping the now-removed `visibility: hidden` rules from `styles.css` and regenerating the affected dialog components and `Fonts.tsx`).

## 🔗 Related Issues

_None_

## 🧪 Type of Change

- 🐛 Bug fix
- 📚 Documentation update

## 📦 Affected Packages

- `@seldon/core`
- `@seldon/factory`
- `@seldon/editor`

## 📸 Screenshots/Videos

_N/A_

## 🔍 Code Quality Checklist

- Code follows the project's style guidelines
- Self-review of the code has been performed
- Code is properly commented, particularly in hard-to-understand areas
- No console.log statements or debugging code left in
- TypeScript types are properly defined, no use of "as any"
- No unused imports or variables

## 📋 Breaking Changes

Behavior change to exported output for any component that uses `Display.HIDE`. Such nodes now export as opt-in slots that render nothing by default, rather than always-rendered elements with `visibility: hidden`. One shipped schema, `SubscribeCTA`, sets a child to `HIDE` and is affected; revisit if it relied on reserving layout space. No public API signatures changed.

## 🚀 Deployment Notes

_None_

## 📚 Documentation Updates

Updated the `Display` enum doc comment in `packages/core/properties/values/layout/display.ts` to describe the new `HIDE` (opt-in slot, removed from layout) and `EXCLUDE` (removed from layout, not emitted) semantics.

## ⚠️ Additional Notes

`get-display-styles` and `get-css-from-properties` tests were updated to reflect that `HIDE` no longer emits CSS. Verified with `build:packages`, `typecheck:all`, `lint:all`, `format:check`, and the factory test suite (280 passing).

---

I have read the CLA and I agree to its terms.

Github: AndreiSeldon
Organization: Seldon