### PR TITLE
Fix/package bugs

### DIFF
--- a/packages/ai/mcp/server.ts
+++ b/packages/ai/mcp/server.ts
@@ -334,7 +334,7 @@ export function createSeldonMcpServer(host: McpHost): Server {
         properties: {
           framework: {
             type: "string",
-            description: 'Export framework, for example "react" or "vue".',
+            description: 'Export framework, for example "react", "vue", or "html".',
           },
           styles: { type: "string", description: 'Style output, for example "css-properties".' },
           componentsFolder: { type: "string", description: "Output folder for components." },

--- a/packages/core/components/README.md
+++ b/packages/core/components/README.md
@@ -205,7 +205,7 @@ A schema's defaults sit on top of the same four property shapes the rest of the 
 
 Borders are a special case. Most of the time a component just wants one border that wraps the whole element, so a schema declares a single `border` compound and that's the end of it. But some components need to style individual sides differently, such as a divider line under a row, a left rail on a card, or a top stripe on a banner. For those, the schema declares four additional sibling compounds `borderTop`, `borderRight`, `borderBottom`, and `borderLeft` so each side can carry its own values.
 
-A component that does not declare the per-side compounds intentionally cannot have its sides styled independently. That is a capability decision made at authoring time, not a runtime restriction.
+A component that does not declare the per-side compounds intentionally cannot have its sides styled independently. That is a capability decision made at authoring time, not a runtime restriction. An unset side reads as Default. Set a side even when `border` is None.
 
 ---
 

--- a/packages/core/properties/README.md
+++ b/packages/core/properties/README.md
@@ -344,7 +344,7 @@ Properties that control the visual appearance and styling of components.
 | └ `corners.bottomRight` | `atomic` | `empty` \| `inherit` \| `<length>` \| `option: rounded, squared` \| `theme.ordinal: @corners.*` |
 | `borderCollapse` | `atomic` | `empty` \| `inherit` \| `option: separate, collapse` |
 
-`borderTop`, `borderRight`, `borderBottom`, and `borderLeft` are each a `compound` with the same facets as `border.*`: `preset`, `style`, `color`, `width`, `brightness`, `opacity`.
+`borderTop`, `borderRight`, `borderBottom`, and `borderLeft` are each a `compound` with the same facets as `border.*`: `preset`, `style`, `color`, `width`, `brightness`, `opacity`. An unset side reads as Default. Set a side even when `border` is None. Export emits that side's CSS in that case.
 
 ---
 

--- a/packages/core/themes/looks/README.md
+++ b/packages/core/themes/looks/README.md
@@ -32,7 +32,7 @@ flowchart LR
 | `getBuiltInLookId` | `built-in-looks.ts` | Returns the reserved cleared id for a section (`none` or `normal`), or `null` for `gradient`. Used by pickers and validation. |
 | `getBuiltInLookToken` | `built-in-looks.ts` | Returns the full `@` token for a built-in cleared look, or `null` for `gradient`. Used when matching preset refs. |
 | `isBuiltInLookSection` | `built-in-looks.ts` | Type guard for a look section name. Used when parsing `@` paths. |
-| `getBuiltInLookSectionForPropertyKey` | `built-in-looks.ts` | Maps a compound property key to a look section. Maps border shorthands to `border` and `background` to `gradient`. Used by editor property UI. |
+| `getBuiltInLookSectionForPropertyKey` | `built-in-looks.ts` | Maps a compound property key to a look section. Maps `border` and the four border-side compounds to `border`, and `background` to `gradient`. Used by editor property UI. |
 | `injectBuiltInLooks` | `built-in-looks.ts` | Inserts the cleared look cell into each cleared-look section, then fills missing reserved ids. Called from `computeTheme` in `helpers/compute-theme.ts`. |
 | `buildEmptyLookParameters` | `look-facets.ts` | Every facet of a look section set to the EMPTY property value. Used by injection and custom-token payload defaults. |
 | `RESERVED_LOOK_IDS` | `built-in-looks.ts` | Reserved look ids per section. Used by injection and reserved-name checks. |

--- a/packages/core/workspace/helpers/properties/compound-presets.ts
+++ b/packages/core/workspace/helpers/properties/compound-presets.ts
@@ -1,6 +1,8 @@
 import {
   getBuiltInLookSectionForPropertyKey,
+  getThemeLookPickerToken,
   getThemeLookSection,
+  isBuiltInClearedLookToken,
   isThemeLookPreset,
   readPresetThemeLookRef,
   resolveBuiltInLookApplyName,
@@ -141,8 +143,12 @@ function matchThemePreset(
     return null
   }
 
-  for (const presetValue of Object.values(themeSection)) {
+  for (const [id, presetValue] of Object.entries(themeSection)) {
     if (!isThemeLookPreset(presetValue) || !presetValue.parameters) {
+      continue
+    }
+
+    if (isBuiltInClearedLookToken(propertyKey, getThemeLookPickerToken(propertyKey, id))) {
       continue
     }
 

--- a/packages/core/workspace/helpers/properties/property-display.ts
+++ b/packages/core/workspace/helpers/properties/property-display.ts
@@ -4,7 +4,10 @@ import { parseThemeRef } from "@seldon/core/helpers/theme/get-theme-key-componen
 import { getThemeValueName } from "@seldon/core/helpers/theme/get-theme-value-name"
 import { isHSLObject, isLCHObject, isRGBObject } from "@seldon/core/helpers/type-guards"
 import { COMPUTED_FUNCTION_DISPLAY_NAMES } from "@seldon/core/properties/compute"
-import { getBuiltInLookSectionForPropertyKey } from "@seldon/core/themes/looks"
+import {
+  getBuiltInLookSectionForPropertyKey,
+  isBuiltInLookSection,
+} from "@seldon/core/themes/looks"
 
 import { Unit } from "../../../properties/constants/shared/units"
 import { ValueType } from "../../../properties/constants/shared/value-types"
@@ -180,7 +183,7 @@ export function formatCompoundDisplay(
 
   const builtInSection = getBuiltInLookSectionForPropertyKey(propertyKey)
 
-  if (builtInSection) {
+  if (builtInSection && isBuiltInLookSection(propertyKey)) {
     return builtInSection === "font" ? "Normal" : "None"
   }
 

--- a/packages/core/workspace/model/export-settings.ts
+++ b/packages/core/workspace/model/export-settings.ts
@@ -6,9 +6,10 @@
  *
  * `platform`, `framework`, and `outputFolder` are opaque strings at the
  * workspace boundary, matching how the factory names its export target
- * framework, output layout, and destination folder. The boolean keys mirror the
- * factory's export scope flags one to one, so a surface can feed them straight
- * into the shared flag mapping.
+ * framework, output layout, and destination folder. The editor and the MCP
+ * host nest generated files under `outputFolder` and keep `.seldon` at the
+ * project root. The boolean keys mirror the factory's export scope flags one
+ * to one, so a surface can feed them straight into the shared flag mapping.
  */
 export interface WorkspaceExportSettings {
   platform?: string

--- a/packages/editor/apps/react/.seldon/workspaces/2347a3e9-93d1-41b5-b1d7-9cd7fe37c7d4.json
+++ b/packages/editor/apps/react/.seldon/workspaces/2347a3e9-93d1-41b5-b1d7-9cd7fe37c7d4.json
@@ -6360,6 +6360,17 @@
                     ]
                   },
                   {
+                    "id": "component-dialog-25s2rXij",
+                    "children": [
+                      {
+                        "id": "component-dialog-GTortoeA"
+                      },
+                      {
+                        "id": "component-dialog-0nrLqbP5"
+                      }
+                    ]
+                  },
+                  {
                     "id": "component-panel-4PTSuHoi",
                     "children": [
                       {
@@ -28621,7 +28632,7 @@
           },
           "content": {
             "type": "exact",
-            "value": "Platform"
+            "value": "Component Type"
           },
           "margin": {
             "left": {
@@ -47891,7 +47902,7 @@
           },
           "content": {
             "type": "exact",
-            "value": "Project Folder"
+            "value": "Root Folder"
           },
           "margin": {
             "left": {
@@ -47973,7 +47984,7 @@
           },
           "content": {
             "type": "exact",
-            "value": "Framework"
+            "value": "App Framework"
           },
           "margin": {
             "left": {
@@ -48285,6 +48296,88 @@
           "symbol": {
             "type": "option",
             "value": "material-keyboardArrowDown"
+          }
+        },
+        "origin": "user"
+      },
+      "component-dialog-25s2rXij": {
+        "ref": "exportOutputFolder",
+        "type": "instance",
+        "level": "element",
+        "label": "Form Control",
+        "theme": null,
+        "template": "node:component-formControl-default",
+        "overrides": {},
+        "origin": "user"
+      },
+      "component-dialog-GTortoeA": {
+        "ref": "exportOutputFolderLabel",
+        "type": "instance",
+        "level": "primitive",
+        "label": "Label",
+        "theme": null,
+        "template": "node:component-text-FWkWXaWz",
+        "overrides": {
+          "width": {
+            "type": "option",
+            "value": "fill"
+          },
+          "font": {
+            "size": {
+              "type": "theme.ordinal",
+              "value": "@fontSize.xsmall"
+            }
+          },
+          "content": {
+            "type": "exact",
+            "value": "Export To"
+          },
+          "margin": {
+            "left": {
+              "type": "theme.ordinal",
+              "value": "@margin.cozy"
+            }
+          }
+        },
+        "origin": "user"
+      },
+      "component-dialog-0nrLqbP5": {
+        "ref": "exportOutputFolderField",
+        "type": "instance",
+        "level": "primitive",
+        "label": "Input",
+        "theme": null,
+        "template": "node:component-input-8UX3fonQ",
+        "overrides": {
+          "font": {
+            "size": {
+              "type": "theme.ordinal",
+              "value": "@fontSize.xsmall"
+            }
+          },
+          "border": {
+            "color": {
+              "type": "theme.categorical",
+              "value": "@swatch.primary"
+            }
+          },
+          "height": {
+            "type": "theme.ordinal",
+            "value": "@dimension.medium"
+          },
+          "padding": {
+            "top": {
+              "type": "theme.ordinal",
+              "value": "@padding.tight"
+            },
+            "right": {
+              "type": "theme.ordinal",
+              "value": "@padding.tight"
+            },
+            "bottom": {
+              "type": "theme.ordinal",
+              "value": "@padding.tight"
+            }
           }
         },
         "origin": "user"
@@ -49042,6 +49135,6 @@
     },
     "media": {}
   },
-  "updatedAt": "2026-08-18T15:36:39.991Z",
+  "updatedAt": "2026-09-05T09:52:04.265Z",
   "lastEditor": "react"
 }

--- a/packages/editor/apps/react/app/dialogs/export-components/ExportComponentsController.tsx
+++ b/packages/editor/apps/react/app/dialogs/export-components/ExportComponentsController.tsx
@@ -74,6 +74,8 @@ function ExportComponentsDialog({
   setSavedWorkspace,
   includeScripts,
   setIncludeScripts,
+  outputFolder,
+  setOutputFolder,
   directory,
   chooseDirectory,
   exporting,
@@ -156,6 +158,11 @@ function ExportComponentsDialog({
     [setWorkspaceName],
   )
 
+  const changeOutputFolder = useCallback(
+    (event: ChangeEvent<HTMLInputElement>) => setOutputFolder(event.target.value),
+    [setOutputFolder],
+  )
+
   // Renaming the stored record is a write to the dev server, so it waits for the
   // user to finish rather than firing on every keystroke.
   const commitNameOnEnter = useCallback(
@@ -200,8 +207,18 @@ function ExportComponentsDialog({
       style: styles.opaque,
     },
 
+    exportProjectFolder: {},
+    exportProjectFolderLabel: { children: "Root Folder" },
+    exportProjectFolderField: {
+      value: directoryLabel,
+      placeholder: "Choose a folder…",
+      readOnly: true,
+      onClick: chooseDirectory,
+      style: styles.opaquePointer,
+    },
+
     exportFramework: {},
-    exportFrameworkLabel: { children: "Framework" },
+    exportFrameworkLabel: { children: "App Framework" },
     exportFrameworkCombobox: {},
     exportFrameworkField: {
       value: frameworkLabel,
@@ -212,7 +229,7 @@ function ExportComponentsDialog({
     },
 
     exportPlatform: {},
-    exportPlatformLabel: { children: "Platform" },
+    exportPlatformLabel: { children: "Component Type" },
     exportPlatformCombobox: {},
     exportPlatformField: {
       value: platformLabel,
@@ -222,14 +239,13 @@ function ExportComponentsDialog({
       style: styles.opaquePointer,
     },
 
-    exportProjectFolder: {},
-    exportProjectFolderLabel: { children: "Project Folder" },
-    exportProjectFolderField: {
-      value: directoryLabel,
-      placeholder: "Choose a folder…",
-      readOnly: true,
-      onClick: chooseDirectory,
-      style: styles.opaquePointer,
+    exportOutputFolder: {},
+    exportOutputFolderLabel: { children: "Export To" },
+    exportOutputFolderField: {
+      value: outputFolder,
+      placeholder: "Project root",
+      onChange: changeOutputFolder,
+      style: styles.opaque,
     },
 
     exportFieldset: {},

--- a/packages/editor/apps/react/app/dialogs/export-components/hooks/use-export-components-panel.ts
+++ b/packages/editor/apps/react/app/dialogs/export-components/hooks/use-export-components-panel.ts
@@ -3,11 +3,12 @@ import { useExportCancel, useExportStatus } from "@app/io/export-status-store"
 import { useImportExport } from "@app/io/use-import-export"
 import { useWorkspaceId } from "@app/project/hooks/use-workspace-id"
 import { useWorkspace } from "@app/workspace/hooks/use-workspace"
+import { scanExportRoot } from "@seldon/editor/lib/export/scan-export-root"
 import { pickExportDirectory } from "@seldon/editor/lib/export/write-export-to-directory"
 import { getExportTarget, saveExportTarget } from "@seldon/editor/lib/storage/export-target-store"
 import { PLATFORM_LIST } from "@seldon/factory/export/platforms/registry"
 import { FRAMEWORK_IDS, resolveOutputLayout } from "@seldon/factory/export/presets"
-import { useCallback, useEffect, useMemo, useState } from "react"
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 
 import { useExportOptions } from "./use-export-options"
 
@@ -103,6 +104,7 @@ export function useExportComponentsPanel() {
 
   const platform = (saved?.platform as PlatformId | undefined) ?? storedPlatform
   const framework = (saved?.framework as FrameworkId | undefined) ?? storedFramework
+  const outputFolder = saved?.outputFolder ?? ""
   const includeHidden = saved?.includeHidden ?? storedIncludeHidden
   const allThemes = saved?.allThemes ?? storedAllThemes
   const allFonts = saved?.allFonts ?? storedAllFonts
@@ -115,7 +117,7 @@ export function useExportComponentsPanel() {
     () => ({
       platform,
       framework,
-      outputFolder: saved?.outputFolder,
+      outputFolder: outputFolder || undefined,
       fontLinks,
       allFonts,
       allIcons,
@@ -127,6 +129,7 @@ export function useExportComponentsPanel() {
     [
       platform,
       framework,
+      outputFolder,
       saved,
       fontLinks,
       allFonts,
@@ -151,8 +154,13 @@ export function useExportComponentsPanel() {
     [dispatch, settingsSnapshot],
   )
 
+  const platformTouched = useRef(false)
+  const frameworkTouched = useRef(false)
+  const outputFolderTouched = useRef(false)
+
   const setPlatform = useCallback(
     (value: PlatformId) => {
+      platformTouched.current = true
       setStoredPlatform(value)
       commit({ platform: value })
     },
@@ -161,10 +169,19 @@ export function useExportComponentsPanel() {
 
   const setFramework = useCallback(
     (value: FrameworkId) => {
+      frameworkTouched.current = true
       setStoredFramework(value)
       commit({ framework: value })
     },
     [setStoredFramework, commit],
+  )
+
+  const setOutputFolder = useCallback(
+    (value: string) => {
+      outputFolderTouched.current = true
+      commit({ outputFolder: value || undefined })
+    },
+    [commit],
   )
 
   const setIncludeHidden = useCallback(
@@ -256,6 +273,9 @@ export function useExportComponentsPanel() {
   const reset = useCallback(() => {
     setDirectory(null)
     setNameDraft(null)
+    platformTouched.current = false
+    frameworkTouched.current = false
+    outputFolderTouched.current = false
   }, [])
 
   const close = useCallback(() => {
@@ -296,7 +316,26 @@ export function useExportComponentsPanel() {
     setDirectory(picked)
 
     if (workspaceId) await saveExportTarget(workspaceId, picked)
-  }, [workspaceId])
+
+    const scan = await scanExportRoot(picked, workspaceId, workspace.metadata.label)
+    const patch: Partial<WorkspaceExportSettings> = {}
+
+    if (!platformTouched.current && scan.platform) {
+      setStoredPlatform(scan.platform)
+      patch.platform = scan.platform
+    }
+
+    if (!frameworkTouched.current && scan.framework) {
+      setStoredFramework(scan.framework)
+      patch.framework = scan.framework
+    }
+
+    if (!outputFolderTouched.current && scan.hasOwnedExport) {
+      patch.outputFolder = scan.outputFolder || undefined
+    }
+
+    if (Object.keys(patch).length > 0) commit(patch)
+  }, [workspaceId, workspace.metadata.label, setStoredPlatform, setStoredFramework, commit])
 
   // The dialog dims while an export runs, but the guard is here so a second run
   // cannot start however the click arrived.
@@ -318,6 +357,7 @@ export function useExportComponentsPanel() {
         exportAllIconSetIcons: allIcons,
         includeWorkspace: savedWorkspace,
         includeScripts,
+        outputFolder,
       },
       directory ?? undefined,
     )
@@ -336,6 +376,7 @@ export function useExportComponentsPanel() {
     allIcons,
     savedWorkspace,
     includeScripts,
+    outputFolder,
     directory,
     close,
   ])
@@ -363,6 +404,8 @@ export function useExportComponentsPanel() {
     setSavedWorkspace,
     includeScripts,
     setIncludeScripts,
+    outputFolder,
+    setOutputFolder,
     directory,
     chooseDirectory,
     exporting,

--- a/packages/editor/apps/react/app/dialogs/export-components/hooks/use-export-components-panel.ts
+++ b/packages/editor/apps/react/app/dialogs/export-components/hooks/use-export-components-panel.ts
@@ -18,7 +18,7 @@ import type { PlatformId } from "@seldon/factory/export/types"
 /** Upper bound on a workspace name, matching the inline title rename. */
 const MAX_WORKSPACE_NAME_LENGTH = 200
 
-/** Platforms shown in the dialog picker, in registry order. */
+/** Platforms shown in the dialog picker, sorted by label. */
 export const EXPORT_PLATFORM_OPTIONS = PLATFORM_LIST.map((platform) => ({
   id: platform.id,
   label: platform.label,

--- a/packages/editor/apps/react/app/io/use-import-export.tsx
+++ b/packages/editor/apps/react/app/io/use-import-export.tsx
@@ -7,6 +7,7 @@ import { useAddToast } from "@app/toaster/hooks/use-add-toast"
 import { useSelection } from "@app/workspace/hooks/use-selection"
 import { useWorkspace } from "@app/workspace/hooks/use-workspace"
 import { DEFAULT_COMPONENTS_FOLDER } from "@seldon/editor/lib/export/constants"
+import { joinExportPath, prefixExportPaths } from "@seldon/editor/lib/export/output-folder"
 import {
   findEmittedManifest,
   readExistingManifest,
@@ -181,7 +182,12 @@ export function useImportExport() {
         const framework = options?.target?.framework ?? "react"
 
         const { runLocalExport } = await import("@seldon/editor/lib/export/run-local-export")
-        const files = await runLocalExport(workspace, { ...options, includeWorkspace: false })
+        const outputFolder =
+          options?.outputFolder ?? workspace.metadata.exportSettings?.outputFolder
+        const files = prefixExportPaths(
+          await runLocalExport(workspace, { ...options, includeWorkspace: false }),
+          outputFolder,
+        )
 
         if (!(await confirmExportCollisions(directory, files))) {
           addToast("Export cancelled")
@@ -213,7 +219,10 @@ export function useImportExport() {
         // the project reports about its own use of the generated components, and
         // so the dialog offers the same folder next time.
         if (workspaceId) {
-          const componentsFolder = options?.output?.componentsFolder ?? DEFAULT_COMPONENTS_FOLDER
+          const componentsFolder = joinExportPath(
+            outputFolder,
+            options?.output?.componentsFolder ?? DEFAULT_COMPONENTS_FOLDER,
+          )
 
           await saveExportTarget(workspaceId, directory)
           await linkExportedFolder(workspaceId, directory, componentsFolder)

--- a/packages/editor/apps/react/app/menus/ComboboxOptions.tsx
+++ b/packages/editor/apps/react/app/menus/ComboboxOptions.tsx
@@ -21,6 +21,7 @@ import { createPortal } from "react-dom"
 
 import type { ComboboxOptionItem, OptionIconRender } from "./types"
 import type { IconProps } from "@seldon/components/primitives/Icon"
+import type { SeldonRefs } from "@seldon/components/utils/merge-slot"
 import type { CSSProperties, MouseEvent, ReactNode } from "react"
 
 interface Position {
@@ -60,6 +61,29 @@ const OPTION_ANNOTATION_CLASS = "sdn-text-label sdn-text-label--lqmh"
 // top menu/toast tier (z-50). The backdrop sits one step under the panel.
 const OPTIONS_BACKDROP_Z_INDEX = 44
 const OPTIONS_PANEL_Z_INDEX = 45
+
+/**
+ * Slot refs for one option row. The annotation ref is omitted when the option
+ * has none, so mergeOptionalSlot does not opt the slot in and show "Label".
+ */
+function optionSlotRefs(
+  icon: IconProps["icon"],
+  name: string,
+  annotation: string | undefined,
+): SeldonRefs {
+  if (annotation) {
+    return {
+      optionIcon: { icon },
+      optionLabel: { children: name },
+      optionAnnotation: { children: annotation },
+    }
+  }
+
+  return {
+    optionIcon: { icon },
+    optionLabel: { children: name },
+  }
+}
 
 const backdropStyle: CSSProperties = {
   position: "fixed",
@@ -137,12 +161,11 @@ export function ComboboxOptions({
     const annotationSlot = option.annotation ? {} : undefined
 
     if (icon.kind === "iconId") {
-      // The content reaches every slot by ref name.
-      const optionRefs = {
-        optionIcon: { icon: icon.icon as IconProps["icon"] },
-        optionLabel: { children: option.name },
-        optionAnnotation: { children: option.annotation },
-      }
+      const optionRefs = optionSlotRefs(
+        icon.icon as IconProps["icon"],
+        option.name,
+        option.annotation,
+      )
 
       return (
         <MenuItemOption

--- a/packages/editor/apps/react/sdn/modules/DialogExportComponent.tsx
+++ b/packages/editor/apps/react/sdn/modules/DialogExportComponent.tsx
@@ -62,6 +62,9 @@ export interface DialogExportComponentProps extends HTMLAttributes<HTMLElement> 
   formControl4?: FormControlProps | null
   textLabel4?: TextLabelProps | null
   input4?: InputProps | null
+  formControl5?: FormControlProps | null
+  textLabel28?: TextLabelProps | null
+  input5?: InputProps | null
   formControlRadio?: FormControlRadioProps | null
   textLabel5?: TextLabelProps | null
   frame2?: FrameProps | null
@@ -184,7 +187,7 @@ const sdn: DialogExportComponentProps = {
     "data-seldon-ref": "exportFramework",
   },
   textLabel2: {
-    children: "Framework",
+    children: "App Framework",
     htmlElement: "label",
     "aria-hidden": "false",
     className: "sdn-text-label sdn-text-label--l6fl",
@@ -217,7 +220,7 @@ const sdn: DialogExportComponentProps = {
     "data-seldon-ref": "exportPlatform",
   },
   textLabel3: {
-    children: "Platform",
+    children: "Component Type",
     htmlElement: "label",
     "aria-hidden": "false",
     className: "sdn-text-label sdn-text-label--l6fl",
@@ -250,7 +253,7 @@ const sdn: DialogExportComponentProps = {
     "data-seldon-ref": "exportProjectFolder",
   },
   textLabel4: {
-    children: "Project Folder",
+    children: "Root Folder",
     htmlElement: "label",
     "aria-hidden": "false",
     className: "sdn-text-label sdn-text-label--l6fl",
@@ -261,6 +264,24 @@ const sdn: DialogExportComponentProps = {
     type: "text",
     className: "sdn-input sdn-input--j1ro",
     "data-seldon-ref": "exportProjectFolderField",
+  },
+  formControl5: {
+    "aria-hidden": "false",
+    className: "sdn-form-control sdn-form-control--vmxp",
+    "data-seldon-ref": "exportOutputFolder",
+  },
+  textLabel28: {
+    children: "Export To",
+    htmlElement: "label",
+    "aria-hidden": "false",
+    className: "sdn-text-label sdn-text-label--l6fl",
+    "data-seldon-ref": "exportOutputFolderLabel",
+  },
+  input5: {
+    placeholder: "Project root",
+    type: "text",
+    className: "sdn-input sdn-input--j1ro",
+    "data-seldon-ref": "exportOutputFolderField",
   },
   formControlRadio: {
     "aria-hidden": "false",
@@ -704,6 +725,9 @@ const sdn: DialogExportComponentProps = {
  *     FormControl                          formControl                      -> exportWorkspaceName
  *       TextLabel                          textLabel                        -> exportWorkspaceNameLabel
  *       Input                              input                            -> exportWorkspaceNameField
+ *     FormControl                          formControl4                     -> exportProjectFolder
+ *       TextLabel                          textLabel4                       -> exportProjectFolderLabel
+ *       Input                              input4                           -> exportProjectFolderField
  *     FormControl                          formControl2                     -> exportFramework
  *       TextLabel                          textLabel2                       -> exportFrameworkLabel
  *       ComboboxField                      comboboxField                    -> exportFrameworkCombobox
@@ -716,9 +740,9 @@ const sdn: DialogExportComponentProps = {
  *         Input                            input3                           -> exportPlatformField
  *         ButtonIconic                     buttonIconic2
  *           Icon                           icon2
- *     FormControl                          formControl4                     -> exportProjectFolder
- *       TextLabel                          textLabel4                       -> exportProjectFolderLabel
- *       Input                              input4                           -> exportProjectFolderField
+ *     FormControl                          formControl5                     -> exportOutputFolder
+ *       TextLabel                          textLabel28                      -> exportOutputFolderLabel
+ *       Input                              input5                           -> exportOutputFolderField
  *     FormControlRadio                     formControlRadio                 -> exportFontLinks
  *       TextLabel                          textLabel5                       -> exportFontLinksLabel
  *       Frame                              frame2                           -> exportFontLinksRadios
@@ -849,6 +873,9 @@ export function DialogExportComponent({
   formControl4,
   textLabel4,
   input4,
+  formControl5,
+  textLabel28,
+  input5,
   formControlRadio,
   textLabel5,
   frame2,
@@ -951,6 +978,9 @@ export function DialogExportComponent({
   const formControl4Props = mergeOptionalSlot(sdn.formControl4, formControl4, seldonRefs)
   const textLabel4Props = mergeOptionalSlot(sdn.textLabel4, textLabel4, seldonRefs)
   const input4Props = mergeSlot(sdn.input4, input4, seldonRefs)
+  const formControl5Props = mergeOptionalSlot(sdn.formControl5, formControl5, seldonRefs)
+  const textLabel28Props = mergeOptionalSlot(sdn.textLabel28, textLabel28, seldonRefs)
+  const input5Props = mergeSlot(sdn.input5, input5, seldonRefs)
   const formControlRadioProps = mergeOptionalSlot(
     sdn.formControlRadio,
     formControlRadio,
@@ -1173,6 +1203,12 @@ export function DialogExportComponent({
                 {inputProps !== null && <Input {...inputProps} />}
               </FormControl>
             )}
+            {formControl4Props !== null && (
+              <FormControl {...formControl4Props}>
+                {textLabel4Props !== null && <TextLabel {...textLabel4Props} />}
+                {input4Props !== null && <Input {...input4Props} />}
+              </FormControl>
+            )}
             {formControl2Props !== null && (
               <FormControl {...formControl2Props}>
                 {textLabel2Props !== null && <TextLabel {...textLabel2Props} />}
@@ -1201,10 +1237,10 @@ export function DialogExportComponent({
                 )}
               </FormControl>
             )}
-            {formControl4Props !== null && (
-              <FormControl {...formControl4Props}>
-                {textLabel4Props !== null && <TextLabel {...textLabel4Props} />}
-                {input4Props !== null && <Input {...input4Props} />}
+            {formControl5Props !== null && (
+              <FormControl {...formControl5Props}>
+                {textLabel28Props !== null && <TextLabel {...textLabel28Props} />}
+                {input5Props !== null && <Input {...input5Props} />}
               </FormControl>
             )}
             {formControlRadioProps !== null && (

--- a/packages/editor/apps/react/sdn/refs/bindings.json
+++ b/packages/editor/apps/react/sdn/refs/bindings.json
@@ -1221,7 +1221,7 @@
       {
         "file": "app/dialogs/export-components/ExportComponentsController.tsx",
         "component": "ExportComponentsDialog",
-        "line": 270,
+        "line": 286,
         "conditional": false,
         "expression": "{ role: \"radiogroup\", \"aria-label\": EXPORT_FLAG.allFonts.ariaLabel }",
         "inputs": [
@@ -1261,7 +1261,7 @@
       {
         "file": "app/dialogs/export-components/ExportComponentsController.tsx",
         "component": "ExportComponentsDialog",
-        "line": 271,
+        "line": 287,
         "conditional": false,
         "expression": "{ children: EXPORT_FLAG.allFonts.label }",
         "inputs": [
@@ -1296,14 +1296,14 @@
       {
         "file": "app/dialogs/export-components/ExportComponentsController.tsx",
         "component": "ExportComponentsDialog",
-        "line": 275,
+        "line": 291,
         "conditional": false,
         "expression": "radioRow(() => setAllFonts(false))",
         "inputs": [
           {
             "name": "radioRow",
             "declaredAt": {
-              "line": 352,
+              "line": 368,
               "kind": "function"
             }
           },
@@ -1322,14 +1322,14 @@
       {
         "file": "app/dialogs/export-components/ExportComponentsController.tsx",
         "component": "ExportComponentsDialog",
-        "line": 276,
+        "line": 292,
         "conditional": false,
         "expression": "radioInput(\"export-all-fonts\", !allFonts, () => setAllFonts(false))",
         "inputs": [
           {
             "name": "radioInput",
             "declaredAt": {
-              "line": 357,
+              "line": 373,
               "kind": "function"
             }
           },
@@ -1355,7 +1355,7 @@
       {
         "file": "app/dialogs/export-components/ExportComponentsController.tsx",
         "component": "ExportComponentsDialog",
-        "line": 277,
+        "line": 293,
         "conditional": false,
         "expression": "{ children: \"No\" }",
         "inputs": [],
@@ -1372,14 +1372,14 @@
       {
         "file": "app/dialogs/export-components/ExportComponentsController.tsx",
         "component": "ExportComponentsDialog",
-        "line": 272,
+        "line": 288,
         "conditional": false,
         "expression": "radioRow(() => setAllFonts(true))",
         "inputs": [
           {
             "name": "radioRow",
             "declaredAt": {
-              "line": 352,
+              "line": 368,
               "kind": "function"
             }
           },
@@ -1398,14 +1398,14 @@
       {
         "file": "app/dialogs/export-components/ExportComponentsController.tsx",
         "component": "ExportComponentsDialog",
-        "line": 273,
+        "line": 289,
         "conditional": false,
         "expression": "radioInput(\"export-all-fonts\", allFonts, () => setAllFonts(true))",
         "inputs": [
           {
             "name": "radioInput",
             "declaredAt": {
-              "line": 357,
+              "line": 373,
               "kind": "function"
             }
           },
@@ -1431,7 +1431,7 @@
       {
         "file": "app/dialogs/export-components/ExportComponentsController.tsx",
         "component": "ExportComponentsDialog",
-        "line": 274,
+        "line": 290,
         "conditional": false,
         "expression": "{ children: \"Yes\" }",
         "inputs": [],
@@ -1448,7 +1448,7 @@
       {
         "file": "app/dialogs/export-components/ExportComponentsController.tsx",
         "component": "ExportComponentsDialog",
-        "line": 279,
+        "line": 295,
         "conditional": false,
         "expression": "{ role: \"radiogroup\", \"aria-label\": EXPORT_FLAG.allIcons.ariaLabel }",
         "inputs": [
@@ -1488,7 +1488,7 @@
       {
         "file": "app/dialogs/export-components/ExportComponentsController.tsx",
         "component": "ExportComponentsDialog",
-        "line": 280,
+        "line": 296,
         "conditional": false,
         "expression": "{ children: EXPORT_FLAG.allIcons.label }",
         "inputs": [
@@ -1523,14 +1523,14 @@
       {
         "file": "app/dialogs/export-components/ExportComponentsController.tsx",
         "component": "ExportComponentsDialog",
-        "line": 284,
+        "line": 300,
         "conditional": false,
         "expression": "radioRow(() => setAllIcons(false))",
         "inputs": [
           {
             "name": "radioRow",
             "declaredAt": {
-              "line": 352,
+              "line": 368,
               "kind": "function"
             }
           },
@@ -1549,14 +1549,14 @@
       {
         "file": "app/dialogs/export-components/ExportComponentsController.tsx",
         "component": "ExportComponentsDialog",
-        "line": 285,
+        "line": 301,
         "conditional": false,
         "expression": "radioInput(\"export-all-icons\", !allIcons, () => setAllIcons(false))",
         "inputs": [
           {
             "name": "radioInput",
             "declaredAt": {
-              "line": 357,
+              "line": 373,
               "kind": "function"
             }
           },
@@ -1582,7 +1582,7 @@
       {
         "file": "app/dialogs/export-components/ExportComponentsController.tsx",
         "component": "ExportComponentsDialog",
-        "line": 286,
+        "line": 302,
         "conditional": false,
         "expression": "{ children: \"No\" }",
         "inputs": [],
@@ -1599,14 +1599,14 @@
       {
         "file": "app/dialogs/export-components/ExportComponentsController.tsx",
         "component": "ExportComponentsDialog",
-        "line": 281,
+        "line": 297,
         "conditional": false,
         "expression": "radioRow(() => setAllIcons(true))",
         "inputs": [
           {
             "name": "radioRow",
             "declaredAt": {
-              "line": 352,
+              "line": 368,
               "kind": "function"
             }
           },
@@ -1625,14 +1625,14 @@
       {
         "file": "app/dialogs/export-components/ExportComponentsController.tsx",
         "component": "ExportComponentsDialog",
-        "line": 282,
+        "line": 298,
         "conditional": false,
         "expression": "radioInput(\"export-all-icons\", allIcons, () => setAllIcons(true))",
         "inputs": [
           {
             "name": "radioInput",
             "declaredAt": {
-              "line": 357,
+              "line": 373,
               "kind": "function"
             }
           },
@@ -1658,7 +1658,7 @@
       {
         "file": "app/dialogs/export-components/ExportComponentsController.tsx",
         "component": "ExportComponentsDialog",
-        "line": 283,
+        "line": 299,
         "conditional": false,
         "expression": "{ children: \"Yes\" }",
         "inputs": [],
@@ -1675,7 +1675,7 @@
       {
         "file": "app/dialogs/export-components/ExportComponentsController.tsx",
         "component": "ExportComponentsDialog",
-        "line": 261,
+        "line": 277,
         "conditional": false,
         "expression": "{ role: \"radiogroup\", \"aria-label\": EXPORT_FLAG.allThemes.ariaLabel }",
         "inputs": [
@@ -1715,7 +1715,7 @@
       {
         "file": "app/dialogs/export-components/ExportComponentsController.tsx",
         "component": "ExportComponentsDialog",
-        "line": 262,
+        "line": 278,
         "conditional": false,
         "expression": "{ children: EXPORT_FLAG.allThemes.label }",
         "inputs": [
@@ -1750,14 +1750,14 @@
       {
         "file": "app/dialogs/export-components/ExportComponentsController.tsx",
         "component": "ExportComponentsDialog",
-        "line": 266,
+        "line": 282,
         "conditional": false,
         "expression": "radioRow(() => setAllThemes(false))",
         "inputs": [
           {
             "name": "radioRow",
             "declaredAt": {
-              "line": 352,
+              "line": 368,
               "kind": "function"
             }
           },
@@ -1776,14 +1776,14 @@
       {
         "file": "app/dialogs/export-components/ExportComponentsController.tsx",
         "component": "ExportComponentsDialog",
-        "line": 267,
+        "line": 283,
         "conditional": false,
         "expression": "radioInput(\"export-all-themes\", !allThemes, () => setAllThemes(false))",
         "inputs": [
           {
             "name": "radioInput",
             "declaredAt": {
-              "line": 357,
+              "line": 373,
               "kind": "function"
             }
           },
@@ -1809,7 +1809,7 @@
       {
         "file": "app/dialogs/export-components/ExportComponentsController.tsx",
         "component": "ExportComponentsDialog",
-        "line": 268,
+        "line": 284,
         "conditional": false,
         "expression": "{ children: \"No\" }",
         "inputs": [],
@@ -1826,14 +1826,14 @@
       {
         "file": "app/dialogs/export-components/ExportComponentsController.tsx",
         "component": "ExportComponentsDialog",
-        "line": 263,
+        "line": 279,
         "conditional": false,
         "expression": "radioRow(() => setAllThemes(true))",
         "inputs": [
           {
             "name": "radioRow",
             "declaredAt": {
-              "line": 352,
+              "line": 368,
               "kind": "function"
             }
           },
@@ -1852,14 +1852,14 @@
       {
         "file": "app/dialogs/export-components/ExportComponentsController.tsx",
         "component": "ExportComponentsDialog",
-        "line": 264,
+        "line": 280,
         "conditional": false,
         "expression": "radioInput(\"export-all-themes\", allThemes, () => setAllThemes(true))",
         "inputs": [
           {
             "name": "radioInput",
             "declaredAt": {
-              "line": 357,
+              "line": 373,
               "kind": "function"
             }
           },
@@ -1885,7 +1885,7 @@
       {
         "file": "app/dialogs/export-components/ExportComponentsController.tsx",
         "component": "ExportComponentsDialog",
-        "line": 265,
+        "line": 281,
         "conditional": false,
         "expression": "{ children: \"Yes\" }",
         "inputs": [],
@@ -1902,7 +1902,7 @@
       {
         "file": "app/dialogs/export-components/ExportComponentsController.tsx",
         "component": "ExportComponentsDialog",
-        "line": 314,
+        "line": 330,
         "conditional": false,
         "expression": "{ onClick: cancel }",
         "inputs": [
@@ -1935,7 +1935,7 @@
       {
         "file": "app/dialogs/export-components/ExportComponentsController.tsx",
         "component": "ExportComponentsDialog",
-        "line": 315,
+        "line": 331,
         "conditional": false,
         "expression": "{ children: \"Cancel\" }",
         "inputs": [],
@@ -1952,7 +1952,7 @@
       {
         "file": "app/dialogs/export-components/ExportComponentsController.tsx",
         "component": "ExportComponentsDialog",
-        "line": 316,
+        "line": 332,
         "conditional": false,
         "expression": "{ onClick: save, \"aria-disabled\": exporting, style: confirmStyle }",
         "inputs": [
@@ -1973,7 +1973,7 @@
           {
             "name": "confirmStyle",
             "declaredAt": {
-              "line": 176,
+              "line": 183,
               "kind": "const"
             }
           }
@@ -2012,7 +2012,7 @@
               {
                 "name": "confirmStyle",
                 "declaredAt": {
-                  "line": 176,
+                  "line": 183,
                   "kind": "const"
                 }
               }
@@ -2025,7 +2025,7 @@
       {
         "file": "app/dialogs/export-components/ExportComponentsController.tsx",
         "component": "ExportComponentsDialog",
-        "line": 317,
+        "line": 333,
         "conditional": false,
         "expression": "{ children: \"Export\" }",
         "inputs": [],
@@ -2042,7 +2042,7 @@
       {
         "file": "app/dialogs/export-components/ExportComponentsController.tsx",
         "component": "ExportComponentsDialog",
-        "line": 235,
+        "line": 251,
         "conditional": false,
         "expression": "{}",
         "inputs": [],
@@ -2053,7 +2053,7 @@
       {
         "file": "app/dialogs/export-components/ExportComponentsController.tsx",
         "component": "ExportComponentsDialog",
-        "line": 236,
+        "line": 252,
         "conditional": false,
         "expression": "{ children: \"Include\" }",
         "inputs": [],
@@ -2070,7 +2070,7 @@
       {
         "file": "app/dialogs/export-components/ExportComponentsController.tsx",
         "component": "ExportComponentsDialog",
-        "line": 243,
+        "line": 259,
         "conditional": false,
         "expression": "{ role: \"radiogroup\", \"aria-label\": EXPORT_FLAG.fontLinks.ariaLabel }",
         "inputs": [
@@ -2110,7 +2110,7 @@
       {
         "file": "app/dialogs/export-components/ExportComponentsController.tsx",
         "component": "ExportComponentsDialog",
-        "line": 244,
+        "line": 260,
         "conditional": false,
         "expression": "{ children: EXPORT_FLAG.fontLinks.label }",
         "inputs": [
@@ -2145,14 +2145,14 @@
       {
         "file": "app/dialogs/export-components/ExportComponentsController.tsx",
         "component": "ExportComponentsDialog",
-        "line": 248,
+        "line": 264,
         "conditional": false,
         "expression": "radioRow(() => setFontLinks(false))",
         "inputs": [
           {
             "name": "radioRow",
             "declaredAt": {
-              "line": 352,
+              "line": 368,
               "kind": "function"
             }
           },
@@ -2171,14 +2171,14 @@
       {
         "file": "app/dialogs/export-components/ExportComponentsController.tsx",
         "component": "ExportComponentsDialog",
-        "line": 249,
+        "line": 265,
         "conditional": false,
         "expression": "radioInput(\"export-font-links\", !fontLinks, () => setFontLinks(false))",
         "inputs": [
           {
             "name": "radioInput",
             "declaredAt": {
-              "line": 357,
+              "line": 373,
               "kind": "function"
             }
           },
@@ -2204,7 +2204,7 @@
       {
         "file": "app/dialogs/export-components/ExportComponentsController.tsx",
         "component": "ExportComponentsDialog",
-        "line": 250,
+        "line": 266,
         "conditional": false,
         "expression": "{ children: \"No\" }",
         "inputs": [],
@@ -2221,14 +2221,14 @@
       {
         "file": "app/dialogs/export-components/ExportComponentsController.tsx",
         "component": "ExportComponentsDialog",
-        "line": 245,
+        "line": 261,
         "conditional": false,
         "expression": "radioRow(() => setFontLinks(true))",
         "inputs": [
           {
             "name": "radioRow",
             "declaredAt": {
-              "line": 352,
+              "line": 368,
               "kind": "function"
             }
           },
@@ -2247,14 +2247,14 @@
       {
         "file": "app/dialogs/export-components/ExportComponentsController.tsx",
         "component": "ExportComponentsDialog",
-        "line": 246,
+        "line": 262,
         "conditional": false,
         "expression": "radioInput(\"export-font-links\", fontLinks, () => setFontLinks(true))",
         "inputs": [
           {
             "name": "radioInput",
             "declaredAt": {
-              "line": 357,
+              "line": 373,
               "kind": "function"
             }
           },
@@ -2280,7 +2280,7 @@
       {
         "file": "app/dialogs/export-components/ExportComponentsController.tsx",
         "component": "ExportComponentsDialog",
-        "line": 247,
+        "line": 263,
         "conditional": false,
         "expression": "{ children: \"Yes\" }",
         "inputs": [],
@@ -2297,7 +2297,7 @@
       {
         "file": "app/dialogs/export-components/ExportComponentsController.tsx",
         "component": "ExportComponentsDialog",
-        "line": 203,
+        "line": 220,
         "conditional": false,
         "expression": "{}",
         "inputs": [],
@@ -2308,7 +2308,7 @@
       {
         "file": "app/dialogs/export-components/ExportComponentsController.tsx",
         "component": "ExportComponentsDialog",
-        "line": 205,
+        "line": 222,
         "conditional": false,
         "expression": "{}",
         "inputs": [],
@@ -2319,14 +2319,14 @@
       {
         "file": "app/dialogs/export-components/ExportComponentsController.tsx",
         "component": "ExportComponentsDialog",
-        "line": 206,
+        "line": 223,
         "conditional": false,
         "expression": "{ value: frameworkLabel, readOnly: true, onClick: openFramework, \"aria-expanded\": frameworkOpen, style: styles.opaquePointer, }",
         "inputs": [
           {
             "name": "frameworkLabel",
             "declaredAt": {
-              "line": 136,
+              "line": 138,
               "kind": "const",
               "via": "useMemo"
             }
@@ -2334,7 +2334,7 @@
           {
             "name": "openFramework",
             "declaredAt": {
-              "line": 112,
+              "line": 114,
               "kind": "const",
               "via": "useCallback"
             }
@@ -2342,7 +2342,7 @@
           {
             "name": "frameworkOpen",
             "declaredAt": {
-              "line": 103,
+              "line": 105,
               "kind": "const",
               "via": "useState"
             }
@@ -2350,7 +2350,7 @@
           {
             "name": "styles",
             "declaredAt": {
-              "line": 361,
+              "line": 377,
               "kind": "const"
             }
           }
@@ -2363,7 +2363,7 @@
               {
                 "name": "frameworkLabel",
                 "declaredAt": {
-                  "line": 136,
+                  "line": 138,
                   "kind": "const",
                   "via": "useMemo"
                 }
@@ -2382,7 +2382,7 @@
               {
                 "name": "openFramework",
                 "declaredAt": {
-                  "line": 112,
+                  "line": 114,
                   "kind": "const",
                   "via": "useCallback"
                 }
@@ -2396,7 +2396,7 @@
               {
                 "name": "frameworkOpen",
                 "declaredAt": {
-                  "line": 103,
+                  "line": 105,
                   "kind": "const",
                   "via": "useState"
                 }
@@ -2410,7 +2410,7 @@
               {
                 "name": "styles",
                 "declaredAt": {
-                  "line": 361,
+                  "line": 377,
                   "kind": "const"
                 }
               }
@@ -2423,14 +2423,14 @@
       {
         "file": "app/dialogs/export-components/ExportComponentsController.tsx",
         "component": "ExportComponentsDialog",
-        "line": 204,
+        "line": 221,
         "conditional": false,
-        "expression": "{ children: \"Framework\" }",
+        "expression": "{ children: \"App Framework\" }",
         "inputs": [],
         "props": [
           {
             "key": "children",
-            "expression": "\"Framework\"",
+            "expression": "\"App Framework\"",
             "inputs": []
           }
         ]
@@ -2440,7 +2440,7 @@
       {
         "file": "app/dialogs/export-components/ExportComponentsController.tsx",
         "component": "ExportComponentsDialog",
-        "line": 252,
+        "line": 268,
         "conditional": false,
         "expression": "{ role: \"radiogroup\", \"aria-label\": EXPORT_FLAG.includeHidden.ariaLabel }",
         "inputs": [
@@ -2480,7 +2480,7 @@
       {
         "file": "app/dialogs/export-components/ExportComponentsController.tsx",
         "component": "ExportComponentsDialog",
-        "line": 253,
+        "line": 269,
         "conditional": false,
         "expression": "{ children: EXPORT_FLAG.includeHidden.label }",
         "inputs": [
@@ -2515,14 +2515,14 @@
       {
         "file": "app/dialogs/export-components/ExportComponentsController.tsx",
         "component": "ExportComponentsDialog",
-        "line": 257,
+        "line": 273,
         "conditional": false,
         "expression": "radioRow(() => setIncludeHidden(false))",
         "inputs": [
           {
             "name": "radioRow",
             "declaredAt": {
-              "line": 352,
+              "line": 368,
               "kind": "function"
             }
           },
@@ -2541,14 +2541,14 @@
       {
         "file": "app/dialogs/export-components/ExportComponentsController.tsx",
         "component": "ExportComponentsDialog",
-        "line": 258,
+        "line": 274,
         "conditional": false,
         "expression": "radioInput(\"export-hidden\", !includeHidden, () => setIncludeHidden(false))",
         "inputs": [
           {
             "name": "radioInput",
             "declaredAt": {
-              "line": 357,
+              "line": 373,
               "kind": "function"
             }
           },
@@ -2574,7 +2574,7 @@
       {
         "file": "app/dialogs/export-components/ExportComponentsController.tsx",
         "component": "ExportComponentsDialog",
-        "line": 259,
+        "line": 275,
         "conditional": false,
         "expression": "{ children: \"No\" }",
         "inputs": [],
@@ -2591,14 +2591,14 @@
       {
         "file": "app/dialogs/export-components/ExportComponentsController.tsx",
         "component": "ExportComponentsDialog",
-        "line": 254,
+        "line": 270,
         "conditional": false,
         "expression": "radioRow(() => setIncludeHidden(true))",
         "inputs": [
           {
             "name": "radioRow",
             "declaredAt": {
-              "line": 352,
+              "line": 368,
               "kind": "function"
             }
           },
@@ -2617,14 +2617,14 @@
       {
         "file": "app/dialogs/export-components/ExportComponentsController.tsx",
         "component": "ExportComponentsDialog",
-        "line": 255,
+        "line": 271,
         "conditional": false,
         "expression": "radioInput(\"export-hidden\", includeHidden, () => setIncludeHidden(true))",
         "inputs": [
           {
             "name": "radioInput",
             "declaredAt": {
-              "line": 357,
+              "line": 373,
               "kind": "function"
             }
           },
@@ -2650,7 +2650,7 @@
       {
         "file": "app/dialogs/export-components/ExportComponentsController.tsx",
         "component": "ExportComponentsDialog",
-        "line": 256,
+        "line": 272,
         "conditional": false,
         "expression": "{ children: \"Yes\" }",
         "inputs": [],
@@ -2663,11 +2663,119 @@
         ]
       }
     ],
+    "exportOutputFolder": [
+      {
+        "file": "app/dialogs/export-components/ExportComponentsController.tsx",
+        "component": "ExportComponentsDialog",
+        "line": 242,
+        "conditional": false,
+        "expression": "{}",
+        "inputs": [],
+        "props": []
+      }
+    ],
+    "exportOutputFolderField": [
+      {
+        "file": "app/dialogs/export-components/ExportComponentsController.tsx",
+        "component": "ExportComponentsDialog",
+        "line": 244,
+        "conditional": false,
+        "expression": "{ value: outputFolder, placeholder: \"Project root\", onChange: changeOutputFolder, style: styles.opaque, }",
+        "inputs": [
+          {
+            "name": "outputFolder",
+            "declaredAt": {
+              "line": 55,
+              "kind": "parameter"
+            }
+          },
+          {
+            "name": "changeOutputFolder",
+            "declaredAt": {
+              "line": 161,
+              "kind": "const",
+              "via": "useCallback"
+            }
+          },
+          {
+            "name": "styles",
+            "declaredAt": {
+              "line": 377,
+              "kind": "const"
+            }
+          }
+        ],
+        "props": [
+          {
+            "key": "value",
+            "expression": "outputFolder",
+            "inputs": [
+              {
+                "name": "outputFolder",
+                "declaredAt": {
+                  "line": 55,
+                  "kind": "parameter"
+                }
+              }
+            ]
+          },
+          {
+            "key": "placeholder",
+            "expression": "\"Project root\"",
+            "inputs": []
+          },
+          {
+            "key": "onChange",
+            "expression": "changeOutputFolder",
+            "inputs": [
+              {
+                "name": "changeOutputFolder",
+                "declaredAt": {
+                  "line": 161,
+                  "kind": "const",
+                  "via": "useCallback"
+                }
+              }
+            ]
+          },
+          {
+            "key": "style",
+            "expression": "styles.opaque",
+            "inputs": [
+              {
+                "name": "styles",
+                "declaredAt": {
+                  "line": 377,
+                  "kind": "const"
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "exportOutputFolderLabel": [
+      {
+        "file": "app/dialogs/export-components/ExportComponentsController.tsx",
+        "component": "ExportComponentsDialog",
+        "line": 243,
+        "conditional": false,
+        "expression": "{ children: \"Export To\" }",
+        "inputs": [],
+        "props": [
+          {
+            "key": "children",
+            "expression": "\"Export To\"",
+            "inputs": []
+          }
+        ]
+      }
+    ],
     "exportPlatform": [
       {
         "file": "app/dialogs/export-components/ExportComponentsController.tsx",
         "component": "ExportComponentsDialog",
-        "line": 214,
+        "line": 231,
         "conditional": false,
         "expression": "{}",
         "inputs": [],
@@ -2678,7 +2786,7 @@
       {
         "file": "app/dialogs/export-components/ExportComponentsController.tsx",
         "component": "ExportComponentsDialog",
-        "line": 216,
+        "line": 233,
         "conditional": false,
         "expression": "{}",
         "inputs": [],
@@ -2689,14 +2797,14 @@
       {
         "file": "app/dialogs/export-components/ExportComponentsController.tsx",
         "component": "ExportComponentsDialog",
-        "line": 217,
+        "line": 234,
         "conditional": false,
         "expression": "{ value: platformLabel, readOnly: true, onClick: openPlatform, \"aria-expanded\": platformOpen, style: styles.opaquePointer, }",
         "inputs": [
           {
             "name": "platformLabel",
             "declaredAt": {
-              "line": 118,
+              "line": 120,
               "kind": "const",
               "via": "useMemo"
             }
@@ -2704,7 +2812,7 @@
           {
             "name": "openPlatform",
             "declaredAt": {
-              "line": 106,
+              "line": 108,
               "kind": "const",
               "via": "useCallback"
             }
@@ -2712,7 +2820,7 @@
           {
             "name": "platformOpen",
             "declaredAt": {
-              "line": 101,
+              "line": 103,
               "kind": "const",
               "via": "useState"
             }
@@ -2720,7 +2828,7 @@
           {
             "name": "styles",
             "declaredAt": {
-              "line": 361,
+              "line": 377,
               "kind": "const"
             }
           }
@@ -2733,7 +2841,7 @@
               {
                 "name": "platformLabel",
                 "declaredAt": {
-                  "line": 118,
+                  "line": 120,
                   "kind": "const",
                   "via": "useMemo"
                 }
@@ -2752,7 +2860,7 @@
               {
                 "name": "openPlatform",
                 "declaredAt": {
-                  "line": 106,
+                  "line": 108,
                   "kind": "const",
                   "via": "useCallback"
                 }
@@ -2766,7 +2874,7 @@
               {
                 "name": "platformOpen",
                 "declaredAt": {
-                  "line": 101,
+                  "line": 103,
                   "kind": "const",
                   "via": "useState"
                 }
@@ -2780,7 +2888,7 @@
               {
                 "name": "styles",
                 "declaredAt": {
-                  "line": 361,
+                  "line": 377,
                   "kind": "const"
                 }
               }
@@ -2793,14 +2901,14 @@
       {
         "file": "app/dialogs/export-components/ExportComponentsController.tsx",
         "component": "ExportComponentsDialog",
-        "line": 215,
+        "line": 232,
         "conditional": false,
-        "expression": "{ children: \"Platform\" }",
+        "expression": "{ children: \"Component Type\" }",
         "inputs": [],
         "props": [
           {
             "key": "children",
-            "expression": "\"Platform\"",
+            "expression": "\"Component Type\"",
             "inputs": []
           }
         ]
@@ -2810,7 +2918,7 @@
       {
         "file": "app/dialogs/export-components/ExportComponentsController.tsx",
         "component": "ExportComponentsDialog",
-        "line": 225,
+        "line": 210,
         "conditional": false,
         "expression": "{}",
         "inputs": [],
@@ -2821,14 +2929,14 @@
       {
         "file": "app/dialogs/export-components/ExportComponentsController.tsx",
         "component": "ExportComponentsDialog",
-        "line": 227,
+        "line": 212,
         "conditional": false,
         "expression": "{ value: directoryLabel, placeholder: \"Choose a folder…\", readOnly: true, onClick: chooseDirectory, style: styles.opaquePointer, }",
         "inputs": [
           {
             "name": "directoryLabel",
             "declaredAt": {
-              "line": 171,
+              "line": 178,
               "kind": "const"
             }
           },
@@ -2842,7 +2950,7 @@
           {
             "name": "styles",
             "declaredAt": {
-              "line": 361,
+              "line": 377,
               "kind": "const"
             }
           }
@@ -2855,7 +2963,7 @@
               {
                 "name": "directoryLabel",
                 "declaredAt": {
-                  "line": 171,
+                  "line": 178,
                   "kind": "const"
                 }
               }
@@ -2891,7 +2999,7 @@
               {
                 "name": "styles",
                 "declaredAt": {
-                  "line": 361,
+                  "line": 377,
                   "kind": "const"
                 }
               }
@@ -2904,14 +3012,14 @@
       {
         "file": "app/dialogs/export-components/ExportComponentsController.tsx",
         "component": "ExportComponentsDialog",
-        "line": 226,
+        "line": 211,
         "conditional": false,
-        "expression": "{ children: \"Project Folder\" }",
+        "expression": "{ children: \"Root Folder\" }",
         "inputs": [],
         "props": [
           {
             "key": "children",
-            "expression": "\"Project Folder\"",
+            "expression": "\"Root Folder\"",
             "inputs": []
           }
         ]
@@ -2921,7 +3029,7 @@
       {
         "file": "app/dialogs/export-components/ExportComponentsController.tsx",
         "component": "ExportComponentsDialog",
-        "line": 301,
+        "line": 317,
         "conditional": false,
         "expression": "{ role: \"radiogroup\", \"aria-label\": EXPORT_FLAG.includeScripts.ariaLabel }",
         "inputs": [
@@ -2961,7 +3069,7 @@
       {
         "file": "app/dialogs/export-components/ExportComponentsController.tsx",
         "component": "ExportComponentsDialog",
-        "line": 302,
+        "line": 318,
         "conditional": false,
         "expression": "{ children: EXPORT_FLAG.includeScripts.label }",
         "inputs": [
@@ -2996,14 +3104,14 @@
       {
         "file": "app/dialogs/export-components/ExportComponentsController.tsx",
         "component": "ExportComponentsDialog",
-        "line": 308,
+        "line": 324,
         "conditional": false,
         "expression": "radioRow(() => setIncludeScripts(false))",
         "inputs": [
           {
             "name": "radioRow",
             "declaredAt": {
-              "line": 352,
+              "line": 368,
               "kind": "function"
             }
           },
@@ -3022,14 +3130,14 @@
       {
         "file": "app/dialogs/export-components/ExportComponentsController.tsx",
         "component": "ExportComponentsDialog",
-        "line": 309,
+        "line": 325,
         "conditional": false,
         "expression": "radioInput(\"export-scripts\", !includeScripts, () => setIncludeScripts(false), )",
         "inputs": [
           {
             "name": "radioInput",
             "declaredAt": {
-              "line": 357,
+              "line": 373,
               "kind": "function"
             }
           },
@@ -3055,7 +3163,7 @@
       {
         "file": "app/dialogs/export-components/ExportComponentsController.tsx",
         "component": "ExportComponentsDialog",
-        "line": 312,
+        "line": 328,
         "conditional": false,
         "expression": "{ children: \"No\" }",
         "inputs": [],
@@ -3072,14 +3180,14 @@
       {
         "file": "app/dialogs/export-components/ExportComponentsController.tsx",
         "component": "ExportComponentsDialog",
-        "line": 303,
+        "line": 319,
         "conditional": false,
         "expression": "radioRow(() => setIncludeScripts(true))",
         "inputs": [
           {
             "name": "radioRow",
             "declaredAt": {
-              "line": 352,
+              "line": 368,
               "kind": "function"
             }
           },
@@ -3098,14 +3206,14 @@
       {
         "file": "app/dialogs/export-components/ExportComponentsController.tsx",
         "component": "ExportComponentsDialog",
-        "line": 304,
+        "line": 320,
         "conditional": false,
         "expression": "radioInput(\"export-scripts\", includeScripts, () => setIncludeScripts(true), )",
         "inputs": [
           {
             "name": "radioInput",
             "declaredAt": {
-              "line": 357,
+              "line": 373,
               "kind": "function"
             }
           },
@@ -3131,7 +3239,7 @@
       {
         "file": "app/dialogs/export-components/ExportComponentsController.tsx",
         "component": "ExportComponentsDialog",
-        "line": 307,
+        "line": 323,
         "conditional": false,
         "expression": "{ children: \"Yes\" }",
         "inputs": [],
@@ -3148,7 +3256,7 @@
       {
         "file": "app/dialogs/export-components/ExportComponentsController.tsx",
         "component": "ExportComponentsDialog",
-        "line": 190,
+        "line": 197,
         "conditional": false,
         "expression": "{ children: \"Export Components\" }",
         "inputs": [],
@@ -3165,7 +3273,7 @@
       {
         "file": "app/dialogs/export-components/ExportComponentsController.tsx",
         "component": "ExportComponentsDialog",
-        "line": 288,
+        "line": 304,
         "conditional": false,
         "expression": "{ role: \"radiogroup\", \"aria-label\": EXPORT_FLAG.savedWorkspace.ariaLabel }",
         "inputs": [
@@ -3205,7 +3313,7 @@
       {
         "file": "app/dialogs/export-components/ExportComponentsController.tsx",
         "component": "ExportComponentsDialog",
-        "line": 289,
+        "line": 305,
         "conditional": false,
         "expression": "{ children: EXPORT_FLAG.savedWorkspace.label }",
         "inputs": [
@@ -3240,7 +3348,7 @@
       {
         "file": "app/dialogs/export-components/ExportComponentsController.tsx",
         "component": "ExportComponentsDialog",
-        "line": 192,
+        "line": 199,
         "conditional": false,
         "expression": "{}",
         "inputs": [],
@@ -3251,7 +3359,7 @@
       {
         "file": "app/dialogs/export-components/ExportComponentsController.tsx",
         "component": "ExportComponentsDialog",
-        "line": 194,
+        "line": 201,
         "conditional": false,
         "expression": "{ value: workspaceName, placeholder: \"Untitled workspace\", onChange: changeWorkspaceName, onBlur: commitWorkspaceName, onKeyDown: commitNameOnEnter, style: styl...",
         "inputs": [
@@ -3265,7 +3373,7 @@
           {
             "name": "changeWorkspaceName",
             "declaredAt": {
-              "line": 154,
+              "line": 156,
               "kind": "const",
               "via": "useCallback"
             }
@@ -3280,7 +3388,7 @@
           {
             "name": "commitNameOnEnter",
             "declaredAt": {
-              "line": 161,
+              "line": 168,
               "kind": "const",
               "via": "useCallback"
             }
@@ -3288,7 +3396,7 @@
           {
             "name": "styles",
             "declaredAt": {
-              "line": 361,
+              "line": 377,
               "kind": "const"
             }
           }
@@ -3319,7 +3427,7 @@
               {
                 "name": "changeWorkspaceName",
                 "declaredAt": {
-                  "line": 154,
+                  "line": 156,
                   "kind": "const",
                   "via": "useCallback"
                 }
@@ -3346,7 +3454,7 @@
               {
                 "name": "commitNameOnEnter",
                 "declaredAt": {
-                  "line": 161,
+                  "line": 168,
                   "kind": "const",
                   "via": "useCallback"
                 }
@@ -3360,7 +3468,7 @@
               {
                 "name": "styles",
                 "declaredAt": {
-                  "line": 361,
+                  "line": 377,
                   "kind": "const"
                 }
               }
@@ -3373,7 +3481,7 @@
       {
         "file": "app/dialogs/export-components/ExportComponentsController.tsx",
         "component": "ExportComponentsDialog",
-        "line": 193,
+        "line": 200,
         "conditional": false,
         "expression": "{ children: \"Workspace Name\" }",
         "inputs": [],
@@ -3390,14 +3498,14 @@
       {
         "file": "app/dialogs/export-components/ExportComponentsController.tsx",
         "component": "ExportComponentsDialog",
-        "line": 295,
+        "line": 311,
         "conditional": false,
         "expression": "radioRow(() => setSavedWorkspace(false))",
         "inputs": [
           {
             "name": "radioRow",
             "declaredAt": {
-              "line": 352,
+              "line": 368,
               "kind": "function"
             }
           },
@@ -3416,14 +3524,14 @@
       {
         "file": "app/dialogs/export-components/ExportComponentsController.tsx",
         "component": "ExportComponentsDialog",
-        "line": 296,
+        "line": 312,
         "conditional": false,
         "expression": "radioInput(\"export-saved-workspace\", !savedWorkspace, () => setSavedWorkspace(false), )",
         "inputs": [
           {
             "name": "radioInput",
             "declaredAt": {
-              "line": 357,
+              "line": 373,
               "kind": "function"
             }
           },
@@ -3449,7 +3557,7 @@
       {
         "file": "app/dialogs/export-components/ExportComponentsController.tsx",
         "component": "ExportComponentsDialog",
-        "line": 299,
+        "line": 315,
         "conditional": false,
         "expression": "{ children: \"No\" }",
         "inputs": [],
@@ -3466,14 +3574,14 @@
       {
         "file": "app/dialogs/export-components/ExportComponentsController.tsx",
         "component": "ExportComponentsDialog",
-        "line": 290,
+        "line": 306,
         "conditional": false,
         "expression": "radioRow(() => setSavedWorkspace(true))",
         "inputs": [
           {
             "name": "radioRow",
             "declaredAt": {
-              "line": 352,
+              "line": 368,
               "kind": "function"
             }
           },
@@ -3492,14 +3600,14 @@
       {
         "file": "app/dialogs/export-components/ExportComponentsController.tsx",
         "component": "ExportComponentsDialog",
-        "line": 291,
+        "line": 307,
         "conditional": false,
         "expression": "radioInput(\"export-saved-workspace\", savedWorkspace, () => setSavedWorkspace(true), )",
         "inputs": [
           {
             "name": "radioInput",
             "declaredAt": {
-              "line": 357,
+              "line": 373,
               "kind": "function"
             }
           },
@@ -3525,7 +3633,7 @@
       {
         "file": "app/dialogs/export-components/ExportComponentsController.tsx",
         "component": "ExportComponentsDialog",
-        "line": 294,
+        "line": 310,
         "conditional": false,
         "expression": "{ children: \"Yes\" }",
         "inputs": [],
@@ -7461,123 +7569,6 @@
           }
         ],
         "props": []
-      }
-    ],
-    "optionAnnotation": [
-      {
-        "file": "app/menus/ComboboxOptions.tsx",
-        "component": "renderOption",
-        "line": 144,
-        "conditional": false,
-        "expression": "{ children: option.annotation }",
-        "inputs": [
-          {
-            "name": "option",
-            "declaredAt": {
-              "line": 41,
-              "kind": "parameter"
-            }
-          }
-        ],
-        "props": [
-          {
-            "key": "children",
-            "expression": "option.annotation",
-            "inputs": [
-              {
-                "name": "option",
-                "declaredAt": {
-                  "line": 41,
-                  "kind": "parameter"
-                }
-              }
-            ]
-          }
-        ]
-      }
-    ],
-    "optionIcon": [
-      {
-        "file": "app/menus/ComboboxOptions.tsx",
-        "component": "renderOption",
-        "line": 142,
-        "conditional": false,
-        "expression": "{ icon: icon.icon as IconProps[\"icon\"] }",
-        "inputs": [
-          {
-            "name": "icon",
-            "declaredAt": {
-              "line": 113,
-              "kind": "const",
-              "via": "resolveIcon"
-            }
-          },
-          {
-            "name": "IconProps",
-            "declaredAt": {
-              "line": 23,
-              "kind": "import",
-              "module": "@seldon/components/primitives/Icon"
-            }
-          }
-        ],
-        "props": [
-          {
-            "key": "icon",
-            "expression": "icon.icon as IconProps[\"icon\"]",
-            "inputs": [
-              {
-                "name": "icon",
-                "declaredAt": {
-                  "line": 113,
-                  "kind": "const",
-                  "via": "resolveIcon"
-                }
-              },
-              {
-                "name": "IconProps",
-                "declaredAt": {
-                  "line": 23,
-                  "kind": "import",
-                  "module": "@seldon/components/primitives/Icon"
-                }
-              }
-            ]
-          }
-        ]
-      }
-    ],
-    "optionLabel": [
-      {
-        "file": "app/menus/ComboboxOptions.tsx",
-        "component": "renderOption",
-        "line": 143,
-        "conditional": false,
-        "expression": "{ children: option.name }",
-        "inputs": [
-          {
-            "name": "option",
-            "declaredAt": {
-              "line": 41,
-              "kind": "parameter"
-            }
-          }
-        ],
-        "props": [
-          {
-            "key": "children",
-            "expression": "option.name",
-            "inputs": [
-              {
-                "name": "option",
-                "declaredAt": {
-                  "line": 41,
-                  "kind": "parameter"
-                }
-              }
-            ]
-          }
-        ]
       }
     ],
     "paletteClose": [
@@ -12332,13 +12323,13 @@
         {
           "file": "app/dialogs/export-components/ExportComponentsController.tsx",
           "component": "ExportComponentsDialog",
-          "line": 332,
+          "line": 348,
           "expression": "barHandle",
           "inputs": [
             {
               "name": "barHandle",
               "declaredAt": {
-                "line": 178,
+                "line": 185,
                 "kind": "const",
                 "via": "useMemo"
               }
@@ -12453,13 +12444,13 @@
         {
           "file": "app/menus/ComboboxOptions.tsx",
           "component": "ComboboxOptions",
-          "line": 188,
+          "line": 211,
           "expression": "handleClose",
           "inputs": [
             {
               "name": "handleClose",
               "declaredAt": {
-                "line": 73,
+                "line": 97,
                 "kind": "parameter"
               }
             }
@@ -14761,13 +14752,13 @@
         {
           "file": "app/menus/ComboboxOptions.tsx",
           "component": "renderOption",
-          "line": 128,
+          "line": 152,
           "expression": "option.disabled || undefined",
           "inputs": [
             {
               "name": "option",
               "declaredAt": {
-                "line": 41,
+                "line": 42,
                 "kind": "parameter"
               }
             }
@@ -14777,13 +14768,13 @@
         {
           "file": "app/menus/ComboboxOptions.tsx",
           "component": "renderOption",
-          "line": 128,
+          "line": 152,
           "expression": "option.disabled || undefined",
           "inputs": [
             {
               "name": "option",
               "declaredAt": {
-                "line": 41,
+                "line": 42,
                 "kind": "parameter"
               }
             }
@@ -14795,13 +14786,13 @@
         {
           "file": "app/menus/ComboboxOptions.tsx",
           "component": "renderOption",
-          "line": 127,
+          "line": 151,
           "expression": "isSelected || undefined",
           "inputs": [
             {
               "name": "isSelected",
               "declaredAt": {
-                "line": 111,
+                "line": 135,
                 "kind": "const"
               }
             }
@@ -14811,13 +14802,13 @@
         {
           "file": "app/menus/ComboboxOptions.tsx",
           "component": "renderOption",
-          "line": 127,
+          "line": 151,
           "expression": "isSelected || undefined",
           "inputs": [
             {
               "name": "isSelected",
               "declaredAt": {
-                "line": 111,
+                "line": 135,
                 "kind": "const"
               }
             }
@@ -14829,20 +14820,20 @@
         {
           "file": "app/menus/ComboboxOptions.tsx",
           "component": "renderOption",
-          "line": 129,
+          "line": 153,
           "expression": "isHighlighted ? HIGHLIGHT_CLASS : undefined",
           "inputs": [
             {
               "name": "isHighlighted",
               "declaredAt": {
-                "line": 112,
+                "line": 136,
                 "kind": "const"
               }
             },
             {
               "name": "HIGHLIGHT_CLASS",
               "declaredAt": {
-                "line": 49,
+                "line": 50,
                 "kind": "const"
               }
             }
@@ -14852,20 +14843,20 @@
         {
           "file": "app/menus/ComboboxOptions.tsx",
           "component": "renderOption",
-          "line": 129,
+          "line": 153,
           "expression": "isHighlighted ? HIGHLIGHT_CLASS : undefined",
           "inputs": [
             {
               "name": "isHighlighted",
               "declaredAt": {
-                "line": 112,
+                "line": 136,
                 "kind": "const"
               }
             },
             {
               "name": "HIGHLIGHT_CLASS",
               "declaredAt": {
-                "line": 49,
+                "line": 50,
                 "kind": "const"
               }
             }
@@ -14877,7 +14868,7 @@
         {
           "file": "app/menus/ComboboxOptions.tsx",
           "component": "renderOption",
-          "line": 151,
+          "line": 174,
           "expression": "{}",
           "inputs": [],
           "spread": false
@@ -14887,13 +14878,13 @@
         {
           "file": "app/menus/ComboboxOptions.tsx",
           "component": "renderOption",
-          "line": 130,
+          "line": 154,
           "expression": "handleMouseDown",
           "inputs": [
             {
               "name": "handleMouseDown",
               "declaredAt": {
-                "line": 115,
+                "line": 139,
                 "kind": "const"
               }
             }
@@ -14903,13 +14894,13 @@
         {
           "file": "app/menus/ComboboxOptions.tsx",
           "component": "renderOption",
-          "line": 130,
+          "line": 154,
           "expression": "handleMouseDown",
           "inputs": [
             {
               "name": "handleMouseDown",
               "declaredAt": {
-                "line": 115,
+                "line": 139,
                 "kind": "const"
               }
             }
@@ -14921,13 +14912,13 @@
         {
           "file": "app/menus/ComboboxOptions.tsx",
           "component": "renderOption",
-          "line": 131,
+          "line": 155,
           "expression": "handleMouseEnter",
           "inputs": [
             {
               "name": "handleMouseEnter",
               "declaredAt": {
-                "line": 121,
+                "line": 145,
                 "kind": "const"
               }
             }
@@ -14937,13 +14928,13 @@
         {
           "file": "app/menus/ComboboxOptions.tsx",
           "component": "renderOption",
-          "line": 131,
+          "line": 155,
           "expression": "handleMouseEnter",
           "inputs": [
             {
               "name": "handleMouseEnter",
               "declaredAt": {
-                "line": 121,
+                "line": 145,
                 "kind": "const"
               }
             }
@@ -14955,7 +14946,7 @@
         {
           "file": "app/menus/ComboboxOptions.tsx",
           "component": "renderOption",
-          "line": 126,
+          "line": 150,
           "expression": "\"option\"",
           "inputs": [],
           "spread": true
@@ -14963,7 +14954,7 @@
         {
           "file": "app/menus/ComboboxOptions.tsx",
           "component": "renderOption",
-          "line": 126,
+          "line": 150,
           "expression": "\"option\"",
           "inputs": [],
           "spread": true
@@ -14973,7 +14964,7 @@
         {
           "file": "app/menus/ComboboxOptions.tsx",
           "component": "renderOption",
-          "line": 152,
+          "line": 175,
           "expression": "{}",
           "inputs": [],
           "spread": false
@@ -14983,13 +14974,13 @@
         {
           "file": "app/menus/ComboboxOptions.tsx",
           "component": "renderOption",
-          "line": 153,
+          "line": 176,
           "expression": "annotationSlot",
           "inputs": [
             {
               "name": "annotationSlot",
               "declaredAt": {
-                "line": 137,
+                "line": 161,
                 "kind": "const"
               }
             }
@@ -15003,13 +14994,13 @@
         {
           "file": "app/menus/ComboboxOptions.tsx",
           "component": "ComboboxOptions",
-          "line": 189,
+          "line": 212,
           "expression": "onPointerLeave",
           "inputs": [
             {
               "name": "onPointerLeave",
               "declaredAt": {
-                "line": 73,
+                "line": 97,
                 "kind": "parameter"
               }
             }

--- a/packages/editor/apps/vue/app/canvas/Canvas.vue
+++ b/packages/editor/apps/vue/app/canvas/Canvas.vue
@@ -320,6 +320,8 @@ watch(
   position: absolute;
   top: 0;
   left: 0;
+  min-width: 100%;
+  min-height: 100%;
   padding: 2rem;
   display: flex;
   align-items: flex-start;

--- a/packages/editor/apps/vue/app/canvas/use-canvas-resize-anchor.ts
+++ b/packages/editor/apps/vue/app/canvas/use-canvas-resize-anchor.ts
@@ -1,0 +1,72 @@
+import { getCanvasElement } from "@seldon/editor/lib/canvas/dom/canvas-elements"
+import { onBeforeUnmount, onMounted } from "vue"
+
+import type { PanZoomTransform } from "@seldon/editor/lib/canvas/pan-zoom/pan-zoom-engine"
+
+/**
+ * Holds the board still when the canvas pane changes width.
+ *
+ * The board is flex-centered in the canvas pane, so its base position is halfway
+ * across it. Toggling a sidebar or the properties palette changes the pane's
+ * width, which moves that center and slides the board even though nothing
+ * panned. This watches the pane's width and shifts the pan by half the change
+ * the other way, so the board keeps its place on screen. Vertical needs no such
+ * fix: the board is top-anchored, so a height change does not move it. Mirrors
+ * the React `CanvasResizeAnchor`.
+ */
+export function useCanvasResizeAnchor(
+  getTransform: () => PanZoomTransform,
+  setTransform: (x: number, y: number, scale: number) => void,
+): void {
+  let width: number | null = null
+  let observer: ResizeObserver | null = null
+  let innerRaf = 0
+  let outerRaf = 0
+
+  onMounted(() => {
+    const canvas = getCanvasElement()
+
+    if (!canvas) return
+
+    // The board is centered by CSS at whatever width the pane settles to on
+    // launch, so the initial layout is not a move to hold against. Observing is
+    // deferred past the mount settle, and the baseline is then taken from the
+    // first callback rather than measured up front. Compensating for the settle
+    // would push the board offscreen on launch; only a later change, from
+    // toggling a sidebar or the palette, is a real move to hold.
+    const start = (): void => {
+      observer = new ResizeObserver((entries) => {
+        const next = entries[0]?.contentRect.width
+
+        if (next === undefined) return
+
+        if (width === null) {
+          width = next
+
+          return
+        }
+
+        const delta = next - width
+
+        width = next
+
+        if (delta === 0) return
+        const { x, y, scale } = getTransform()
+
+        setTransform(x - delta / 2, y, scale)
+      })
+
+      observer.observe(canvas)
+    }
+
+    outerRaf = requestAnimationFrame(() => {
+      innerRaf = requestAnimationFrame(start)
+    })
+  })
+
+  onBeforeUnmount(() => {
+    cancelAnimationFrame(outerRaf)
+    cancelAnimationFrame(innerRaf)
+    observer?.disconnect()
+  })
+}

--- a/packages/editor/apps/vue/app/canvas/use-pan-zoom.ts
+++ b/packages/editor/apps/vue/app/canvas/use-pan-zoom.ts
@@ -1,3 +1,4 @@
+import { useCanvasResizeAnchor } from "@app/canvas/use-canvas-resize-anchor"
 import { useZoomControlsStore } from "@app/canvas/zoom-controls-store"
 import { createPanZoomEngine } from "@seldon/editor/lib/canvas/pan-zoom/pan-zoom-engine"
 import { onBeforeUnmount, onMounted, ref, watch } from "vue"
@@ -13,7 +14,8 @@ const ZOOM_STEP = 1.2
  * `createPanZoomEngine`. Wheel with Ctrl/Cmd zooms toward the cursor; a plain
  * wheel pans; holding space or the middle button drags to pan. Watches the
  * zoom-controls store counters so the topbar buttons and shortcuts drive the
- * same transform.
+ * same transform. {@link useCanvasResizeAnchor} holds the board still when a
+ * sidebar or palette changes the pane width.
  */
 export function usePanZoom(viewport: Ref<HTMLElement | null>) {
   const engine = createPanZoomEngine({
@@ -39,6 +41,11 @@ export function usePanZoom(viewport: Ref<HTMLElement | null>) {
   }
 
   const unsubscribe = engine.subscribe(sync)
+
+  useCanvasResizeAnchor(
+    () => engine.getTransform(),
+    (x, y, nextScale) => engine.setTransform(x, y, nextScale),
+  )
 
   watch(
     () => zoom.zoomInCounter,

--- a/packages/editor/apps/vue/app/dialogs/ExportDialog.vue
+++ b/packages/editor/apps/vue/app/dialogs/ExportDialog.vue
@@ -11,6 +11,7 @@ import { useDraggableWindow } from "@app/windows/use-draggable-window"
 import { useDispatch } from "@app/workspace/use-dispatch"
 import { useWorkspace } from "@app/workspace/use-workspace"
 import DialogExportComponent from "@seldon/components/modules/DialogExportComponent.vue"
+import { scanExportRoot } from "@seldon/editor/lib/export/scan-export-root"
 import { pickExportDirectory } from "@seldon/editor/lib/export/write-export-to-directory"
 import { getExportTarget, saveExportTarget } from "@seldon/editor/lib/storage/export-target-store"
 import { EXPORT_FLAGS } from "@seldon/factory/export/options"
@@ -98,13 +99,17 @@ const {
   includeScripts,
 } = storeToRefs(options)
 const directory = ref<FileSystemDirectoryHandle | null>(null)
+const outputFolder = ref(workspace.value.metadata.exportSettings?.outputFolder ?? "")
+const platformTouched = ref(false)
+const frameworkTouched = ref(false)
+const outputFolderTouched = ref(false)
 
 /** The store's current selections as one settings block, ready to persist. */
 function buildExportSettings(): WorkspaceExportSettings {
   return {
     platform: platform.value,
     framework: framework.value,
-    outputFolder: workspace.value.metadata.exportSettings?.outputFolder,
+    outputFolder: outputFolder.value || undefined,
     fontLinks: fontLinks.value,
     allFonts: allFonts.value,
     allIcons: allIcons.value,
@@ -118,6 +123,11 @@ function buildExportSettings(): WorkspaceExportSettings {
 /** Seeds the store from the workspace's saved settings when it has any. */
 function seedFromWorkspace(): void {
   const saved = workspace.value.metadata.exportSettings
+
+  platformTouched.value = false
+  frameworkTouched.value = false
+  outputFolderTouched.value = false
+  outputFolder.value = saved?.outputFolder ?? ""
 
   if (!saved) return
 
@@ -139,6 +149,7 @@ watch(
   [
     platform,
     framework,
+    outputFolder,
     includeHidden,
     allThemes,
     allFonts,
@@ -186,6 +197,7 @@ const platformItems = computed<MenuEntry[]>(() =>
     activeMarker: "bullet",
     disabled: !option.available,
     onSelect: () => {
+      platformTouched.value = true
       platform.value = option.id
     },
   })),
@@ -200,6 +212,7 @@ const frameworkItems = computed<MenuEntry[]>(() =>
     activeMarker: "bullet",
     disabled: !option.available,
     onSelect: () => {
+      frameworkTouched.value = true
       framework.value = option.id
     },
   })),
@@ -228,6 +241,11 @@ function onNameInput(event: Event): void {
   const value = (event.target as HTMLInputElement).value
   nameDraft.value = value
   dispatch({ type: "set_workspace_label", payload: { value } })
+}
+
+function onOutputFolderInput(event: Event): void {
+  outputFolderTouched.value = true
+  outputFolder.value = (event.target as HTMLInputElement).value
 }
 
 /** Settles the trimmed name the field shows into the workspace label. */
@@ -262,6 +280,14 @@ async function chooseDirectory(): Promise<void> {
   const id = workspaceId.value
 
   if (id) await saveExportTarget(id, picked)
+
+  const scan = await scanExportRoot(picked, id, workspace.value.metadata.label)
+
+  if (!platformTouched.value && scan.platform) platform.value = scan.platform
+  if (!frameworkTouched.value && scan.framework) framework.value = scan.framework
+  if (!outputFolderTouched.value && scan.hasOwnedExport) {
+    outputFolder.value = scan.outputFolder ?? ""
+  }
 }
 
 // The Export button dims while an export runs, but the guard is here so a second
@@ -283,6 +309,7 @@ async function runExport(): Promise<void> {
     exportAllIconSetIcons: allIcons.value,
     includeWorkspace: savedWorkspace.value,
     includeScripts: includeScripts.value,
+    outputFolder: outputFolder.value,
   }
 
   await exportToFolder(options, directory.value ?? undefined)
@@ -316,6 +343,9 @@ function closeUnlessExporting(): void {
 function reset(): void {
   directory.value = null
   nameDraft.value = null
+  platformTouched.value = false
+  frameworkTouched.value = false
+  outputFolderTouched.value = false
 }
 
 function close(): void {
@@ -393,8 +423,18 @@ const seldonRefs = computed<Record<string, Record<string, unknown>>>(() => ({
     style: styles.opaque,
   },
 
+  exportProjectFolder: {},
+  exportProjectFolderLabel: { children: "Root Folder" },
+  exportProjectFolderField: {
+    value: directoryLabel.value,
+    placeholder: "Choose a folder…",
+    readonly: true,
+    onClick: chooseDirectory,
+    style: styles.opaquePointer,
+  },
+
   exportFramework: {},
-  exportFrameworkLabel: { children: "Framework" },
+  exportFrameworkLabel: { children: "App Framework" },
   exportFrameworkCombobox: {},
   exportFrameworkField: {
     value: frameworkLabel.value,
@@ -405,7 +445,7 @@ const seldonRefs = computed<Record<string, Record<string, unknown>>>(() => ({
   },
 
   exportPlatform: {},
-  exportPlatformLabel: { children: "Platform" },
+  exportPlatformLabel: { children: "Component Type" },
   exportPlatformCombobox: {},
   exportPlatformField: {
     value: platformLabel.value,
@@ -415,14 +455,13 @@ const seldonRefs = computed<Record<string, Record<string, unknown>>>(() => ({
     style: styles.opaquePointer,
   },
 
-  exportProjectFolder: {},
-  exportProjectFolderLabel: { children: "Project Folder" },
-  exportProjectFolderField: {
-    value: directoryLabel.value,
-    placeholder: "Choose a folder…",
-    readonly: true,
-    onClick: chooseDirectory,
-    style: styles.opaquePointer,
+  exportOutputFolder: {},
+  exportOutputFolderLabel: { children: "Export To" },
+  exportOutputFolderField: {
+    value: outputFolder.value,
+    placeholder: "Project root",
+    onInput: onOutputFolderInput,
+    style: styles.opaque,
   },
 
   exportFieldset: {},

--- a/packages/editor/apps/vue/app/editor/EditorPage.vue
+++ b/packages/editor/apps/vue/app/editor/EditorPage.vue
@@ -15,7 +15,9 @@ import { useResolvedInterfaceMode } from "@app/editor/use-resolved-interface-mod
 import { useMcpBridge } from "@app/mcp/use-mcp-bridge"
 import FocusRingOverlay from "@app/overlays/FocusRingOverlay.vue"
 import HariController from "@app/palettes/hari/HariController.vue"
+import { useDirtyStore } from "@app/persistence/dirty-store"
 import { useWorkspaceAutosave } from "@app/persistence/use-workspace-autosave"
+import { useWorkspaceRemoteRefresh } from "@app/persistence/use-workspace-remote-refresh"
 import { useWorkspaceSaveStore } from "@app/persistence/workspace-save-store"
 import ObjectsSidebar from "@app/sidebars/objects/ObjectsSidebar.vue"
 import PanelPropertyController from "@app/sidebars/properties/PanelPropertyController.vue"
@@ -31,6 +33,9 @@ import { useRoute } from "vue-router"
 const route = useRoute()
 const history = useHistoryStore()
 const save = useWorkspaceSaveStore()
+const dirty = useDirtyStore()
+const { record } = storeToRefs(save)
+const { isDirty } = storeToRefs(dirty)
 const config = useEditorConfigStore()
 const { workspace } = useWorkspace()
 
@@ -101,6 +106,7 @@ function startPropertiesResize(event: PointerEvent): void {
 
 useEditorShortcuts()
 useWorkspaceAutosave()
+useWorkspaceRemoteRefresh(record, isDirty)
 
 const status = ref<"loading" | "ready" | "missing">("loading")
 
@@ -110,14 +116,14 @@ useMcpBridge(workspaceId)
 
 async function load(id: string): Promise<void> {
   status.value = "loading"
-  const record = await getStoredWorkspace(id)
-  if (!record) {
+  const stored = await getStoredWorkspace(id)
+  if (!stored) {
     status.value = "missing"
     return
   }
-  save.setRecord(record)
-  history.reset(record.workspace)
-  save.markLoaded(record.id)
+  save.setRecord(stored)
+  history.reset(stored.workspace)
+  save.markLoaded(stored.id)
   status.value = "ready"
 }
 

--- a/packages/editor/apps/vue/app/io/use-import-export.ts
+++ b/packages/editor/apps/vue/app/io/use-import-export.ts
@@ -6,6 +6,7 @@ import { useDispatch } from "@app/workspace/use-dispatch"
 import { useSelection } from "@app/workspace/use-selection"
 import { useWorkspace } from "@app/workspace/use-workspace"
 import { DEFAULT_COMPONENTS_FOLDER } from "@seldon/editor/lib/export/constants"
+import { joinExportPath, prefixExportPaths } from "@seldon/editor/lib/export/output-folder"
 import {
   findEmittedManifest,
   readExistingManifest,
@@ -175,7 +176,12 @@ export function useImportExport() {
       const framework = options?.target?.framework ?? "vue"
 
       const { runLocalExport } = await import("@seldon/editor/lib/export/run-local-export")
-      const files = await runLocalExport(workspace.value, { ...options, includeWorkspace: false })
+      const outputFolder =
+        options?.outputFolder ?? workspace.value.metadata.exportSettings?.outputFolder
+      const files = prefixExportPaths(
+        await runLocalExport(workspace.value, { ...options, includeWorkspace: false }),
+        outputFolder,
+      )
 
       if (!(await confirmExportCollisions(directory, files))) {
         toast.addToast("Export cancelled")
@@ -211,7 +217,10 @@ export function useImportExport() {
       const id = workspaceId.value
 
       if (id) {
-        const componentsFolder = options?.output?.componentsFolder ?? DEFAULT_COMPONENTS_FOLDER
+        const componentsFolder = joinExportPath(
+          outputFolder,
+          options?.output?.componentsFolder ?? DEFAULT_COMPONENTS_FOLDER,
+        )
 
         await saveExportTarget(id, directory)
         await projectLink.linkExportedFolder(id, directory, componentsFolder)

--- a/packages/editor/apps/vue/app/menus/ComboboxOptions.vue
+++ b/packages/editor/apps/vue/app/menus/ComboboxOptions.vue
@@ -83,10 +83,20 @@ const optionsStyle = {
 // The content reaches every slot by ref name. Every slot on a menu row is opt-in,
 // so each keeps a positional enabler; without one the slot would not render.
 function optionRefs(option: ComboboxOptionItem): Record<string, Record<string, unknown>> {
+  const optionIcon = { icon: props.resolveIcon?.(option.value) ?? "seldon-component" }
+  const optionLabel = { children: option.name }
+
+  if (option.annotation) {
+    return {
+      optionIcon,
+      optionLabel,
+      optionAnnotation: { children: option.annotation },
+    }
+  }
+
   return {
-    optionIcon: { icon: props.resolveIcon?.(option.value) ?? "seldon-component" },
-    optionLabel: { children: option.name },
-    optionAnnotation: { children: option.annotation },
+    optionIcon,
+    optionLabel,
   }
 }
 

--- a/packages/editor/apps/vue/app/persistence/dirty-store.ts
+++ b/packages/editor/apps/vue/app/persistence/dirty-store.ts
@@ -4,7 +4,9 @@ import { ref } from "vue"
 /**
  * Tracks whether the in-memory workspace has unsaved edits relative to the
  * persisted copy. The dispatch pipeline marks it dirty; the save pipeline clears
- * it. Mirrors the React `setIsLocalWorkspaceDirty` sync flag.
+ * it. Autosave writes only while dirty. Remote refresh reads it so a local edit
+ * is never overwritten by a newer store file. Mirrors the React
+ * `setIsLocalWorkspaceDirty` sync flag.
  */
 export const useDirtyStore = defineStore("dirty", () => {
   const isDirty = ref(false)

--- a/packages/editor/apps/vue/app/persistence/use-workspace-remote-refresh.ts
+++ b/packages/editor/apps/vue/app/persistence/use-workspace-remote-refresh.ts
@@ -1,0 +1,64 @@
+import { useWorkspaceSaveStore } from "@app/persistence/workspace-save-store"
+import { useDispatch } from "@app/workspace/use-dispatch"
+import { getStoredWorkspace } from "@seldon/editor/lib/storage/workspace-store"
+import { onBeforeUnmount, onMounted, watch } from "vue"
+
+import type { StoredWorkspace } from "@seldon/editor/lib/storage/workspace-store"
+import type { Ref } from "vue"
+
+/**
+ * Refreshes the open workspace when the shared store changes outside this tab,
+ * such as an MCP commit against the same `.seldon/workspaces` file. On window
+ * focus it reads the stored record, and when the store is newer than the tab's
+ * last write and the tab is clean, it adopts the stored workspace as one undo
+ * step. A dirty tab is left untouched, so a local edit is never clobbered by a
+ * remote change. The baseline is the save store's own record, so the tab's
+ * autosaves never trigger a self-reload. Mirrors the React
+ * `useWorkspaceRemoteRefresh`.
+ */
+export function useWorkspaceRemoteRefresh(
+  record: Ref<StoredWorkspace | null>,
+  isDirty: Ref<boolean>,
+): void {
+  const dispatch = useDispatch()
+  const save = useWorkspaceSaveStore()
+  let isDirtyNow = isDirty.value
+
+  const stopDirty = watch(isDirty, (value) => {
+    isDirtyNow = value
+  })
+
+  async function refresh(): Promise<void> {
+    if (isDirtyNow) return
+    const current = record.value
+
+    if (!current?.id) return
+    const stored = await getStoredWorkspace(current.id)
+
+    if (!stored) return
+    const baseline = save.record?.updatedAt ?? current.updatedAt
+
+    if (stored.updatedAt <= baseline) return
+    dispatch({ type: "set_workspace", payload: { workspace: stored.workspace } })
+    save.setRecord(stored)
+  }
+
+  function onFocus(): void {
+    void refresh()
+  }
+
+  function onVisibilityChange(): void {
+    if (document.visibilityState === "visible") void refresh()
+  }
+
+  onMounted(() => {
+    window.addEventListener("focus", onFocus)
+    document.addEventListener("visibilitychange", onVisibilityChange)
+  })
+
+  onBeforeUnmount(() => {
+    window.removeEventListener("focus", onFocus)
+    document.removeEventListener("visibilitychange", onVisibilityChange)
+    stopDirty()
+  })
+}

--- a/packages/editor/apps/vue/sdn/modules/DialogExportComponent.vue
+++ b/packages/editor/apps/vue/sdn/modules/DialogExportComponent.vue
@@ -26,6 +26,9 @@
  *     FormControl                          formControl                      -> exportWorkspaceName
  *       TextLabel                          textLabel                        -> exportWorkspaceNameLabel
  *       Input                              input                            -> exportWorkspaceNameField
+ *     FormControl                          formControl4                     -> exportProjectFolder
+ *       TextLabel                          textLabel4                       -> exportProjectFolderLabel
+ *       Input                              input4                           -> exportProjectFolderField
  *     FormControl                          formControl2                     -> exportFramework
  *       TextLabel                          textLabel2                       -> exportFrameworkLabel
  *       ComboboxField                      comboboxField                    -> exportFrameworkCombobox
@@ -38,9 +41,9 @@
  *         Input                            input3                           -> exportPlatformField
  *         ButtonIconic                     buttonIconic2
  *           Icon                           icon2
- *     FormControl                          formControl4                     -> exportProjectFolder
- *       TextLabel                          textLabel4                       -> exportProjectFolderLabel
- *       Input                              input4                           -> exportProjectFolderField
+ *     FormControl                          formControl5                     -> exportOutputFolder
+ *       TextLabel                          textLabel28                      -> exportOutputFolderLabel
+ *       Input                              input5                           -> exportOutputFolderField
  *     FormControlRadio                     formControlRadio                 -> exportFontLinks
  *       TextLabel                          textLabel5                       -> exportFontLinksLabel
  *       Frame                              frame2                           -> exportFontLinksRadios
@@ -191,6 +194,9 @@ const props = defineProps<{
   formControl4?: Record<string, unknown> | null
   textLabel4?: Record<string, unknown> | null
   input4?: Record<string, unknown> | null
+  formControl5?: Record<string, unknown> | null
+  textLabel28?: Record<string, unknown> | null
+  input5?: Record<string, unknown> | null
   formControlRadio?: Record<string, unknown> | null
   textLabel5?: Record<string, unknown> | null
   frame2?: Record<string, unknown> | null
@@ -312,7 +318,7 @@ const sdn: Record<string, any> = {
     "data-seldon-ref": "exportFramework",
   },
   textLabel2: {
-    children: "Framework",
+    children: "App Framework",
     htmlElement: "label",
     "aria-hidden": "false",
     className: "sdn-text-label sdn-text-label--l6fl",
@@ -345,7 +351,7 @@ const sdn: Record<string, any> = {
     "data-seldon-ref": "exportPlatform",
   },
   textLabel3: {
-    children: "Platform",
+    children: "Component Type",
     htmlElement: "label",
     "aria-hidden": "false",
     className: "sdn-text-label sdn-text-label--l6fl",
@@ -378,7 +384,7 @@ const sdn: Record<string, any> = {
     "data-seldon-ref": "exportProjectFolder",
   },
   textLabel4: {
-    children: "Project Folder",
+    children: "Root Folder",
     htmlElement: "label",
     "aria-hidden": "false",
     className: "sdn-text-label sdn-text-label--l6fl",
@@ -389,6 +395,24 @@ const sdn: Record<string, any> = {
     type: "text",
     className: "sdn-input sdn-input--j1ro",
     "data-seldon-ref": "exportProjectFolderField",
+  },
+  formControl5: {
+    "aria-hidden": "false",
+    className: "sdn-form-control sdn-form-control--vmxp",
+    "data-seldon-ref": "exportOutputFolder",
+  },
+  textLabel28: {
+    children: "Export To",
+    htmlElement: "label",
+    "aria-hidden": "false",
+    className: "sdn-text-label sdn-text-label--l6fl",
+    "data-seldon-ref": "exportOutputFolderLabel",
+  },
+  input5: {
+    placeholder: "Project root",
+    type: "text",
+    className: "sdn-input sdn-input--j1ro",
+    "data-seldon-ref": "exportOutputFolderField",
   },
   formControlRadio: {
     "aria-hidden": "false",
@@ -868,6 +892,13 @@ const textLabel4Props = computed(() =>
   mergeOptionalSlot(sdn.textLabel4, props.textLabel4, props.seldonRefs),
 )
 const input4Props = computed(() => mergeSlot(sdn.input4, props.input4, props.seldonRefs))
+const formControl5Props = computed(() =>
+  mergeOptionalSlot(sdn.formControl5, props.formControl5, props.seldonRefs),
+)
+const textLabel28Props = computed(() =>
+  mergeOptionalSlot(sdn.textLabel28, props.textLabel28, props.seldonRefs),
+)
+const input5Props = computed(() => mergeSlot(sdn.input5, props.input5, props.seldonRefs))
 const formControlRadioProps = computed(() =>
   mergeOptionalSlot(sdn.formControlRadio, props.formControlRadio, props.seldonRefs),
 )
@@ -1129,6 +1160,10 @@ const textLabel27Props = computed(() =>
           <TextLabel v-if="textLabelProps !== null" v-bind="textLabelProps" />
           <Input v-if="inputProps !== null" v-bind="inputProps" />
         </FormControl>
+        <FormControl v-if="formControl4Props !== null" v-bind="formControl4Props">
+          <TextLabel v-if="textLabel4Props !== null" v-bind="textLabel4Props" />
+          <Input v-if="input4Props !== null" v-bind="input4Props" />
+        </FormControl>
         <FormControl v-if="formControl2Props !== null" v-bind="formControl2Props">
           <TextLabel v-if="textLabel2Props !== null" v-bind="textLabel2Props" />
           <ComboboxField
@@ -1151,9 +1186,9 @@ const textLabel27Props = computed(() =>
             :icon="null"
           />
         </FormControl>
-        <FormControl v-if="formControl4Props !== null" v-bind="formControl4Props">
-          <TextLabel v-if="textLabel4Props !== null" v-bind="textLabel4Props" />
-          <Input v-if="input4Props !== null" v-bind="input4Props" />
+        <FormControl v-if="formControl5Props !== null" v-bind="formControl5Props">
+          <TextLabel v-if="textLabel28Props !== null" v-bind="textLabel28Props" />
+          <Input v-if="input5Props !== null" v-bind="input5Props" />
         </FormControl>
         <FormControlRadio v-if="formControlRadioProps !== null" v-bind="formControlRadioProps">
           <TextLabel v-if="textLabel5Props !== null" v-bind="textLabel5Props" />

--- a/packages/editor/apps/vue/sdn/refs/bindings.json
+++ b/packages/editor/apps/vue/sdn/refs/bindings.json
@@ -2,7 +2,7 @@
   "version": 1,
   "mode": "full",
   "framework": "vue",
-  "scannedFiles": 195,
+  "scannedFiles": 197,
   "refs": {
     "boardState": [
       {
@@ -1043,14 +1043,14 @@
       {
         "file": "app/dialogs/ExportDialog.vue",
         "component": "ExportDialog",
-        "line": 486,
+        "line": 525,
         "conditional": false,
         "expression": "{ role: \"radiogroup\", \"aria-label\": EXPORT_FLAG.allFonts.ariaLabel }",
         "inputs": [
           {
             "name": "EXPORT_FLAG",
             "declaredAt": {
-              "line": 39,
+              "line": 40,
               "kind": "const",
               "via": "EXPORT_FLAGS.reduce"
             }
@@ -1069,7 +1069,7 @@
               {
                 "name": "EXPORT_FLAG",
                 "declaredAt": {
-                  "line": 39,
+                  "line": 40,
                   "kind": "const",
                   "via": "EXPORT_FLAGS.reduce"
                 }
@@ -1083,14 +1083,14 @@
       {
         "file": "app/dialogs/ExportDialog.vue",
         "component": "ExportDialog",
-        "line": 487,
+        "line": 526,
         "conditional": false,
         "expression": "{ children: EXPORT_FLAG.allFonts.label }",
         "inputs": [
           {
             "name": "EXPORT_FLAG",
             "declaredAt": {
-              "line": 39,
+              "line": 40,
               "kind": "const",
               "via": "EXPORT_FLAGS.reduce"
             }
@@ -1104,7 +1104,7 @@
               {
                 "name": "EXPORT_FLAG",
                 "declaredAt": {
-                  "line": 39,
+                  "line": 40,
                   "kind": "const",
                   "via": "EXPORT_FLAGS.reduce"
                 }
@@ -1118,21 +1118,21 @@
       {
         "file": "app/dialogs/ExportDialog.vue",
         "component": "ExportDialog",
-        "line": 495,
+        "line": 534,
         "conditional": false,
         "expression": "radioRow(() => (allFonts.value = false))",
         "inputs": [
           {
             "name": "radioRow",
             "declaredAt": {
-              "line": 363,
+              "line": 393,
               "kind": "function"
             }
           },
           {
             "name": "allFonts",
             "declaredAt": {
-              "line": 89,
+              "line": 90,
               "kind": "const",
               "via": "storeToRefs"
             }
@@ -1145,21 +1145,21 @@
       {
         "file": "app/dialogs/ExportDialog.vue",
         "component": "ExportDialog",
-        "line": 496,
+        "line": 535,
         "conditional": false,
         "expression": "radioInput( \"export-all-fonts\", !allFonts.value, () => (allFonts.value = false), )",
         "inputs": [
           {
             "name": "radioInput",
             "declaredAt": {
-              "line": 368,
+              "line": 398,
               "kind": "function"
             }
           },
           {
             "name": "allFonts",
             "declaredAt": {
-              "line": 89,
+              "line": 90,
               "kind": "const",
               "via": "storeToRefs"
             }
@@ -1172,7 +1172,7 @@
       {
         "file": "app/dialogs/ExportDialog.vue",
         "component": "ExportDialog",
-        "line": 501,
+        "line": 540,
         "conditional": false,
         "expression": "{ children: \"No\" }",
         "inputs": [],
@@ -1189,21 +1189,21 @@
       {
         "file": "app/dialogs/ExportDialog.vue",
         "component": "ExportDialog",
-        "line": 488,
+        "line": 527,
         "conditional": false,
         "expression": "radioRow(() => (allFonts.value = true))",
         "inputs": [
           {
             "name": "radioRow",
             "declaredAt": {
-              "line": 363,
+              "line": 393,
               "kind": "function"
             }
           },
           {
             "name": "allFonts",
             "declaredAt": {
-              "line": 89,
+              "line": 90,
               "kind": "const",
               "via": "storeToRefs"
             }
@@ -1216,21 +1216,21 @@
       {
         "file": "app/dialogs/ExportDialog.vue",
         "component": "ExportDialog",
-        "line": 489,
+        "line": 528,
         "conditional": false,
         "expression": "radioInput( \"export-all-fonts\", allFonts.value, () => (allFonts.value = true), )",
         "inputs": [
           {
             "name": "radioInput",
             "declaredAt": {
-              "line": 368,
+              "line": 398,
               "kind": "function"
             }
           },
           {
             "name": "allFonts",
             "declaredAt": {
-              "line": 89,
+              "line": 90,
               "kind": "const",
               "via": "storeToRefs"
             }
@@ -1243,7 +1243,7 @@
       {
         "file": "app/dialogs/ExportDialog.vue",
         "component": "ExportDialog",
-        "line": 494,
+        "line": 533,
         "conditional": false,
         "expression": "{ children: \"Yes\" }",
         "inputs": [],
@@ -1260,14 +1260,14 @@
       {
         "file": "app/dialogs/ExportDialog.vue",
         "component": "ExportDialog",
-        "line": 503,
+        "line": 542,
         "conditional": false,
         "expression": "{ role: \"radiogroup\", \"aria-label\": EXPORT_FLAG.allIcons.ariaLabel }",
         "inputs": [
           {
             "name": "EXPORT_FLAG",
             "declaredAt": {
-              "line": 39,
+              "line": 40,
               "kind": "const",
               "via": "EXPORT_FLAGS.reduce"
             }
@@ -1286,7 +1286,7 @@
               {
                 "name": "EXPORT_FLAG",
                 "declaredAt": {
-                  "line": 39,
+                  "line": 40,
                   "kind": "const",
                   "via": "EXPORT_FLAGS.reduce"
                 }
@@ -1300,14 +1300,14 @@
       {
         "file": "app/dialogs/ExportDialog.vue",
         "component": "ExportDialog",
-        "line": 504,
+        "line": 543,
         "conditional": false,
         "expression": "{ children: EXPORT_FLAG.allIcons.label }",
         "inputs": [
           {
             "name": "EXPORT_FLAG",
             "declaredAt": {
-              "line": 39,
+              "line": 40,
               "kind": "const",
               "via": "EXPORT_FLAGS.reduce"
             }
@@ -1321,7 +1321,7 @@
               {
                 "name": "EXPORT_FLAG",
                 "declaredAt": {
-                  "line": 39,
+                  "line": 40,
                   "kind": "const",
                   "via": "EXPORT_FLAGS.reduce"
                 }
@@ -1335,21 +1335,21 @@
       {
         "file": "app/dialogs/ExportDialog.vue",
         "component": "ExportDialog",
-        "line": 512,
+        "line": 551,
         "conditional": false,
         "expression": "radioRow(() => (allIcons.value = false))",
         "inputs": [
           {
             "name": "radioRow",
             "declaredAt": {
-              "line": 363,
+              "line": 393,
               "kind": "function"
             }
           },
           {
             "name": "allIcons",
             "declaredAt": {
-              "line": 89,
+              "line": 90,
               "kind": "const",
               "via": "storeToRefs"
             }
@@ -1362,21 +1362,21 @@
       {
         "file": "app/dialogs/ExportDialog.vue",
         "component": "ExportDialog",
-        "line": 513,
+        "line": 552,
         "conditional": false,
         "expression": "radioInput( \"export-all-icons\", !allIcons.value, () => (allIcons.value = false), )",
         "inputs": [
           {
             "name": "radioInput",
             "declaredAt": {
-              "line": 368,
+              "line": 398,
               "kind": "function"
             }
           },
           {
             "name": "allIcons",
             "declaredAt": {
-              "line": 89,
+              "line": 90,
               "kind": "const",
               "via": "storeToRefs"
             }
@@ -1389,7 +1389,7 @@
       {
         "file": "app/dialogs/ExportDialog.vue",
         "component": "ExportDialog",
-        "line": 518,
+        "line": 557,
         "conditional": false,
         "expression": "{ children: \"No\" }",
         "inputs": [],
@@ -1406,21 +1406,21 @@
       {
         "file": "app/dialogs/ExportDialog.vue",
         "component": "ExportDialog",
-        "line": 505,
+        "line": 544,
         "conditional": false,
         "expression": "radioRow(() => (allIcons.value = true))",
         "inputs": [
           {
             "name": "radioRow",
             "declaredAt": {
-              "line": 363,
+              "line": 393,
               "kind": "function"
             }
           },
           {
             "name": "allIcons",
             "declaredAt": {
-              "line": 89,
+              "line": 90,
               "kind": "const",
               "via": "storeToRefs"
             }
@@ -1433,21 +1433,21 @@
       {
         "file": "app/dialogs/ExportDialog.vue",
         "component": "ExportDialog",
-        "line": 506,
+        "line": 545,
         "conditional": false,
         "expression": "radioInput( \"export-all-icons\", allIcons.value, () => (allIcons.value = true), )",
         "inputs": [
           {
             "name": "radioInput",
             "declaredAt": {
-              "line": 368,
+              "line": 398,
               "kind": "function"
             }
           },
           {
             "name": "allIcons",
             "declaredAt": {
-              "line": 89,
+              "line": 90,
               "kind": "const",
               "via": "storeToRefs"
             }
@@ -1460,7 +1460,7 @@
       {
         "file": "app/dialogs/ExportDialog.vue",
         "component": "ExportDialog",
-        "line": 511,
+        "line": 550,
         "conditional": false,
         "expression": "{ children: \"Yes\" }",
         "inputs": [],
@@ -1477,14 +1477,14 @@
       {
         "file": "app/dialogs/ExportDialog.vue",
         "component": "ExportDialog",
-        "line": 469,
+        "line": 508,
         "conditional": false,
         "expression": "{ role: \"radiogroup\", \"aria-label\": EXPORT_FLAG.allThemes.ariaLabel }",
         "inputs": [
           {
             "name": "EXPORT_FLAG",
             "declaredAt": {
-              "line": 39,
+              "line": 40,
               "kind": "const",
               "via": "EXPORT_FLAGS.reduce"
             }
@@ -1503,7 +1503,7 @@
               {
                 "name": "EXPORT_FLAG",
                 "declaredAt": {
-                  "line": 39,
+                  "line": 40,
                   "kind": "const",
                   "via": "EXPORT_FLAGS.reduce"
                 }
@@ -1517,14 +1517,14 @@
       {
         "file": "app/dialogs/ExportDialog.vue",
         "component": "ExportDialog",
-        "line": 470,
+        "line": 509,
         "conditional": false,
         "expression": "{ children: EXPORT_FLAG.allThemes.label }",
         "inputs": [
           {
             "name": "EXPORT_FLAG",
             "declaredAt": {
-              "line": 39,
+              "line": 40,
               "kind": "const",
               "via": "EXPORT_FLAGS.reduce"
             }
@@ -1538,7 +1538,7 @@
               {
                 "name": "EXPORT_FLAG",
                 "declaredAt": {
-                  "line": 39,
+                  "line": 40,
                   "kind": "const",
                   "via": "EXPORT_FLAGS.reduce"
                 }
@@ -1552,21 +1552,21 @@
       {
         "file": "app/dialogs/ExportDialog.vue",
         "component": "ExportDialog",
-        "line": 478,
+        "line": 517,
         "conditional": false,
         "expression": "radioRow(() => (allThemes.value = false))",
         "inputs": [
           {
             "name": "radioRow",
             "declaredAt": {
-              "line": 363,
+              "line": 393,
               "kind": "function"
             }
           },
           {
             "name": "allThemes",
             "declaredAt": {
-              "line": 89,
+              "line": 90,
               "kind": "const",
               "via": "storeToRefs"
             }
@@ -1579,21 +1579,21 @@
       {
         "file": "app/dialogs/ExportDialog.vue",
         "component": "ExportDialog",
-        "line": 479,
+        "line": 518,
         "conditional": false,
         "expression": "radioInput( \"export-all-themes\", !allThemes.value, () => (allThemes.value = false), )",
         "inputs": [
           {
             "name": "radioInput",
             "declaredAt": {
-              "line": 368,
+              "line": 398,
               "kind": "function"
             }
           },
           {
             "name": "allThemes",
             "declaredAt": {
-              "line": 89,
+              "line": 90,
               "kind": "const",
               "via": "storeToRefs"
             }
@@ -1606,7 +1606,7 @@
       {
         "file": "app/dialogs/ExportDialog.vue",
         "component": "ExportDialog",
-        "line": 484,
+        "line": 523,
         "conditional": false,
         "expression": "{ children: \"No\" }",
         "inputs": [],
@@ -1623,21 +1623,21 @@
       {
         "file": "app/dialogs/ExportDialog.vue",
         "component": "ExportDialog",
-        "line": 471,
+        "line": 510,
         "conditional": false,
         "expression": "radioRow(() => (allThemes.value = true))",
         "inputs": [
           {
             "name": "radioRow",
             "declaredAt": {
-              "line": 363,
+              "line": 393,
               "kind": "function"
             }
           },
           {
             "name": "allThemes",
             "declaredAt": {
-              "line": 89,
+              "line": 90,
               "kind": "const",
               "via": "storeToRefs"
             }
@@ -1650,21 +1650,21 @@
       {
         "file": "app/dialogs/ExportDialog.vue",
         "component": "ExportDialog",
-        "line": 472,
+        "line": 511,
         "conditional": false,
         "expression": "radioInput( \"export-all-themes\", allThemes.value, () => (allThemes.value = true), )",
         "inputs": [
           {
             "name": "radioInput",
             "declaredAt": {
-              "line": 368,
+              "line": 398,
               "kind": "function"
             }
           },
           {
             "name": "allThemes",
             "declaredAt": {
-              "line": 89,
+              "line": 90,
               "kind": "const",
               "via": "storeToRefs"
             }
@@ -1677,7 +1677,7 @@
       {
         "file": "app/dialogs/ExportDialog.vue",
         "component": "ExportDialog",
-        "line": 477,
+        "line": 516,
         "conditional": false,
         "expression": "{ children: \"Yes\" }",
         "inputs": [],
@@ -1694,14 +1694,14 @@
       {
         "file": "app/dialogs/ExportDialog.vue",
         "component": "ExportDialog",
-        "line": 554,
+        "line": 593,
         "conditional": false,
         "expression": "{ onClick: cancel }",
         "inputs": [
           {
             "name": "cancel",
             "declaredAt": {
-              "line": 296,
+              "line": 323,
               "kind": "function"
             }
           }
@@ -1714,7 +1714,7 @@
               {
                 "name": "cancel",
                 "declaredAt": {
-                  "line": 296,
+                  "line": 323,
                   "kind": "function"
                 }
               }
@@ -1727,7 +1727,7 @@
       {
         "file": "app/dialogs/ExportDialog.vue",
         "component": "ExportDialog",
-        "line": 555,
+        "line": 594,
         "conditional": false,
         "expression": "{ children: \"Cancel\" }",
         "inputs": [],
@@ -1744,21 +1744,21 @@
       {
         "file": "app/dialogs/ExportDialog.vue",
         "component": "ExportDialog",
-        "line": 556,
+        "line": 595,
         "conditional": false,
         "expression": "{ onClick: runExport, \"aria-disabled\": isExporting.value, style: isExporting.value ? styles.busy : undefined, }",
         "inputs": [
           {
             "name": "runExport",
             "declaredAt": {
-              "line": 270,
+              "line": 296,
               "kind": "function"
             }
           },
           {
             "name": "isExporting",
             "declaredAt": {
-              "line": 80,
+              "line": 81,
               "kind": "const",
               "via": "storeToRefs"
             }
@@ -1766,7 +1766,7 @@
           {
             "name": "styles",
             "declaredAt": {
-              "line": 345,
+              "line": 375,
               "kind": "const"
             }
           }
@@ -1779,7 +1779,7 @@
               {
                 "name": "runExport",
                 "declaredAt": {
-                  "line": 270,
+                  "line": 296,
                   "kind": "function"
                 }
               }
@@ -1792,7 +1792,7 @@
               {
                 "name": "isExporting",
                 "declaredAt": {
-                  "line": 80,
+                  "line": 81,
                   "kind": "const",
                   "via": "storeToRefs"
                 }
@@ -1806,7 +1806,7 @@
               {
                 "name": "isExporting",
                 "declaredAt": {
-                  "line": 80,
+                  "line": 81,
                   "kind": "const",
                   "via": "storeToRefs"
                 }
@@ -1814,7 +1814,7 @@
               {
                 "name": "styles",
                 "declaredAt": {
-                  "line": 345,
+                  "line": 375,
                   "kind": "const"
                 }
               }
@@ -1827,7 +1827,7 @@
       {
         "file": "app/dialogs/ExportDialog.vue",
         "component": "ExportDialog",
-        "line": 561,
+        "line": 600,
         "conditional": false,
         "expression": "{ children: \"Export\" }",
         "inputs": [],
@@ -1844,7 +1844,7 @@
       {
         "file": "app/dialogs/ExportDialog.vue",
         "component": "ExportDialog",
-        "line": 428,
+        "line": 467,
         "conditional": false,
         "expression": "{}",
         "inputs": [],
@@ -1855,7 +1855,7 @@
       {
         "file": "app/dialogs/ExportDialog.vue",
         "component": "ExportDialog",
-        "line": 429,
+        "line": 468,
         "conditional": false,
         "expression": "{ children: \"Include\" }",
         "inputs": [],
@@ -1872,14 +1872,14 @@
       {
         "file": "app/dialogs/ExportDialog.vue",
         "component": "ExportDialog",
-        "line": 435,
+        "line": 474,
         "conditional": false,
         "expression": "{ role: \"radiogroup\", \"aria-label\": EXPORT_FLAG.fontLinks.ariaLabel }",
         "inputs": [
           {
             "name": "EXPORT_FLAG",
             "declaredAt": {
-              "line": 39,
+              "line": 40,
               "kind": "const",
               "via": "EXPORT_FLAGS.reduce"
             }
@@ -1898,7 +1898,7 @@
               {
                 "name": "EXPORT_FLAG",
                 "declaredAt": {
-                  "line": 39,
+                  "line": 40,
                   "kind": "const",
                   "via": "EXPORT_FLAGS.reduce"
                 }
@@ -1912,14 +1912,14 @@
       {
         "file": "app/dialogs/ExportDialog.vue",
         "component": "ExportDialog",
-        "line": 436,
+        "line": 475,
         "conditional": false,
         "expression": "{ children: EXPORT_FLAG.fontLinks.label }",
         "inputs": [
           {
             "name": "EXPORT_FLAG",
             "declaredAt": {
-              "line": 39,
+              "line": 40,
               "kind": "const",
               "via": "EXPORT_FLAGS.reduce"
             }
@@ -1933,7 +1933,7 @@
               {
                 "name": "EXPORT_FLAG",
                 "declaredAt": {
-                  "line": 39,
+                  "line": 40,
                   "kind": "const",
                   "via": "EXPORT_FLAGS.reduce"
                 }
@@ -1947,21 +1947,21 @@
       {
         "file": "app/dialogs/ExportDialog.vue",
         "component": "ExportDialog",
-        "line": 444,
+        "line": 483,
         "conditional": false,
         "expression": "radioRow(() => (fontLinks.value = false))",
         "inputs": [
           {
             "name": "radioRow",
             "declaredAt": {
-              "line": 363,
+              "line": 393,
               "kind": "function"
             }
           },
           {
             "name": "fontLinks",
             "declaredAt": {
-              "line": 89,
+              "line": 90,
               "kind": "const",
               "via": "storeToRefs"
             }
@@ -1974,21 +1974,21 @@
       {
         "file": "app/dialogs/ExportDialog.vue",
         "component": "ExportDialog",
-        "line": 445,
+        "line": 484,
         "conditional": false,
         "expression": "radioInput( \"export-font-links\", !fontLinks.value, () => (fontLinks.value = false), )",
         "inputs": [
           {
             "name": "radioInput",
             "declaredAt": {
-              "line": 368,
+              "line": 398,
               "kind": "function"
             }
           },
           {
             "name": "fontLinks",
             "declaredAt": {
-              "line": 89,
+              "line": 90,
               "kind": "const",
               "via": "storeToRefs"
             }
@@ -2001,7 +2001,7 @@
       {
         "file": "app/dialogs/ExportDialog.vue",
         "component": "ExportDialog",
-        "line": 450,
+        "line": 489,
         "conditional": false,
         "expression": "{ children: \"No\" }",
         "inputs": [],
@@ -2018,21 +2018,21 @@
       {
         "file": "app/dialogs/ExportDialog.vue",
         "component": "ExportDialog",
-        "line": 437,
+        "line": 476,
         "conditional": false,
         "expression": "radioRow(() => (fontLinks.value = true))",
         "inputs": [
           {
             "name": "radioRow",
             "declaredAt": {
-              "line": 363,
+              "line": 393,
               "kind": "function"
             }
           },
           {
             "name": "fontLinks",
             "declaredAt": {
-              "line": 89,
+              "line": 90,
               "kind": "const",
               "via": "storeToRefs"
             }
@@ -2045,21 +2045,21 @@
       {
         "file": "app/dialogs/ExportDialog.vue",
         "component": "ExportDialog",
-        "line": 438,
+        "line": 477,
         "conditional": false,
         "expression": "radioInput( \"export-font-links\", fontLinks.value, () => (fontLinks.value = true), )",
         "inputs": [
           {
             "name": "radioInput",
             "declaredAt": {
-              "line": 368,
+              "line": 398,
               "kind": "function"
             }
           },
           {
             "name": "fontLinks",
             "declaredAt": {
-              "line": 89,
+              "line": 90,
               "kind": "const",
               "via": "storeToRefs"
             }
@@ -2072,7 +2072,7 @@
       {
         "file": "app/dialogs/ExportDialog.vue",
         "component": "ExportDialog",
-        "line": 443,
+        "line": 482,
         "conditional": false,
         "expression": "{ children: \"Yes\" }",
         "inputs": [],
@@ -2089,7 +2089,7 @@
       {
         "file": "app/dialogs/ExportDialog.vue",
         "component": "ExportDialog",
-        "line": 396,
+        "line": 436,
         "conditional": false,
         "expression": "{}",
         "inputs": [],
@@ -2100,7 +2100,7 @@
       {
         "file": "app/dialogs/ExportDialog.vue",
         "component": "ExportDialog",
-        "line": 398,
+        "line": 438,
         "conditional": false,
         "expression": "{}",
         "inputs": [],
@@ -2111,14 +2111,14 @@
       {
         "file": "app/dialogs/ExportDialog.vue",
         "component": "ExportDialog",
-        "line": 399,
+        "line": 439,
         "conditional": false,
         "expression": "{ value: frameworkLabel.value, readonly: true, onClick: openFramework, \"aria-expanded\": frameworkOpen.value, style: styles.opaquePointer, }",
         "inputs": [
           {
             "name": "frameworkLabel",
             "declaredAt": {
-              "line": 165,
+              "line": 176,
               "kind": "const",
               "via": "computed"
             }
@@ -2126,14 +2126,14 @@
           {
             "name": "openFramework",
             "declaredAt": {
-              "line": 218,
+              "line": 231,
               "kind": "function"
             }
           },
           {
             "name": "frameworkOpen",
             "declaredAt": {
-              "line": 177,
+              "line": 188,
               "kind": "const",
               "via": "ref"
             }
@@ -2141,7 +2141,7 @@
           {
             "name": "styles",
             "declaredAt": {
-              "line": 345,
+              "line": 375,
               "kind": "const"
             }
           }
@@ -2154,7 +2154,7 @@
               {
                 "name": "frameworkLabel",
                 "declaredAt": {
-                  "line": 165,
+                  "line": 176,
                   "kind": "const",
                   "via": "computed"
                 }
@@ -2173,7 +2173,7 @@
               {
                 "name": "openFramework",
                 "declaredAt": {
-                  "line": 218,
+                  "line": 231,
                   "kind": "function"
                 }
               }
@@ -2186,7 +2186,7 @@
               {
                 "name": "frameworkOpen",
                 "declaredAt": {
-                  "line": 177,
+                  "line": 188,
                   "kind": "const",
                   "via": "ref"
                 }
@@ -2200,7 +2200,7 @@
               {
                 "name": "styles",
                 "declaredAt": {
-                  "line": 345,
+                  "line": 375,
                   "kind": "const"
                 }
               }
@@ -2213,14 +2213,14 @@
       {
         "file": "app/dialogs/ExportDialog.vue",
         "component": "ExportDialog",
-        "line": 397,
+        "line": 437,
         "conditional": false,
-        "expression": "{ children: \"Framework\" }",
+        "expression": "{ children: \"App Framework\" }",
         "inputs": [],
         "props": [
           {
             "key": "children",
-            "expression": "\"Framework\"",
+            "expression": "\"App Framework\"",
             "inputs": []
           }
         ]
@@ -2230,14 +2230,14 @@
       {
         "file": "app/dialogs/ExportDialog.vue",
         "component": "ExportDialog",
-        "line": 452,
+        "line": 491,
         "conditional": false,
         "expression": "{ role: \"radiogroup\", \"aria-label\": EXPORT_FLAG.includeHidden.ariaLabel }",
         "inputs": [
           {
             "name": "EXPORT_FLAG",
             "declaredAt": {
-              "line": 39,
+              "line": 40,
               "kind": "const",
               "via": "EXPORT_FLAGS.reduce"
             }
@@ -2256,7 +2256,7 @@
               {
                 "name": "EXPORT_FLAG",
                 "declaredAt": {
-                  "line": 39,
+                  "line": 40,
                   "kind": "const",
                   "via": "EXPORT_FLAGS.reduce"
                 }
@@ -2270,14 +2270,14 @@
       {
         "file": "app/dialogs/ExportDialog.vue",
         "component": "ExportDialog",
-        "line": 453,
+        "line": 492,
         "conditional": false,
         "expression": "{ children: EXPORT_FLAG.includeHidden.label }",
         "inputs": [
           {
             "name": "EXPORT_FLAG",
             "declaredAt": {
-              "line": 39,
+              "line": 40,
               "kind": "const",
               "via": "EXPORT_FLAGS.reduce"
             }
@@ -2291,7 +2291,7 @@
               {
                 "name": "EXPORT_FLAG",
                 "declaredAt": {
-                  "line": 39,
+                  "line": 40,
                   "kind": "const",
                   "via": "EXPORT_FLAGS.reduce"
                 }
@@ -2305,21 +2305,21 @@
       {
         "file": "app/dialogs/ExportDialog.vue",
         "component": "ExportDialog",
-        "line": 461,
+        "line": 500,
         "conditional": false,
         "expression": "radioRow(() => (includeHidden.value = false))",
         "inputs": [
           {
             "name": "radioRow",
             "declaredAt": {
-              "line": 363,
+              "line": 393,
               "kind": "function"
             }
           },
           {
             "name": "includeHidden",
             "declaredAt": {
-              "line": 89,
+              "line": 90,
               "kind": "const",
               "via": "storeToRefs"
             }
@@ -2332,21 +2332,21 @@
       {
         "file": "app/dialogs/ExportDialog.vue",
         "component": "ExportDialog",
-        "line": 462,
+        "line": 501,
         "conditional": false,
         "expression": "radioInput( \"export-hidden\", !includeHidden.value, () => (includeHidden.value = false), )",
         "inputs": [
           {
             "name": "radioInput",
             "declaredAt": {
-              "line": 368,
+              "line": 398,
               "kind": "function"
             }
           },
           {
             "name": "includeHidden",
             "declaredAt": {
-              "line": 89,
+              "line": 90,
               "kind": "const",
               "via": "storeToRefs"
             }
@@ -2359,7 +2359,7 @@
       {
         "file": "app/dialogs/ExportDialog.vue",
         "component": "ExportDialog",
-        "line": 467,
+        "line": 506,
         "conditional": false,
         "expression": "{ children: \"No\" }",
         "inputs": [],
@@ -2376,21 +2376,21 @@
       {
         "file": "app/dialogs/ExportDialog.vue",
         "component": "ExportDialog",
-        "line": 454,
+        "line": 493,
         "conditional": false,
         "expression": "radioRow(() => (includeHidden.value = true))",
         "inputs": [
           {
             "name": "radioRow",
             "declaredAt": {
-              "line": 363,
+              "line": 393,
               "kind": "function"
             }
           },
           {
             "name": "includeHidden",
             "declaredAt": {
-              "line": 89,
+              "line": 90,
               "kind": "const",
               "via": "storeToRefs"
             }
@@ -2403,21 +2403,21 @@
       {
         "file": "app/dialogs/ExportDialog.vue",
         "component": "ExportDialog",
-        "line": 455,
+        "line": 494,
         "conditional": false,
         "expression": "radioInput( \"export-hidden\", includeHidden.value, () => (includeHidden.value = true), )",
         "inputs": [
           {
             "name": "radioInput",
             "declaredAt": {
-              "line": 368,
+              "line": 398,
               "kind": "function"
             }
           },
           {
             "name": "includeHidden",
             "declaredAt": {
-              "line": 89,
+              "line": 90,
               "kind": "const",
               "via": "storeToRefs"
             }
@@ -2430,7 +2430,7 @@
       {
         "file": "app/dialogs/ExportDialog.vue",
         "component": "ExportDialog",
-        "line": 460,
+        "line": 499,
         "conditional": false,
         "expression": "{ children: \"Yes\" }",
         "inputs": [],
@@ -2443,11 +2443,119 @@
         ]
       }
     ],
+    "exportOutputFolder": [
+      {
+        "file": "app/dialogs/ExportDialog.vue",
+        "component": "ExportDialog",
+        "line": 458,
+        "conditional": false,
+        "expression": "{}",
+        "inputs": [],
+        "props": []
+      }
+    ],
+    "exportOutputFolderField": [
+      {
+        "file": "app/dialogs/ExportDialog.vue",
+        "component": "ExportDialog",
+        "line": 460,
+        "conditional": false,
+        "expression": "{ value: outputFolder.value, placeholder: \"Project root\", onInput: onOutputFolderInput, style: styles.opaque, }",
+        "inputs": [
+          {
+            "name": "outputFolder",
+            "declaredAt": {
+              "line": 102,
+              "kind": "const",
+              "via": "ref"
+            }
+          },
+          {
+            "name": "onOutputFolderInput",
+            "declaredAt": {
+              "line": 246,
+              "kind": "function"
+            }
+          },
+          {
+            "name": "styles",
+            "declaredAt": {
+              "line": 375,
+              "kind": "const"
+            }
+          }
+        ],
+        "props": [
+          {
+            "key": "value",
+            "expression": "outputFolder.value",
+            "inputs": [
+              {
+                "name": "outputFolder",
+                "declaredAt": {
+                  "line": 102,
+                  "kind": "const",
+                  "via": "ref"
+                }
+              }
+            ]
+          },
+          {
+            "key": "placeholder",
+            "expression": "\"Project root\"",
+            "inputs": []
+          },
+          {
+            "key": "onInput",
+            "expression": "onOutputFolderInput",
+            "inputs": [
+              {
+                "name": "onOutputFolderInput",
+                "declaredAt": {
+                  "line": 246,
+                  "kind": "function"
+                }
+              }
+            ]
+          },
+          {
+            "key": "style",
+            "expression": "styles.opaque",
+            "inputs": [
+              {
+                "name": "styles",
+                "declaredAt": {
+                  "line": 375,
+                  "kind": "const"
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "exportOutputFolderLabel": [
+      {
+        "file": "app/dialogs/ExportDialog.vue",
+        "component": "ExportDialog",
+        "line": 459,
+        "conditional": false,
+        "expression": "{ children: \"Export To\" }",
+        "inputs": [],
+        "props": [
+          {
+            "key": "children",
+            "expression": "\"Export To\"",
+            "inputs": []
+          }
+        ]
+      }
+    ],
     "exportPlatform": [
       {
         "file": "app/dialogs/ExportDialog.vue",
         "component": "ExportDialog",
-        "line": 407,
+        "line": 447,
         "conditional": false,
         "expression": "{}",
         "inputs": [],
@@ -2458,7 +2566,7 @@
       {
         "file": "app/dialogs/ExportDialog.vue",
         "component": "ExportDialog",
-        "line": 409,
+        "line": 449,
         "conditional": false,
         "expression": "{}",
         "inputs": [],
@@ -2469,14 +2577,14 @@
       {
         "file": "app/dialogs/ExportDialog.vue",
         "component": "ExportDialog",
-        "line": 410,
+        "line": 450,
         "conditional": false,
         "expression": "{ value: platformLabel.value, readonly: true, onClick: openPlatform, \"aria-expanded\": platformOpen.value, style: styles.opaquePointer, }",
         "inputs": [
           {
             "name": "platformLabel",
             "declaredAt": {
-              "line": 162,
+              "line": 173,
               "kind": "const",
               "via": "computed"
             }
@@ -2484,14 +2592,14 @@
           {
             "name": "openPlatform",
             "declaredAt": {
-              "line": 211,
+              "line": 224,
               "kind": "function"
             }
           },
           {
             "name": "platformOpen",
             "declaredAt": {
-              "line": 175,
+              "line": 186,
               "kind": "const",
               "via": "ref"
             }
@@ -2499,7 +2607,7 @@
           {
             "name": "styles",
             "declaredAt": {
-              "line": 345,
+              "line": 375,
               "kind": "const"
             }
           }
@@ -2512,7 +2620,7 @@
               {
                 "name": "platformLabel",
                 "declaredAt": {
-                  "line": 162,
+                  "line": 173,
                   "kind": "const",
                   "via": "computed"
                 }
@@ -2531,7 +2639,7 @@
               {
                 "name": "openPlatform",
                 "declaredAt": {
-                  "line": 211,
+                  "line": 224,
                   "kind": "function"
                 }
               }
@@ -2544,7 +2652,7 @@
               {
                 "name": "platformOpen",
                 "declaredAt": {
-                  "line": 175,
+                  "line": 186,
                   "kind": "const",
                   "via": "ref"
                 }
@@ -2558,7 +2666,7 @@
               {
                 "name": "styles",
                 "declaredAt": {
-                  "line": 345,
+                  "line": 375,
                   "kind": "const"
                 }
               }
@@ -2571,14 +2679,14 @@
       {
         "file": "app/dialogs/ExportDialog.vue",
         "component": "ExportDialog",
-        "line": 408,
+        "line": 448,
         "conditional": false,
-        "expression": "{ children: \"Platform\" }",
+        "expression": "{ children: \"Component Type\" }",
         "inputs": [],
         "props": [
           {
             "key": "children",
-            "expression": "\"Platform\"",
+            "expression": "\"Component Type\"",
             "inputs": []
           }
         ]
@@ -2588,7 +2696,7 @@
       {
         "file": "app/dialogs/ExportDialog.vue",
         "component": "ExportDialog",
-        "line": 418,
+        "line": 426,
         "conditional": false,
         "expression": "{}",
         "inputs": [],
@@ -2599,14 +2707,14 @@
       {
         "file": "app/dialogs/ExportDialog.vue",
         "component": "ExportDialog",
-        "line": 420,
+        "line": 428,
         "conditional": false,
         "expression": "{ value: directoryLabel.value, placeholder: \"Choose a folder…\", readonly: true, onClick: chooseDirectory, style: styles.opaquePointer, }",
         "inputs": [
           {
             "name": "directoryLabel",
             "declaredAt": {
-              "line": 161,
+              "line": 172,
               "kind": "const",
               "via": "computed"
             }
@@ -2614,14 +2722,14 @@
           {
             "name": "chooseDirectory",
             "declaredAt": {
-              "line": 251,
+              "line": 269,
               "kind": "function"
             }
           },
           {
             "name": "styles",
             "declaredAt": {
-              "line": 345,
+              "line": 375,
               "kind": "const"
             }
           }
@@ -2634,7 +2742,7 @@
               {
                 "name": "directoryLabel",
                 "declaredAt": {
-                  "line": 161,
+                  "line": 172,
                   "kind": "const",
                   "via": "computed"
                 }
@@ -2658,7 +2766,7 @@
               {
                 "name": "chooseDirectory",
                 "declaredAt": {
-                  "line": 251,
+                  "line": 269,
                   "kind": "function"
                 }
               }
@@ -2671,7 +2779,7 @@
               {
                 "name": "styles",
                 "declaredAt": {
-                  "line": 345,
+                  "line": 375,
                   "kind": "const"
                 }
               }
@@ -2684,14 +2792,14 @@
       {
         "file": "app/dialogs/ExportDialog.vue",
         "component": "ExportDialog",
-        "line": 419,
+        "line": 427,
         "conditional": false,
-        "expression": "{ children: \"Project Folder\" }",
+        "expression": "{ children: \"Root Folder\" }",
         "inputs": [],
         "props": [
           {
             "key": "children",
-            "expression": "\"Project Folder\"",
+            "expression": "\"Root Folder\"",
             "inputs": []
           }
         ]
@@ -2701,14 +2809,14 @@
       {
         "file": "app/dialogs/ExportDialog.vue",
         "component": "ExportDialog",
-        "line": 537,
+        "line": 576,
         "conditional": false,
         "expression": "{ role: \"radiogroup\", \"aria-label\": EXPORT_FLAG.includeScripts.ariaLabel }",
         "inputs": [
           {
             "name": "EXPORT_FLAG",
             "declaredAt": {
-              "line": 39,
+              "line": 40,
               "kind": "const",
               "via": "EXPORT_FLAGS.reduce"
             }
@@ -2727,7 +2835,7 @@
               {
                 "name": "EXPORT_FLAG",
                 "declaredAt": {
-                  "line": 39,
+                  "line": 40,
                   "kind": "const",
                   "via": "EXPORT_FLAGS.reduce"
                 }
@@ -2741,14 +2849,14 @@
       {
         "file": "app/dialogs/ExportDialog.vue",
         "component": "ExportDialog",
-        "line": 538,
+        "line": 577,
         "conditional": false,
         "expression": "{ children: EXPORT_FLAG.includeScripts.label }",
         "inputs": [
           {
             "name": "EXPORT_FLAG",
             "declaredAt": {
-              "line": 39,
+              "line": 40,
               "kind": "const",
               "via": "EXPORT_FLAGS.reduce"
             }
@@ -2762,7 +2870,7 @@
               {
                 "name": "EXPORT_FLAG",
                 "declaredAt": {
-                  "line": 39,
+                  "line": 40,
                   "kind": "const",
                   "via": "EXPORT_FLAGS.reduce"
                 }
@@ -2776,21 +2884,21 @@
       {
         "file": "app/dialogs/ExportDialog.vue",
         "component": "ExportDialog",
-        "line": 546,
+        "line": 585,
         "conditional": false,
         "expression": "radioRow(() => (includeScripts.value = false))",
         "inputs": [
           {
             "name": "radioRow",
             "declaredAt": {
-              "line": 363,
+              "line": 393,
               "kind": "function"
             }
           },
           {
             "name": "includeScripts",
             "declaredAt": {
-              "line": 89,
+              "line": 90,
               "kind": "const",
               "via": "storeToRefs"
             }
@@ -2803,21 +2911,21 @@
       {
         "file": "app/dialogs/ExportDialog.vue",
         "component": "ExportDialog",
-        "line": 547,
+        "line": 586,
         "conditional": false,
         "expression": "radioInput( \"export-scripts\", !includeScripts.value, () => (includeScripts.value = false), )",
         "inputs": [
           {
             "name": "radioInput",
             "declaredAt": {
-              "line": 368,
+              "line": 398,
               "kind": "function"
             }
           },
           {
             "name": "includeScripts",
             "declaredAt": {
-              "line": 89,
+              "line": 90,
               "kind": "const",
               "via": "storeToRefs"
             }
@@ -2830,7 +2938,7 @@
       {
         "file": "app/dialogs/ExportDialog.vue",
         "component": "ExportDialog",
-        "line": 552,
+        "line": 591,
         "conditional": false,
         "expression": "{ children: \"No\" }",
         "inputs": [],
@@ -2847,21 +2955,21 @@
       {
         "file": "app/dialogs/ExportDialog.vue",
         "component": "ExportDialog",
-        "line": 539,
+        "line": 578,
         "conditional": false,
         "expression": "radioRow(() => (includeScripts.value = true))",
         "inputs": [
           {
             "name": "radioRow",
             "declaredAt": {
-              "line": 363,
+              "line": 393,
               "kind": "function"
             }
           },
           {
             "name": "includeScripts",
             "declaredAt": {
-              "line": 89,
+              "line": 90,
               "kind": "const",
               "via": "storeToRefs"
             }
@@ -2874,21 +2982,21 @@
       {
         "file": "app/dialogs/ExportDialog.vue",
         "component": "ExportDialog",
-        "line": 540,
+        "line": 579,
         "conditional": false,
         "expression": "radioInput( \"export-scripts\", includeScripts.value, () => (includeScripts.value = true), )",
         "inputs": [
           {
             "name": "radioInput",
             "declaredAt": {
-              "line": 368,
+              "line": 398,
               "kind": "function"
             }
           },
           {
             "name": "includeScripts",
             "declaredAt": {
-              "line": 89,
+              "line": 90,
               "kind": "const",
               "via": "storeToRefs"
             }
@@ -2901,7 +3009,7 @@
       {
         "file": "app/dialogs/ExportDialog.vue",
         "component": "ExportDialog",
-        "line": 545,
+        "line": 584,
         "conditional": false,
         "expression": "{ children: \"Yes\" }",
         "inputs": [],
@@ -2918,7 +3026,7 @@
       {
         "file": "app/dialogs/ExportDialog.vue",
         "component": "ExportDialog",
-        "line": 383,
+        "line": 413,
         "conditional": false,
         "expression": "{ children: \"Export Components\" }",
         "inputs": [],
@@ -2935,14 +3043,14 @@
       {
         "file": "app/dialogs/ExportDialog.vue",
         "component": "ExportDialog",
-        "line": 520,
+        "line": 559,
         "conditional": false,
         "expression": "{ role: \"radiogroup\", \"aria-label\": EXPORT_FLAG.savedWorkspace.ariaLabel }",
         "inputs": [
           {
             "name": "EXPORT_FLAG",
             "declaredAt": {
-              "line": 39,
+              "line": 40,
               "kind": "const",
               "via": "EXPORT_FLAGS.reduce"
             }
@@ -2961,7 +3069,7 @@
               {
                 "name": "EXPORT_FLAG",
                 "declaredAt": {
-                  "line": 39,
+                  "line": 40,
                   "kind": "const",
                   "via": "EXPORT_FLAGS.reduce"
                 }
@@ -2975,14 +3083,14 @@
       {
         "file": "app/dialogs/ExportDialog.vue",
         "component": "ExportDialog",
-        "line": 521,
+        "line": 560,
         "conditional": false,
         "expression": "{ children: EXPORT_FLAG.savedWorkspace.label }",
         "inputs": [
           {
             "name": "EXPORT_FLAG",
             "declaredAt": {
-              "line": 39,
+              "line": 40,
               "kind": "const",
               "via": "EXPORT_FLAGS.reduce"
             }
@@ -2996,7 +3104,7 @@
               {
                 "name": "EXPORT_FLAG",
                 "declaredAt": {
-                  "line": 39,
+                  "line": 40,
                   "kind": "const",
                   "via": "EXPORT_FLAGS.reduce"
                 }
@@ -3010,7 +3118,7 @@
       {
         "file": "app/dialogs/ExportDialog.vue",
         "component": "ExportDialog",
-        "line": 385,
+        "line": 415,
         "conditional": false,
         "expression": "{}",
         "inputs": [],
@@ -3021,14 +3129,14 @@
       {
         "file": "app/dialogs/ExportDialog.vue",
         "component": "ExportDialog",
-        "line": 387,
+        "line": 417,
         "conditional": false,
         "expression": "{ value: workspaceName.value, placeholder: \"Untitled workspace\", onInput: onNameInput, onBlur: commitName, onKeydown: commitNameOnEnter, style: styles.opaque, }",
         "inputs": [
           {
             "name": "workspaceName",
             "declaredAt": {
-              "line": 159,
+              "line": 170,
               "kind": "const",
               "via": "computed"
             }
@@ -3036,28 +3144,28 @@
           {
             "name": "onNameInput",
             "declaredAt": {
-              "line": 227,
+              "line": 240,
               "kind": "function"
             }
           },
           {
             "name": "commitName",
             "declaredAt": {
-              "line": 234,
+              "line": 252,
               "kind": "function"
             }
           },
           {
             "name": "commitNameOnEnter",
             "declaredAt": {
-              "line": 242,
+              "line": 260,
               "kind": "function"
             }
           },
           {
             "name": "styles",
             "declaredAt": {
-              "line": 345,
+              "line": 375,
               "kind": "const"
             }
           }
@@ -3070,7 +3178,7 @@
               {
                 "name": "workspaceName",
                 "declaredAt": {
-                  "line": 159,
+                  "line": 170,
                   "kind": "const",
                   "via": "computed"
                 }
@@ -3089,7 +3197,7 @@
               {
                 "name": "onNameInput",
                 "declaredAt": {
-                  "line": 227,
+                  "line": 240,
                   "kind": "function"
                 }
               }
@@ -3102,7 +3210,7 @@
               {
                 "name": "commitName",
                 "declaredAt": {
-                  "line": 234,
+                  "line": 252,
                   "kind": "function"
                 }
               }
@@ -3115,7 +3223,7 @@
               {
                 "name": "commitNameOnEnter",
                 "declaredAt": {
-                  "line": 242,
+                  "line": 260,
                   "kind": "function"
                 }
               }
@@ -3128,7 +3236,7 @@
               {
                 "name": "styles",
                 "declaredAt": {
-                  "line": 345,
+                  "line": 375,
                   "kind": "const"
                 }
               }
@@ -3141,7 +3249,7 @@
       {
         "file": "app/dialogs/ExportDialog.vue",
         "component": "ExportDialog",
-        "line": 386,
+        "line": 416,
         "conditional": false,
         "expression": "{ children: \"Workspace Name\" }",
         "inputs": [],
@@ -3158,21 +3266,21 @@
       {
         "file": "app/dialogs/ExportDialog.vue",
         "component": "ExportDialog",
-        "line": 529,
+        "line": 568,
         "conditional": false,
         "expression": "radioRow(() => (savedWorkspace.value = false))",
         "inputs": [
           {
             "name": "radioRow",
             "declaredAt": {
-              "line": 363,
+              "line": 393,
               "kind": "function"
             }
           },
           {
             "name": "savedWorkspace",
             "declaredAt": {
-              "line": 89,
+              "line": 90,
               "kind": "const",
               "via": "storeToRefs"
             }
@@ -3185,21 +3293,21 @@
       {
         "file": "app/dialogs/ExportDialog.vue",
         "component": "ExportDialog",
-        "line": 530,
+        "line": 569,
         "conditional": false,
         "expression": "radioInput( \"export-saved-workspace\", !savedWorkspace.value, () => (savedWorkspace.value = false), )",
         "inputs": [
           {
             "name": "radioInput",
             "declaredAt": {
-              "line": 368,
+              "line": 398,
               "kind": "function"
             }
           },
           {
             "name": "savedWorkspace",
             "declaredAt": {
-              "line": 89,
+              "line": 90,
               "kind": "const",
               "via": "storeToRefs"
             }
@@ -3212,7 +3320,7 @@
       {
         "file": "app/dialogs/ExportDialog.vue",
         "component": "ExportDialog",
-        "line": 535,
+        "line": 574,
         "conditional": false,
         "expression": "{ children: \"No\" }",
         "inputs": [],
@@ -3229,21 +3337,21 @@
       {
         "file": "app/dialogs/ExportDialog.vue",
         "component": "ExportDialog",
-        "line": 522,
+        "line": 561,
         "conditional": false,
         "expression": "radioRow(() => (savedWorkspace.value = true))",
         "inputs": [
           {
             "name": "radioRow",
             "declaredAt": {
-              "line": 363,
+              "line": 393,
               "kind": "function"
             }
           },
           {
             "name": "savedWorkspace",
             "declaredAt": {
-              "line": 89,
+              "line": 90,
               "kind": "const",
               "via": "storeToRefs"
             }
@@ -3256,21 +3364,21 @@
       {
         "file": "app/dialogs/ExportDialog.vue",
         "component": "ExportDialog",
-        "line": 523,
+        "line": 562,
         "conditional": false,
         "expression": "radioInput( \"export-saved-workspace\", savedWorkspace.value, () => (savedWorkspace.value = true), )",
         "inputs": [
           {
             "name": "radioInput",
             "declaredAt": {
-              "line": 368,
+              "line": 398,
               "kind": "function"
             }
           },
           {
             "name": "savedWorkspace",
             "declaredAt": {
-              "line": 89,
+              "line": 90,
               "kind": "const",
               "via": "storeToRefs"
             }
@@ -3283,7 +3391,7 @@
       {
         "file": "app/dialogs/ExportDialog.vue",
         "component": "ExportDialog",
-        "line": 528,
+        "line": 567,
         "conditional": false,
         "expression": "{ children: \"Yes\" }",
         "inputs": [],
@@ -6886,7 +6994,7 @@
       {
         "file": "app/menus/ComboboxOptions.vue",
         "component": "ComboboxOptions",
-        "line": 89,
+        "line": 93,
         "conditional": false,
         "expression": "{ children: option.annotation }",
         "inputs": [
@@ -6919,82 +7027,72 @@
       {
         "file": "app/menus/ComboboxOptions.vue",
         "component": "ComboboxOptions",
-        "line": 87,
+        "line": 91,
         "conditional": false,
-        "expression": "{ icon: props.resolveIcon?.(option.value) ?? \"seldon-component\" }",
+        "expression": "optionIcon",
         "inputs": [
           {
-            "name": "props",
+            "name": "optionIcon",
             "declaredAt": {
-              "line": 27,
-              "kind": "const",
-              "via": "defineProps"
-            }
-          },
-          {
-            "name": "option",
-            "declaredAt": {
-              "line": 48,
-              "kind": "parameter"
+              "line": 86,
+              "kind": "const"
             }
           }
         ],
-        "props": [
+        "props": []
+      },
+      {
+        "file": "app/menus/ComboboxOptions.vue",
+        "component": "ComboboxOptions",
+        "line": 98,
+        "conditional": false,
+        "expression": "optionIcon",
+        "inputs": [
           {
-            "key": "icon",
-            "expression": "props.resolveIcon?.(option.value) ?? \"seldon-component\"",
-            "inputs": [
-              {
-                "name": "props",
-                "declaredAt": {
-                  "line": 27,
-                  "kind": "const",
-                  "via": "defineProps"
-                }
-              },
-              {
-                "name": "option",
-                "declaredAt": {
-                  "line": 48,
-                  "kind": "parameter"
-                }
-              }
-            ]
+            "name": "optionIcon",
+            "declaredAt": {
+              "line": 86,
+              "kind": "const"
+            }
           }
-        ]
+        ],
+        "props": []
       }
     ],
     "optionLabel": [
       {
         "file": "app/menus/ComboboxOptions.vue",
         "component": "ComboboxOptions",
-        "line": 88,
+        "line": 92,
         "conditional": false,
-        "expression": "{ children: option.name }",
+        "expression": "optionLabel",
         "inputs": [
           {
-            "name": "option",
+            "name": "optionLabel",
             "declaredAt": {
-              "line": 48,
-              "kind": "parameter"
+              "line": 87,
+              "kind": "const"
             }
           }
         ],
-        "props": [
+        "props": []
+      },
+      {
+        "file": "app/menus/ComboboxOptions.vue",
+        "component": "ComboboxOptions",
+        "line": 99,
+        "conditional": false,
+        "expression": "optionLabel",
+        "inputs": [
           {
-            "key": "children",
-            "expression": "option.name",
-            "inputs": [
-              {
-                "name": "option",
-                "declaredAt": {
-                  "line": 48,
-                  "kind": "parameter"
-                }
-              }
-            ]
+            "name": "optionLabel",
+            "declaredAt": {
+              "line": 87,
+              "kind": "const"
+            }
           }
-        ]
+        ],
+        "props": []
       }
     ],
     "paletteClose": [
@@ -11351,13 +11449,13 @@
         {
           "file": "app/dialogs/ExportDialog.vue",
           "component": "ExportDialog",
-          "line": 577,
+          "line": 616,
           "expression": "isExporting",
           "inputs": [
             {
               "name": "isExporting",
               "declaredAt": {
-                "line": 80,
+                "line": 81,
                 "kind": "const",
                 "via": "storeToRefs"
               }
@@ -11370,13 +11468,13 @@
         {
           "file": "app/dialogs/ExportDialog.vue",
           "component": "ExportDialog",
-          "line": 578,
+          "line": 617,
           "expression": "barHandle",
           "inputs": [
             {
               "name": "barHandle",
               "declaredAt": {
-                "line": 372,
+                "line": 402,
                 "kind": "const",
                 "via": "computed"
               }
@@ -11389,7 +11487,7 @@
         {
           "file": "app/dialogs/ExportDialog.vue",
           "component": "ExportDialog",
-          "line": 576,
+          "line": 615,
           "expression": "\"export-components-dialog\"",
           "inputs": [],
           "spread": false
@@ -12800,7 +12898,7 @@
         {
           "file": "app/menus/ComboboxOptions.vue",
           "component": "ComboboxOptions",
-          "line": 203,
+          "line": 213,
           "expression": "option.value === value || undefined",
           "inputs": [
             {
@@ -12825,7 +12923,7 @@
         {
           "file": "app/menus/ComboboxOptions.vue",
           "component": "ComboboxOptions",
-          "line": 205,
+          "line": 215,
           "expression": "{}",
           "inputs": [],
           "spread": false
@@ -12835,7 +12933,7 @@
         {
           "file": "app/menus/ComboboxOptions.vue",
           "component": "ComboboxOptions",
-          "line": 206,
+          "line": 216,
           "expression": "{}",
           "inputs": [],
           "spread": false
@@ -12845,13 +12943,13 @@
         {
           "file": "app/menus/ComboboxOptions.vue",
           "component": "ComboboxOptions",
-          "line": 207,
+          "line": 217,
           "expression": "optionAnnotationSlot(option)",
           "inputs": [
             {
               "name": "optionAnnotationSlot",
               "declaredAt": {
-                "line": 94,
+                "line": 104,
                 "kind": "function"
               }
             },

--- a/packages/editor/shared/README.md
+++ b/packages/editor/shared/README.md
@@ -208,7 +208,7 @@ The topbar holds the menus and tools. Dialogs cover catalog inserts, component c
 - **Export code to a folder**: generate framework and CSS files into a chosen directory.
 - **Ask the AI assistant**: open the chat, describe a change, and let the agent apply workspace actions as one undo step.
 
-Folder export runs through the local export route. [lib/export/run-local-export.ts](./lib/export/run-local-export.ts) posts the workspace to `/api/export`, which [vite/export-api-plugin.ts](./vite/export-api-plugin.ts) serves by bundling the Factory export handler. The app then writes the returned files to the folder the browser picks. The JSON download stays available as the version-control handoff artifact.
+Folder export runs through the local export route. [lib/export/run-local-export.ts](./lib/export/run-local-export.ts) posts the workspace to `/api/export`, which [vite/export-api-plugin.ts](./vite/export-api-plugin.ts) serves by bundling the Factory export handler. The app then writes the returned files to the folder the browser picks. `.seldon` stays at that project root. Generated files nest under `exportSettings.outputFolder` when that field is set. The JSON download stays available as the version-control handoff artifact.
 
 ---
 

--- a/packages/editor/shared/lib/export/output-folder.ts
+++ b/packages/editor/shared/lib/export/output-folder.ts
@@ -1,0 +1,52 @@
+import type { FileToExport } from "@seldon/factory/export/types"
+
+/**
+ * Normalizes a project-relative output folder. Empty means the project root.
+ * Rejects a path that climbs out of the root, so a typed value cannot write
+ * outside the folder the user picked.
+ */
+export function normalizeOutputFolder(value: string | undefined): string {
+  if (!value) return ""
+
+  const segments = value
+    .replaceAll("\\", "/")
+    .split("/")
+    .filter((segment) => segment && segment !== ".")
+
+  if (segments.some((segment) => segment === "..")) return ""
+
+  return segments.join("/")
+}
+
+/**
+ * Joins an output folder and a layout folder into one project-relative path.
+ * `decks` plus `sdn` becomes `decks/sdn`. An empty output folder returns the
+ * layout folder unchanged.
+ */
+export function joinExportPath(outputFolder: string | undefined, componentsFolder: string): string {
+  const prefix = normalizeOutputFolder(outputFolder)
+  const folder = componentsFolder.replaceAll("\\", "/").replace(/^\/+|\/+$/g, "")
+
+  if (!prefix) return folder
+  if (!folder) return prefix
+
+  return `${prefix}/${folder}`
+}
+
+/**
+ * Nests each export file under the output folder. The workspace source and the
+ * store stay at the project root. An empty folder leaves the paths unchanged.
+ */
+export function prefixExportPaths(
+  files: FileToExport[],
+  outputFolder: string | undefined,
+): FileToExport[] {
+  const prefix = normalizeOutputFolder(outputFolder)
+
+  if (!prefix) return files
+
+  return files.map((file) => ({
+    ...file,
+    path: `${prefix}/${file.path.replace(/^\/+/, "")}`,
+  }))
+}

--- a/packages/editor/shared/lib/export/run-local-export.ts
+++ b/packages/editor/shared/lib/export/run-local-export.ts
@@ -8,6 +8,11 @@ import type { ExportOptions, FileToExport } from "@seldon/factory/export/types"
  */
 export type LocalExportOptions = Partial<Omit<ExportOptions, "output">> & {
   output?: Partial<ExportOptions["output"]>
+  /**
+   * Project-relative folder generated files nest under. The workspace source
+   * and the store stay at the picked project root. Empty means the root.
+   */
+  outputFolder?: string
 }
 
 type WireFile = {
@@ -51,10 +56,11 @@ export async function runLocalExport(
   workspace: Workspace,
   options?: LocalExportOptions,
 ): Promise<FileToExport[]> {
+  const { outputFolder: _outputFolder, ...factoryOptions } = options ?? {}
   const response = await fetch("/api/export", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(options ? { workspace, options } : { workspace }),
+    body: JSON.stringify(options ? { workspace, options: factoryOptions } : { workspace }),
   })
 
   if (!response.ok) {

--- a/packages/editor/shared/lib/export/scan-export-root.ts
+++ b/packages/editor/shared/lib/export/scan-export-root.ts
@@ -1,0 +1,222 @@
+import { EXPORT_MANIFEST_FILENAME, parseExportManifest } from "@seldon/factory/export/manifest"
+import { FRAMEWORK_LAYOUTS } from "@seldon/factory/export/presets"
+import { kebabCase } from "change-case"
+
+import type { ExportManifest } from "@seldon/factory/export/manifest"
+import type { FrameworkId } from "@seldon/factory/export/presets"
+import type { PlatformId } from "@seldon/factory/export/types"
+
+/** Folders a project scan never enters. */
+const SKIP_DIRECTORIES = new Set([
+  "node_modules",
+  ".git",
+  "dist",
+  ".next",
+  ".nuxt",
+  "coverage",
+  ".turbo",
+  "out",
+])
+
+/** How deep to walk for a components folder such as `decks/sdn`. */
+const MAX_SCAN_DEPTH = 3
+
+const SOURCE_FILE = /^(.+)\.(react|vue|html)\.json$/
+
+const LAYOUTS_BY_FOLDER_LENGTH = Object.entries(FRAMEWORK_LAYOUTS).sort(
+  (left, right) => right[1].componentsFolder.length - left[1].componentsFolder.length,
+) as Array<[FrameworkId, { componentsFolder: string }]>
+
+type IterableDirectoryHandle = FileSystemDirectoryHandle & {
+  values: () => AsyncIterableIterator<FileSystemDirectoryHandle | FileSystemFileHandle>
+}
+
+export interface ExportRootScan {
+  hasOwnedExport: boolean
+  framework?: FrameworkId
+  platform?: PlatformId
+  outputFolder?: string
+}
+
+interface FoundManifest {
+  directoryPath: string
+  manifest: ExportManifest
+}
+
+/**
+ * Reads App Framework, Component Type, and Export To from a picked project root.
+ *
+ * An export this workspace already owns wins. That match fills all three fields,
+ * including an empty Export To when the layout already names the folder. A root
+ * with no owned export only fills App Framework from the app's package file, so
+ * a second workspace in the same repo is not forced onto the first export.
+ */
+export async function scanExportRoot(
+  root: FileSystemDirectoryHandle,
+  workspaceId?: string | null,
+  workspaceLabel?: string | null,
+): Promise<ExportRootScan> {
+  const manifests = await findManifests(root)
+  const owned = workspaceId
+    ? manifests.find((entry) => entry.manifest.workspaceId === workspaceId)
+    : undefined
+
+  if (owned) {
+    const layout = layoutFromComponentsPath(owned.directoryPath)
+    const platform = platformFromFiles(owned.manifest.files)
+
+    return {
+      hasOwnedExport: true,
+      framework: layout.framework,
+      ...(platform ? { platform } : {}),
+      outputFolder: layout.outputFolder,
+    }
+  }
+
+  const sourcePlatform = await readSourcePlatform(root, workspaceId, workspaceLabel)
+  const framework = await frameworkFromPackage(root)
+
+  if (sourcePlatform) {
+    return {
+      hasOwnedExport: true,
+      platform: sourcePlatform,
+      ...(framework ? { framework } : {}),
+    }
+  }
+
+  return {
+    hasOwnedExport: false,
+    ...(framework ? { framework } : {}),
+  }
+}
+
+async function findManifests(
+  root: FileSystemDirectoryHandle,
+  prefix = "",
+  depth = 0,
+): Promise<FoundManifest[]> {
+  const found: FoundManifest[] = []
+
+  for await (const entry of (root as IterableDirectoryHandle).values()) {
+    if (entry.kind === "file" && entry.name === EXPORT_MANIFEST_FILENAME) {
+      const text = await (await (entry as FileSystemFileHandle).getFile()).text()
+      const manifest = parseExportManifest(text)
+
+      if (manifest) found.push({ directoryPath: prefix, manifest })
+      continue
+    }
+
+    if (entry.kind !== "directory") continue
+    if (SKIP_DIRECTORIES.has(entry.name)) continue
+    if (depth >= MAX_SCAN_DEPTH) continue
+
+    const nextPrefix = prefix ? `${prefix}/${entry.name}` : entry.name
+    const nested = await findManifests(entry as FileSystemDirectoryHandle, nextPrefix, depth + 1)
+
+    found.push(...nested)
+  }
+
+  return found
+}
+
+async function readSourcePlatform(
+  root: FileSystemDirectoryHandle,
+  workspaceId?: string | null,
+  workspaceLabel?: string | null,
+): Promise<PlatformId | undefined> {
+  let directory: FileSystemDirectoryHandle
+
+  try {
+    directory = await root.getDirectoryHandle(".seldon")
+  } catch {
+    return undefined
+  }
+
+  const expectedName = workspaceLabel ? kebabCase(workspaceLabel) : ""
+
+  for await (const entry of (directory as IterableDirectoryHandle).values()) {
+    if (entry.kind !== "file") continue
+
+    const match = SOURCE_FILE.exec(entry.name)
+
+    if (!match) continue
+
+    const platform = match[2] as PlatformId
+
+    if (expectedName && match[1] === expectedName) return platform
+    if (!workspaceId) continue
+
+    try {
+      const text = await (await (entry as FileSystemFileHandle).getFile()).text()
+      const parsed = JSON.parse(text) as { metadata?: { id?: string } }
+
+      if (parsed.metadata?.id === workspaceId) return platform
+    } catch {
+      // Skip a file that will not parse.
+    }
+  }
+
+  return undefined
+}
+
+async function frameworkFromPackage(
+  root: FileSystemDirectoryHandle,
+): Promise<FrameworkId | undefined> {
+  try {
+    const handle = await root.getFileHandle("package.json")
+    const text = await (await handle.getFile()).text()
+    const parsed = JSON.parse(text) as {
+      dependencies?: Record<string, string>
+      devDependencies?: Record<string, string>
+    }
+    const deps = { ...parsed.dependencies, ...parsed.devDependencies }
+
+    if (deps.next) return "next"
+    if (deps.nuxt) return "nuxt"
+    if (deps.astro) return "astro"
+    if (deps["@sveltejs/kit"]) return "sveltekit"
+    if (deps["@remix-run/react"] || deps["@remix-run/node"]) return "remix"
+    if (deps.vite) return "vite"
+  } catch {
+    // No package file, or it will not parse.
+  }
+
+  return undefined
+}
+
+function platformFromFiles(files: string[]): PlatformId | undefined {
+  if (files.some((file) => file.endsWith(".vue"))) return "vue"
+  if (files.some((file) => file.endsWith(".tsx"))) return "react"
+
+  if (files.some((file) => file.endsWith(".html") && !file.endsWith("fonts.html"))) {
+    return "html"
+  }
+
+  return undefined
+}
+
+function layoutFromComponentsPath(relative: string): {
+  framework: FrameworkId
+  outputFolder: string
+} {
+  for (const [id, layout] of LAYOUTS_BY_FOLDER_LENGTH) {
+    const folder = layout.componentsFolder
+
+    if (relative === folder) return { framework: id, outputFolder: "" }
+
+    if (relative.endsWith(`/${folder}`)) {
+      return {
+        framework: id,
+        outputFolder: relative.slice(0, -(folder.length + 1)),
+      }
+    }
+  }
+
+  if (relative === "sdn") return { framework: "none", outputFolder: "" }
+
+  if (relative.endsWith("/sdn")) {
+    return { framework: "none", outputFolder: relative.slice(0, -4) }
+  }
+
+  return { framework: "none", outputFolder: relative }
+}

--- a/packages/editor/shared/lib/properties/inspector/flat-property-factory.ts
+++ b/packages/editor/shared/lib/properties/inspector/flat-property-factory.ts
@@ -36,6 +36,7 @@ import {
   validatePropertyValue,
 } from "@seldon/core/properties/schemas/helpers"
 import { getPresetOptions } from "@seldon/core/properties/schemas/helpers/property-options"
+import { getBuiltInLookSectionForPropertyKey } from "@seldon/core/themes/looks"
 import { getPropertiesSubjectId } from "./flat-property"
 import { resolveMatchSiblingLock } from "./match-color-lock"
 import { resolvePropertyValueForDisplay } from "./properties-read"
@@ -116,8 +117,8 @@ function hasCompoundPresetOptions(
     return false
   }
 
-  // Check if theme has a section for this property (e.g., theme.border)
-  const section = (theme as Record<string, unknown>)[propertyKey]
+  const sectionKey = getBuiltInLookSectionForPropertyKey(propertyKey) ?? propertyKey
+  const section = (theme as Record<string, unknown>)[sectionKey]
 
   if (!section || typeof section !== "object") {
     return false

--- a/packages/factory/README.md
+++ b/packages/factory/README.md
@@ -109,7 +109,7 @@ type ExportOptions = {
 }
 ```
 
-`enableRemoteFonts` is off by default. The default keeps exports request-free. Set it to `true` to emit remote font host links in the generated `Fonts.tsx`.
+`enableRemoteFonts` is off by default. The default keeps exports request-free. Set it to `true` to emit remote font host links in the generated `Fonts.tsx` or `Fonts.vue`.
 
 `exportAllIconSetIcons`, `exportAllThemes`, and `exportAllFontCollections` are on by default, so an export ships complete icon sets, themes, and font families. Set `exportAllIconSetIcons` or `exportAllThemes` to `false` to emit only what a component or theme references. Set `exportAllFontCollections` to `false` to emit only the font families a node renders through a direct `font.family` choice.
 
@@ -186,7 +186,7 @@ icons/index.ts                         # icon index, re-exports the emitted icon
 refs/index.ts                          # ref registry, emitted only when nodes carry refs
 refs/registry.json                     # the same registry as data, for tools that do not parse TypeScript
 utils/class-name.ts                    # combineClassNames helper
-Fonts.tsx                              # font loading component
+Fonts.tsx                              # font loading component, Fonts.vue on a Vue export
 styles.css                             # component stylesheet
 styles/{slug}.css                      # one stylesheet per workspace theme
 {workspace-label}.json                 # workspace copy, emitted only with includeWorkspace

--- a/packages/factory/README.md
+++ b/packages/factory/README.md
@@ -1,6 +1,6 @@
 # Seldon · Factory
 
-Seldon Factory turns a valid Seldon workspace into production code. It consumes a **workspace** object and produces a list of files. React is the current output target. It produces React components, CSS, and processed assets. Other targets such as Swift and Java are planned. Factory reads design-time state from Core, resolves properties and themes, and generates output. It does not change the workspace file.
+Seldon Factory turns a valid Seldon workspace into production code. It consumes a **workspace** object and produces a list of files. Available targets are React, Vue, and HTML+CSS. Other targets such as Swift are planned. Factory reads design-time state from Core, resolves properties and themes, and generates output. It does not change the workspace file.
 
 Core owns design-time state and rules. Factory owns export and production code generation.
 
@@ -19,9 +19,11 @@ Factory groups four areas that work together:
 
 Bindings is the only area that reads a project's source rather than a workspace. It runs in the project it scans, never in the editor.
 
-The export stage splits into two subsystems with their own guides:
+The export stage splits into subsystems with their own guides:
 
 - **[React export](./export/react/README.md)** generates components with TypeScript interfaces.
+- **[Vue export](./export/vue/)** generates single-file components.
+- **[HTML+CSS export](./export/html/README.md)** generates flattened HTML fragments.
 - **[CSS export](./export/css/README.md)** generates stylesheets with theme variables and cascade ordering.
 
 Factory imports compute logic from `@seldon/core`. It does not fork property or theme rules.
@@ -77,9 +79,9 @@ npx seldon-export --input .seldon/my-app.react.json --framework next --platform 
 npx seldon-export --input .seldon/my-app.react.json
 ```
 
-`--platform` selects the framework (`react`, `vue`). `--framework` selects the project layout (`none`, `vite`, `next`, `nuxt`, `sveltekit`, `astro`, `remix`). Run `seldon-export --help` for every flag.
+`--platform` selects the framework (`react`, `vue`, `html`). `--framework` selects the project layout (`none`, `vite`, `next`, `nuxt`, `sveltekit`, `astro`, `remix`). Run `seldon-export --help` for every flag.
 
-`exportWorkspace` resolves an asset reader, normalizes the components and assets folders, and dispatches by `target.framework`. React is the only implemented target today, so it delegates to React generation when `target.framework` is `"react"` and throws for any other framework. Future targets such as Swift and Java add their own generation branches here.
+`exportWorkspace` resolves an asset reader, normalizes the components and assets folders, and dispatches by `target.framework`. Available platforms are React, Vue, and HTML+CSS. Planned platforms such as Swift throw until they ship.
 
 ### Export options
 
@@ -109,7 +111,7 @@ type ExportOptions = {
 }
 ```
 
-`enableRemoteFonts` is off by default. The default keeps exports request-free. Set it to `true` to emit remote font host links in the generated `Fonts.tsx` or `Fonts.vue`.
+`enableRemoteFonts` is off by default. The default keeps exports request-free. Set it to `true` to emit remote font host links in `Fonts.tsx`, `Fonts.vue`, or `fonts.html`.
 
 `exportAllIconSetIcons`, `exportAllThemes`, and `exportAllFontCollections` are on by default, so an export ships complete icon sets, themes, and font families. Set `exportAllIconSetIcons` or `exportAllThemes` to `false` to emit only what a component or theme references. Set `exportAllFontCollections` to `false` to emit only the font families a node renders through a direct `font.family` choice.
 
@@ -177,6 +179,7 @@ Factory produces a component library under `output.componentsFolder`, with image
 
 ```
 {level-plural}/{Name}.tsx              # primitives, elements, parts, modules, frames, screens
+{level-plural}/{Name}.html             # flattened HTML+CSS fragment, same tree, no includes
 frames/Frame.tsx                       # generated universal container, wraps HTML.Div
 frames/Container.tsx                   # frame-level component, an instance of {level-plural}/{Name}.tsx
 native-react/HTML.{Tag}.tsx            # native HTML primitive components, such as HTML.Div
@@ -186,7 +189,7 @@ icons/index.ts                         # icon index, re-exports the emitted icon
 refs/index.ts                          # ref registry, emitted only when nodes carry refs
 refs/registry.json                     # the same registry as data, for tools that do not parse TypeScript
 utils/class-name.ts                    # combineClassNames helper
-Fonts.tsx                              # font loading component, Fonts.vue on a Vue export
+Fonts.tsx                              # font loading component, Fonts.vue on Vue, fonts.html on HTML+CSS
 styles.css                             # component stylesheet
 styles/{slug}.css                      # one stylesheet per workspace theme
 {workspace-label}.json                 # workspace copy, emitted only with includeWorkspace

--- a/packages/factory/export/css/README.md
+++ b/packages/factory/export/css/README.md
@@ -92,7 +92,7 @@ Component classes reference theme tokens through CSS custom properties. `buildSt
 
 ## Class Deduplication
 
-`buildStyleRegistry` reuses a class when another node has the same CSS and the same catalog id. Deduplication stays within one component type, but it does cross variants of that component. When two variants of the same component resolve to identical CSS, the later variant reuses the earlier variant's class and emits no class of its own. This keeps the component stylesheet smaller. Consumers that reference class names by hand must resync after an export, because a style edit can merge or split classes.
+`buildStyleRegistry` reuses a class when another node has the same CSS and the same catalog id. Deduplication stays within one component type, but it does cross variants of that component. When two variants of the same component resolve to identical CSS, the later variant reuses the earlier variant's class and emits no class of its own. This keeps the component stylesheet smaller. Do not reference a generated instance class or a shared style class in app CSS. A style edit can merge or split those classes. Select a node with a `data-seldon-ref` name or an app class.
 
 ---
 

--- a/packages/factory/export/export-workspace.ts
+++ b/packages/factory/export/export-workspace.ts
@@ -76,7 +76,7 @@ export async function exportWorkspace(
   // Also emitted here, for the same reason and one more: the integrity hashes
   // must cover the bytes that reach disk, so the scripts carry their own license
   // and format pass and are hashed only once that is done.
-  if (options.includeScripts) {
+  if (options.includeScripts && options.target.framework !== "html") {
     const { generateScripts } = await import("./shared/generate-scripts")
     const { generateScriptsIntegrity } = await import("./shared/generate-scripts-integrity")
     const { generateRules } = await import("./shared/generate-rules")

--- a/packages/factory/export/format-with-prettier.ts
+++ b/packages/factory/export/format-with-prettier.ts
@@ -14,6 +14,7 @@ const PARSER_PROBE_EXTENSION: Record<string, string> = {
   css: ".css",
   json: ".json",
   vue: ".vue",
+  html: ".html",
 }
 
 let prettierModule: PrettierApi | null | undefined

--- a/packages/factory/export/html/README.md
+++ b/packages/factory/export/html/README.md
@@ -1,0 +1,70 @@
+# Seldon · Factory · HTML+CSS Export
+
+Seldon's Factory HTML export turns a Seldon workspace into flattened HTML fragments and shared CSS. It writes one `.html` file per component variant. Each file is that variant's full tree as native tags. Nothing in a file includes another file.
+
+---
+
+## Entry Point
+
+`exportHtml` in `export-html.ts` is the entry point.
+
+```typescript
+async function exportHtml(
+  input: Workspace,
+  options: ExportOptions,
+): Promise<FileToExport[]>
+```
+
+`exportHtml` runs these steps:
+
+1. Build the export context with `buildExportContext` to get the parent index.
+2. Rewrite image paths, then build the CSS style registry.
+3. Discover components with `getComponentsToExport` and remap paths to `.html`.
+4. Emit `styles.css` and one theme file per theme.
+5. Walk each variant tree into a flattened fragment.
+6. Emit the refs registry when nodes carry refs, `fonts.html`, the package README, and image files.
+7. Add an HTML comment license to each `.html` file, then format with Prettier's `html` parser.
+
+The picker label is HTML+CSS. The platform id is `html`.
+
+---
+
+## Fragment Contract
+
+A fragment is inner markup only. It is not a full document.
+
+A card fragment already contains its buttons. A screen fragment already contains its cards. Concatenate fragments as siblings to assemble a new page. Do not nest one fragment file inside another.
+
+Wrap chosen fragments in a document that links `styles.css` and each `styles/{slug}.css` file. Copy font links from `fonts.html` when remote fonts are on.
+
+---
+
+## Discovery
+
+`discovery/get-components-to-export.ts` reuses the React discovery IR and remaps `.tsx` to `.html`. Display rules match the other targets. Exclude and Mock stay out unless `includeHiddenComponents` is on. Stub emits an empty element.
+
+---
+
+## Generation
+
+| File | Role |
+| --- | --- |
+| `generation/generate-html-fragment.ts` | Walks a `JSONTreeNode` tree into native tags, classes, text, attributes, refs, and inline SVG icons |
+| `generation/generate-component-files.ts` | Writes one fragment per variant and collects ref slot data |
+| `generation/generate-readme-file.ts` | Writes the package README |
+
+The Icon primitive is not emitted as its own file. Each use inlines SVG from `getIconData`.
+
+---
+
+## Assets
+
+`assets/get-fonts-snippet.ts` writes `fonts.html` from `export/shared/collect-remote-font-urls.ts`. Remote families emit links only when `enableRemoteFonts` is set.
+
+Images and CSS come from the shared pipelines used by React and Vue.
+
+---
+
+## Formatting
+
+`format-html.ts` runs Prettier's `html` parser. It honors `skipFormat` and `formatConfigRoot`.

--- a/packages/factory/export/html/assets/get-fonts-snippet.ts
+++ b/packages/factory/export/html/assets/get-fonts-snippet.ts
@@ -1,0 +1,21 @@
+import { collectRemoteFontUrls } from "../../shared/collect-remote-font-urls"
+
+import type { ExportOptions, FileToExport } from "../../types"
+import type { Workspace } from "@seldon/core"
+
+/**
+ * Builds a `fonts.html` snippet of remote font host links. Local and system
+ * families emit nothing. The snippet is empty of links when remote fonts are
+ * off. Family selection matches the React and Vue Fonts components.
+ */
+export function getFontsSnippet(workspace: Workspace, options: ExportOptions): FileToExport {
+  const links = collectRemoteFontUrls(workspace, options)
+    .map((url) => `<link rel="stylesheet" href="${url}" />`)
+    .join("\n")
+  const content = links.length > 0 ? `${links}\n` : "<!-- no remote fonts -->\n"
+
+  return {
+    path: `${options.output.componentsFolder}/fonts.html`.replaceAll("//", "/"),
+    content,
+  }
+}

--- a/packages/factory/export/html/discovery/get-components-to-export.ts
+++ b/packages/factory/export/html/discovery/get-components-to-export.ts
@@ -1,0 +1,26 @@
+import { getComponentsToExport as getReactComponentsToExport } from "../../react/discovery/get-components-to-export"
+
+import type { NodeIdToClass } from "../../css/types"
+import type { ComponentToExport, ExportOptions } from "../../types"
+import type { Workspace } from "@seldon/core/workspace/types"
+
+/**
+ * Resolves the component export list for the HTML target. The discovery IR is
+ * framework-neutral, so this reuses the React discovery and only remaps output
+ * file paths from `.tsx` to `.html`.
+ */
+export function getComponentsToExport(
+  workspace: Workspace,
+  options: ExportOptions,
+  nodeIdToClass: NodeIdToClass,
+): ComponentToExport[] {
+  const components = getReactComponentsToExport(workspace, options, nodeIdToClass)
+
+  return components.map((component) => ({
+    ...component,
+    output: {
+      ...component.output,
+      path: component.output.path.replace(/\.tsx$/, ".html"),
+    },
+  }))
+}

--- a/packages/factory/export/html/export-html.ts
+++ b/packages/factory/export/html/export-html.ts
@@ -1,0 +1,153 @@
+import { getComponentSchema } from "@seldon/core/components/catalog"
+import { ORDERED_COMPONENT_LEVELS } from "@seldon/core/components/constants"
+
+import { buildExportContext } from "../../helpers/build-export-context"
+import { buildStyleRegistry } from "../css/discovery/get-style-registry"
+import { generateComponentStylesheet } from "../css/generation/generate-css-stylesheet"
+import { generateThemeStylesheetFiles } from "../css/generation/insert-theme-variables"
+import { getFilesToExportFromImagesToExport } from "../react/assets/get-files-to-export-from-images-to-export"
+import { getImagesToExport } from "../react/assets/get-images-to-export"
+import { replaceImagesWithRelativePaths } from "../react/assets/transform-image-paths"
+import { assertUniqueVariantNames } from "../react/discovery/assert-unique-variant-names"
+import { format } from "../react/format"
+import { insertHtmlLicense, insertLicense } from "../react/generation/inserts/insert-license"
+import { generateRefsRegistry } from "../shared/generate-refs-registry"
+import { getFontsSnippet } from "./assets/get-fonts-snippet"
+import { getComponentsToExport } from "./discovery/get-components-to-export"
+import { formatHtml } from "./format-html"
+import { generateComponentFiles } from "./generation/generate-component-files"
+import { generateReadmeFile } from "./generation/generate-readme-file"
+
+import type { RefViewSource } from "../shared/generate-refs-registry"
+import type { ExportOptions, FileToExport } from "../types"
+import type { Workspace } from "@seldon/core"
+
+/**
+ * Exports a workspace as flattened HTML fragments plus shared CSS. This is the
+ * HTML analog of {@link exportVue}: it reuses the shared CSS pipeline, theme
+ * stylesheets, discovery IR, style registry, and refs registry, and emits one
+ * `.html` file per variant with no includes and no component API.
+ */
+export async function exportHtml(
+  input: Workspace,
+  options: ExportOptions,
+): Promise<FileToExport[]> {
+  const filesToExport: FileToExport[] = []
+  let workspace = input
+
+  const { parentIndex } = buildExportContext(workspace)
+
+  const imagesToExport = await getImagesToExport(workspace, options)
+  const imageFiles = await getFilesToExportFromImagesToExport(imagesToExport, options)
+
+  workspace = replaceImagesWithRelativePaths(workspace, imagesToExport)
+
+  const {
+    nodeIdToClass,
+    classes,
+    stateClasses,
+    descendantStateClasses,
+    classNameToNodeId,
+    nodeTreeDepths,
+  } = buildStyleRegistry(workspace, options.publishAll, parentIndex)
+
+  let componentsToExport = getComponentsToExport(workspace, options, nodeIdToClass)
+
+  assertUniqueVariantNames(workspace, new Set(componentsToExport.map((item) => item.variantId)))
+
+  const levelOrder = ORDERED_COMPONENT_LEVELS.slice().reverse()
+
+  componentsToExport = componentsToExport.sort((a, b) => {
+    const aLevelIndex = levelOrder.indexOf(getComponentSchema(a.componentId).level)
+    const bLevelIndex = levelOrder.indexOf(getComponentSchema(b.componentId).level)
+
+    return aLevelIndex - bLevelIndex
+  })
+
+  filesToExport.push({
+    path: `${options.output.componentsFolder}/styles.css`,
+    content: await generateComponentStylesheet(
+      classes,
+      workspace,
+      classNameToNodeId,
+      nodeTreeDepths,
+      stateClasses,
+      descendantStateClasses,
+      options.formatConfigRoot,
+    ),
+  })
+
+  const themeStylesheets = await generateThemeStylesheetFiles(
+    workspace,
+    options.output.componentsFolder,
+    options.exportAllThemes !== false,
+    options.formatConfigRoot,
+  )
+
+  filesToExport.push(...themeStylesheets)
+
+  let refSources: RefViewSource[] = []
+
+  try {
+    const componentFiles = generateComponentFiles(
+      componentsToExport,
+      workspace,
+      nodeIdToClass,
+      options,
+    )
+
+    filesToExport.push(...componentFiles.files)
+    refSources = componentFiles.refSources
+  } catch (error) {
+    console.warn("Failed to generate HTML fragments:", error)
+  }
+
+  try {
+    filesToExport.push(...(await generateRefsRegistry(refSources, nodeIdToClass, options)))
+  } catch {
+    // Failed to generate refs registry
+  }
+
+  try {
+    filesToExport.push(getFontsSnippet(workspace, options))
+  } catch {
+    // Failed to generate fonts snippet
+  }
+
+  try {
+    filesToExport.push(generateReadmeFile(options))
+  } catch {
+    // Failed to generate README
+  }
+
+  filesToExport.push(...imageFiles)
+
+  await Promise.all(
+    filesToExport.map(async (file) => {
+      if (typeof file.content !== "string") return
+
+      if (isHtmlFragment(file.path)) {
+        file.content = await formatHtml(insertHtmlLicense(file.content), options)
+
+        return
+      }
+
+      if (isFormattableSource(file.path)) {
+        file.content = insertLicense(file.content)
+        if (!options.skipFormat) file.content = await format(file.content, options)
+      }
+    }),
+  )
+
+  return filesToExport
+}
+
+const FORMATTABLE_SOURCE_EXTENSIONS = [".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs"]
+
+function isHtmlFragment(path: string): boolean {
+  return path.endsWith(".html")
+}
+
+function isFormattableSource(path: string): boolean {
+  return FORMATTABLE_SOURCE_EXTENSIONS.some((ext) => path.endsWith(ext))
+}

--- a/packages/factory/export/html/format-html.ts
+++ b/packages/factory/export/html/format-html.ts
@@ -1,0 +1,16 @@
+import { formatWithPrettier } from "../format-with-prettier"
+
+/**
+ * Formats an emitted HTML fragment so a file that lands in a formatted
+ * repository does not fail that repository's own format check.
+ */
+export async function formatHtml(
+  content: string,
+  options?: { skipFormat?: boolean; formatConfigRoot?: string },
+) {
+  if (options?.skipFormat) {
+    return content
+  }
+
+  return formatWithPrettier(content, { parser: "html" }, options?.formatConfigRoot)
+}

--- a/packages/factory/export/html/generated-output.test.ts
+++ b/packages/factory/export/html/generated-output.test.ts
@@ -1,0 +1,80 @@
+import path from "node:path"
+import { fileURLToPath } from "node:url"
+
+import { beforeAll, describe, expect, it } from "vitest"
+
+import { ComponentId } from "@seldon/core/components/constants"
+import { createEmptyWorkspace } from "@seldon/core/workspace/helpers/create-empty-workspace"
+import { addComponent } from "@seldon/core/workspace/reducers/handlers/add/add-component"
+
+import { exportWorkspace } from "../export-workspace"
+
+import type { ExportOptions, FileToExport } from "../types"
+import type { ExtractPayload, Workspace } from "@seldon/core"
+
+const here = path.dirname(fileURLToPath(import.meta.url))
+const repoRoot = path.resolve(here, "../../../..")
+
+const workspace: Workspace = addComponent(
+  { boardKey: ComponentId.BUTTON } as ExtractPayload<"add_component">,
+  createEmptyWorkspace(),
+)
+
+const options: ExportOptions = {
+  rootDirectory: repoRoot,
+  target: { framework: "html", styles: "css-properties" },
+  output: {
+    componentsFolder: "/src/components",
+    assetsFolder: "/public/assets",
+    assetPublicPath: "/assets",
+  },
+  skipFormat: true,
+  exportAllIconSetIcons: false,
+}
+
+let files: FileToExport[]
+
+const content = (predicate: (f: FileToExport) => boolean): string => {
+  const file = files.find(predicate)
+
+  if (!file || typeof file.content !== "string") {
+    throw new Error("expected file content not found")
+  }
+
+  return file.content
+}
+
+beforeAll(async () => {
+  files = await exportWorkspace(workspace, options)
+})
+
+describe("generated Button fragment", () => {
+  it("emits a .html fragment", () => {
+    const file = files.find((f) => /\/Button\.html$/.test(f.path))
+
+    expect(file).toBeDefined()
+  })
+
+  it("renders a native button with the variant class", () => {
+    const source = content((f) => /\/Button\.html$/.test(f.path))
+
+    expect(source).toContain("<button")
+    expect(source).toContain('class="sdn-button"')
+  })
+
+  it("does not emit a component API", () => {
+    const source = content((f) => /\/Button\.html$/.test(f.path))
+
+    expect(source).not.toContain("defineProps")
+    expect(source).not.toContain("seldonRefs")
+    expect(source).not.toContain("mergeSlot")
+  })
+})
+
+describe("generated stylesheet", () => {
+  it("emits a base rule for the default Button variant", () => {
+    const css = content((f) => f.path === "/src/components/styles.css")
+
+    expect(css).toContain(".sdn-button")
+  })
+})

--- a/packages/factory/export/html/generation/generate-component-files.ts
+++ b/packages/factory/export/html/generation/generate-component-files.ts
@@ -1,0 +1,58 @@
+import { generateJSXStructure } from "../../react/generation/preprocess/generate-jsx-structure"
+import { getConditionalPropPaths } from "../../react/generation/shared/get-conditional-prop-paths"
+import { resolveVueReturns } from "../../vue/shared/vue-native-tags"
+import { generateHtmlFragment } from "./generate-html-fragment"
+
+import type { NodeIdToClass } from "../../css/types"
+import type { RefViewSource } from "../../shared/generate-refs-registry"
+import type { ComponentToExport, ExportOptions, FileToExport } from "../../types"
+import type { Workspace } from "@seldon/core/workspace/types"
+
+export interface GeneratedComponentFiles {
+  files: FileToExport[]
+  refSources: RefViewSource[]
+}
+
+/**
+ * Generates one flattened HTML fragment per exported variant. The Icon primitive
+ * is skipped as its own file and inlined at each use, matching the Vue target's
+ * `iconMap` skip.
+ */
+export function generateComponentFiles(
+  componentsToExport: ComponentToExport[],
+  workspace: Workspace,
+  nodeIdToClass: NodeIdToClass,
+  _options: ExportOptions,
+): GeneratedComponentFiles {
+  const files: FileToExport[] = []
+  const refSources: RefViewSource[] = []
+
+  for (const component of componentsToExport) {
+    if (resolveVueReturns(component).returns === "iconMap") continue
+
+    try {
+      const { propNames } = generateJSXStructure(component, nodeIdToClass, workspace)
+
+      files.push({
+        path: component.output.path,
+        content: generateHtmlFragment(component, nodeIdToClass),
+      })
+
+      refSources.push({
+        component,
+        propNames,
+        conditionalPaths: getConditionalPropPaths(component),
+      })
+    } catch (error) {
+      console.warn(
+        `Failed to export HTML fragment "${component.name}" (${component.output.path}):`,
+        error,
+      )
+    }
+  }
+
+  return {
+    files,
+    refSources,
+  }
+}

--- a/packages/factory/export/html/generation/generate-html-fragment.ts
+++ b/packages/factory/export/html/generation/generate-html-fragment.ts
@@ -1,0 +1,214 @@
+import { getComponentExportConfig } from "@seldon/core/components/catalog"
+import { getIconData } from "@seldon/core/icon-sets/data"
+
+import { NATIVE_VUE_TAGS } from "../../vue/shared/vue-native-tags"
+
+import type { NodeIdToClass } from "../../css/types"
+import type { ComponentToExport, DataBinding, JSONTreeNode } from "../../types"
+import type { ComponentExport, NativeReactPrimitive } from "@seldon/core/components/types"
+import type { IconId } from "@seldon/core/icon-sets"
+
+/**
+ * Void HTML elements cannot hold children or text. They emit as self-closing
+ * tags so a fragment stays valid markup.
+ */
+const VOID_HTML_TAGS = new Set([
+  "area",
+  "base",
+  "br",
+  "col",
+  "embed",
+  "hr",
+  "img",
+  "input",
+  "link",
+  "meta",
+  "param",
+  "source",
+  "track",
+  "wbr",
+])
+
+const NATIVE_ATTR_KEYS = ["src", "href", "placeholder", "type", "role"] as const
+
+interface WalkContext {
+  nodeIdToClass: NodeIdToClass
+  rootConfig: ComponentExport
+}
+
+/**
+ * Builds one flattened HTML fragment for an exported variant. The tree is fully
+ * inlined. Nested variants become native tags, not includes.
+ */
+export function generateHtmlFragment(
+  component: ComponentToExport,
+  nodeIdToClass: NodeIdToClass,
+): string {
+  const markup = nodeToHtml(component.tree, 0, {
+    nodeIdToClass,
+    rootConfig: component.config,
+  })
+
+  return `${markup.trimEnd()}\n`
+}
+
+function nodeToHtml(node: JSONTreeNode, indent: number, context: WalkContext): string {
+  const pad = " ".repeat(indent)
+  const react = resolveReactExport(node, context, indent === 0)
+  const tag = resolveTag(node, react)
+  const attrString = buildAttributes(node, context)
+
+  if (react.returns === "iconMap") {
+    return `${pad}${iconSvg(node, context)}\n`
+  }
+
+  if (VOID_HTML_TAGS.has(tag)) {
+    return `${pad}<${tag}${attrString} />\n`
+  }
+
+  if (node.isStub) {
+    return `${pad}<${tag}${attrString}></${tag}>\n`
+  }
+
+  const children = Array.isArray(node.children) ? node.children : []
+  const text = readText(node.dataBinding.props)
+
+  if (children.length === 0) {
+    const body = text === undefined ? "" : escapeText(text)
+
+    return `${pad}<${tag}${attrString}>${body}</${tag}>\n`
+  }
+
+  let inner = ""
+
+  if (text !== undefined) {
+    inner += `${pad}  ${escapeText(text)}\n`
+  }
+
+  for (const child of children) {
+    inner += nodeToHtml(child, indent + 2, context)
+  }
+
+  return `${pad}<${tag}${attrString}>\n${inner}${pad}</${tag}>\n`
+}
+
+function resolveReactExport(
+  node: JSONTreeNode,
+  context: WalkContext,
+  isRoot: boolean,
+): ComponentExport["react"] {
+  if (isRoot) return context.rootConfig.react
+
+  try {
+    return getComponentExportConfig(node.componentId).react
+  } catch {
+    return { returns: "HTMLDiv" }
+  }
+}
+
+function resolveTag(node: JSONTreeNode, react: ComponentExport["react"]): string {
+  const returns = react.returns
+
+  if (returns in NATIVE_VUE_TAGS) {
+    return NATIVE_VUE_TAGS[returns as NativeReactPrimitive]
+  }
+
+  if (returns === "htmlElement") {
+    return safeTag(readString(node.dataBinding.props, "htmlElement"), "div")
+  }
+
+  if (returns === "wrapperElement" || returns === "Frame") {
+    return safeTag(readString(node.dataBinding.props, "wrapperElement"), "div")
+  }
+
+  if (returns === "custom") {
+    const base = react.custom?.base
+
+    if (base && base in NATIVE_VUE_TAGS) {
+      return NATIVE_VUE_TAGS[base]
+    }
+  }
+
+  return "div"
+}
+
+function buildAttributes(node: JSONTreeNode, context: WalkContext): string {
+  const attrs: string[] = []
+  const className = classNames(node, context.nodeIdToClass)
+
+  if (className) attrs.push(`class="${escapeAttr(className)}"`)
+  if (node.ref) attrs.push(`data-seldon-ref="${escapeAttr(node.ref)}"`)
+
+  for (const key of NATIVE_ATTR_KEYS) {
+    const value = readString(node.dataBinding.props, key)
+
+    if (value === undefined) continue
+    attrs.push(`${key}="${escapeAttr(value)}"`)
+  }
+
+  for (const key of Object.keys(node.dataBinding.props)) {
+    if (!key.startsWith("aria-")) continue
+    const value = readString(node.dataBinding.props, key)
+
+    if (value === undefined) continue
+    attrs.push(`${key}="${escapeAttr(value)}"`)
+  }
+
+  if (attrs.length === 0) return ""
+
+  return ` ${attrs.join(" ")}`
+}
+
+function classNames(node: JSONTreeNode, nodeIdToClass: NodeIdToClass): string {
+  if (node.classNames && node.classNames.length > 0) {
+    return node.classNames.filter(Boolean).join(" ")
+  }
+
+  return nodeIdToClass[node.nodeId] ?? ""
+}
+
+function iconSvg(node: JSONTreeNode, context: WalkContext): string {
+  const iconId = readString(node.dataBinding.props, "icon") as IconId | undefined
+  const data = iconId ? getIconData(iconId) : undefined
+  const viewBox = data?.viewBox ?? "0 0 24 24"
+  const body = data?.body ?? ""
+  const className = classNames(node, context.nodeIdToClass)
+  const classAttr = className ? ` class="${escapeAttr(className)}"` : ""
+  const refAttr = node.ref ? ` data-seldon-ref="${escapeAttr(node.ref)}"` : ""
+
+  return `<svg xmlns="http://www.w3.org/2000/svg" viewBox="${escapeAttr(viewBox)}" fill="currentColor" height="1em" width="1em"${classAttr}${refAttr} aria-hidden="true">${body}</svg>`
+}
+
+function readText(props: DataBinding["props"]): string | undefined {
+  const children = readString(props, "children")
+
+  if (children !== undefined) return children
+
+  return readString(props, "content")
+}
+
+function readString(props: DataBinding["props"], key: string): string | undefined {
+  const cell = props[key]
+
+  if (!cell) return undefined
+  const value = cell.value !== undefined ? cell.value : cell.defaultValue
+
+  if (typeof value !== "string") return undefined
+  if (value.length === 0) return undefined
+
+  return value
+}
+
+function safeTag(tag: string | undefined, fallback: string): string {
+  if (tag && /^[a-z][a-z0-9]*$/.test(tag)) return tag
+
+  return fallback
+}
+
+function escapeAttr(value: string): string {
+  return value.replaceAll("&", "&amp;").replaceAll('"', "&quot;").replaceAll("<", "&lt;")
+}
+
+function escapeText(value: string): string {
+  return value.replaceAll("&", "&amp;").replaceAll("<", "&lt;")
+}

--- a/packages/factory/export/html/generation/generate-readme-file.ts
+++ b/packages/factory/export/html/generation/generate-readme-file.ts
@@ -1,0 +1,53 @@
+import type { ExportOptions, FileToExport } from "../../types"
+
+/**
+ * Writes the package README for an HTML+CSS export. Fragments have no props
+ * API. A consumer or MCP wraps chosen files in a document that links the CSS.
+ */
+export function generateReadmeFile(options: ExportOptions): FileToExport {
+  const content = `# Seldon HTML
+
+This export writes flattened HTML fragments and shared CSS. Each file is one variant's full tree as native tags. Nothing in a file includes another file.
+
+## Wrap a fragment
+
+Link the stylesheet and each theme file this export wrote. Paste one or more fragments into the body.
+
+\`\`\`html
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <link rel="stylesheet" href="./styles.css" />
+    <link rel="stylesheet" href="./styles/seldon.css" />
+  </head>
+  <body>
+    <!-- paste fragments here -->
+  </body>
+</html>
+\`\`\`
+
+Remote font links live in \`fonts.html\`. Copy those \`<link>\` tags into the document head when the export ran with remote fonts enabled.
+
+## Assemble pages
+
+A screen fragment is already an assembled page. Use it as the body.
+
+A new page that was not authored as a screen is sibling composition. Concatenate existing fragments next to each other. Do not nest \`Button.html\` inside \`Card.html\`. The card already contains its buttons.
+
+## Files this export writes
+
+- \`{level-plural}/{Name}.html\` is one flattened fragment per variant
+- \`styles.css\` holds reset, base, and component rules
+- \`styles/{slug}.css\` holds theme token variables
+- \`fonts.html\` holds remote font host links
+- \`refs/registry.json\` lists \`data-seldon-ref\` names when nodes carry refs
+
+For more about Seldon, visit [github.com/SeldonDigital/seldon](https://github.com/SeldonDigital/seldon)
+`
+
+  return {
+    path: `${options.output.componentsFolder}/README.md`,
+    content,
+  }
+}

--- a/packages/factory/export/platforms/registry.ts
+++ b/packages/factory/export/platforms/registry.ts
@@ -1,3 +1,4 @@
+import { exportHtml } from "../html/export-html"
 import { exportReact } from "../react/export-react"
 import { exportVue } from "../vue/export-vue"
 
@@ -55,10 +56,19 @@ export const PLATFORMS: Record<PlatformId, PlatformDefinition> = {
     styles: "css-properties",
     export: exportVue,
   },
+  html: {
+    id: "html",
+    label: "HTML+CSS",
+    status: "available",
+    styles: "css-properties",
+    export: exportHtml,
+  },
 }
 
-/** Ordered list of platforms for menus and pickers. */
-export const PLATFORM_LIST: PlatformDefinition[] = Object.values(PLATFORMS)
+/** Platforms for menus and pickers, sorted by label. */
+export const PLATFORM_LIST: PlatformDefinition[] = Object.values(PLATFORMS).sort((a, b) =>
+  a.label.localeCompare(b.label),
+)
 
 /** Look up a platform definition by id. */
 export function getPlatform(id: PlatformId): PlatformDefinition | undefined {

--- a/packages/factory/export/react/README.md
+++ b/packages/factory/export/react/README.md
@@ -144,7 +144,7 @@ Two predicates classify a component for the `Type` line in the generated JSDoc. 
 | `assets/get-files-to-export-from-images-to-export.ts` | Reads image files for export |
 | `assets/get-icons.ts` | Reads the icon component file for each used icon id. It resolves each id to a catalog file with `resolveIconExport`, skips ids that do not resolve with a warning, and generates the `IconDefault` component for the default icon |
 | `assets/generate-icon-index.ts` | Writes the icon index file. It writes an export line only for icons that resolve to a catalog file and deduplicates by component name, so the index never references files that were not emitted |
-| `assets/get-fonts-component.ts` | Writes the `Fonts` component. It emits font host links for remote families only when `options.enableRemoteFonts` is set. With `exportAllFontCollections` on it links every enabled remote family; with it off it links only families a node renders through a direct `font.family` choice |
+| `assets/get-fonts-component.ts` | Writes the `Fonts` component. Family URLs come from `export/shared/collect-remote-font-urls.ts`. It emits font host links for remote families only when `options.enableRemoteFonts` is set. With `exportAllFontCollections` on it links every enabled remote family; with it off it links only families a node renders through a direct `font.family` choice |
 
 The refs registry is shared with the Vue target and lives in [export/shared/generate-refs-registry.ts](../shared/generate-refs-registry.ts). It writes `refs/index.ts` and `refs/registry.json` from the slot data each target collects, and returns an empty list when no node carries a ref, so neither file is emitted unless it has content. See the [factory README](../../README.md) for the emitted shape.
 

--- a/packages/factory/export/react/assets/get-fonts-component.ts
+++ b/packages/factory/export/react/assets/get-fonts-component.ts
@@ -1,6 +1,4 @@
-import { getRemoteFontUrl } from "@seldon/core"
-import { workspaceFontCollectionService } from "@seldon/core/workspace/services"
-
+import { collectRemoteFontUrls } from "../../shared/collect-remote-font-urls"
 import { format } from "../format"
 
 import type { ExportOptions, FileToExport } from "../../types"
@@ -20,46 +18,9 @@ export async function getFontsComponent(
   workspace: Workspace,
   options: ExportOptions,
 ): Promise<FileToExport> {
-  const links: string[] = []
-
-  if (options.enableRemoteFonts) {
-    const seen = new Set<string>()
-    const linkedFamilies = new Set<string>()
-    const enabledByFamily = workspaceFontCollectionService.getEnabledVariantsByFamily(workspace)
-
-    /** Emits one font host link for a remote family, deduped by family and url. */
-    const pushFamily = (familyName: string, variants?: string[]): void => {
-      if (linkedFamilies.has(familyName)) return
-      const url = getRemoteFontUrl(familyName, variants)
-
-      if (!url) return
-      linkedFamilies.add(familyName)
-      if (seen.has(url)) return
-      seen.add(url)
-      links.push(`    <link rel="stylesheet" href="${url}" />`)
-    }
-
-    if (options.exportAllFontCollections !== false) {
-      // Every enabled remote family on a font collection board, whether or not
-      // the project uses it.
-      for (const family of workspaceFontCollectionService.collectWorkspaceFamilies(workspace)) {
-        if (family.origin === "local") continue
-        const enabled = enabledByFamily[family.name]
-
-        // An explicit empty selection (preset None) requests no weights, so skip.
-        if (enabled && enabled.length === 0) continue
-        pushFamily(family.name, enabled)
-      }
-    } else {
-      // Only the remote families a node renders through a direct `font.family`
-      // choice, so an export scoped to used fonts stays request-minimal.
-      for (const familyName of workspaceFontCollectionService.collectUsedRemoteFontFamilies(
-        workspace,
-      )) {
-        pushFamily(familyName, enabledByFamily[familyName])
-      }
-    }
-  }
+  const links = collectRemoteFontUrls(workspace, options).map(
+    (url) => `    <link rel="stylesheet" href="${url}" />`,
+  )
 
   const content = await format(
     `import React from "react"

--- a/packages/factory/export/react/generation/helpers/generate-readme-file.ts
+++ b/packages/factory/export/react/generation/helpers/generate-readme-file.ts
@@ -399,7 +399,7 @@ Always provide meaningful labels and ARIA attributes:
 ### Styling Issues
 - Import \`styles.css\` and each \`styles/{slug}.css\` file your workspace exports
 - Check CSS class conflicts with your existing styles
-- Use browser dev tools to inspect generated class names (instance classes end with a short hash like \`sdn-button-iconic--abc12\`)
+- Select a node by \`data-seldon-ref\` or by an app class you pass in. Do not target a generated instance class. Those names change when styles merge or split.
 
 ### TypeScript Errors
 - Ensure you're importing the correct prop interfaces

--- a/packages/factory/export/react/generation/inserts/insert-license.ts
+++ b/packages/factory/export/react/generation/inserts/insert-license.ts
@@ -22,6 +22,30 @@ export function insertLicense(source: string) {
   })
 }
 
+export const HTML_LICENSE_HEADER = `<!--
+ *
+ * This code was generated using Seldon (https://github.com/SeldonDigital/seldon)
+ *
+ * License: https://github.com/SeldonDigital/seldon/blob/main/LICENSE.md
+ * Do not redistribute or sublicense without permission.
+ *
+ * You may not use this software, or any derivative works of it, in whole or in part,
+ * for the purposes of training, fine-tuning, or otherwise improving (directly or indirectly)
+ * any machine learning or artificial intelligence system without written permission.
+ *
+ -->
+`
+
+/**
+ * Prepends the license as an HTML comment. Idempotent: a source that already
+ * carries the header is returned unchanged.
+ */
+export function insertHtmlLicense(source: string): string {
+  if (source.includes(HTML_LICENSE_HEADER.trim())) return source
+
+  return `${HTML_LICENSE_HEADER}${source}`
+}
+
 /**
  * Inserts the license header inside a single-file component's first `<script>`
  * block, so Prettier's `vue` parser keeps it as a JS block comment instead of

--- a/packages/factory/export/shared/collect-remote-font-urls.ts
+++ b/packages/factory/export/shared/collect-remote-font-urls.ts
@@ -1,0 +1,54 @@
+import { getRemoteFontUrl } from "@seldon/core"
+import { workspaceFontCollectionService } from "@seldon/core/workspace/services"
+
+import type { ExportOptions } from "../types"
+import type { Workspace } from "@seldon/core"
+
+/**
+ * Collects remote font host URLs for the exported Fonts component.
+ *
+ * Local and system families need no network request, so they return nothing.
+ * Remote families only emit a URL when `options.enableRemoteFonts` is set.
+ * `exportAllFontCollections` then selects the family scope: on, every enabled
+ * remote family on a font collection board, whether or not the project uses it;
+ * off, only the families a node actually renders through a direct `font.family`
+ * choice.
+ */
+export function collectRemoteFontUrls(workspace: Workspace, options: ExportOptions): string[] {
+  if (!options.enableRemoteFonts) return []
+
+  const urls: string[] = []
+  const seen = new Set<string>()
+  const linkedFamilies = new Set<string>()
+  const enabledByFamily = workspaceFontCollectionService.getEnabledVariantsByFamily(workspace)
+
+  const pushFamily = (familyName: string, variants?: string[]): void => {
+    if (linkedFamilies.has(familyName)) return
+    const url = getRemoteFontUrl(familyName, variants)
+
+    if (!url) return
+    linkedFamilies.add(familyName)
+    if (seen.has(url)) return
+    seen.add(url)
+    urls.push(url)
+  }
+
+  if (options.exportAllFontCollections !== false) {
+    for (const family of workspaceFontCollectionService.collectWorkspaceFamilies(workspace)) {
+      if (family.origin === "local") continue
+      const enabled = enabledByFamily[family.name]
+
+      // An explicit empty selection (preset None) requests no weights, so skip.
+      if (enabled && enabled.length === 0) continue
+      pushFamily(family.name, enabled)
+    }
+  } else {
+    for (const familyName of workspaceFontCollectionService.collectUsedRemoteFontFamilies(
+      workspace,
+    )) {
+      pushFamily(familyName, enabledByFamily[familyName])
+    }
+  }
+
+  return urls
+}

--- a/packages/factory/export/shared/generate-rules.ts
+++ b/packages/factory/export/shared/generate-rules.ts
@@ -500,5 +500,17 @@ answers \`:root\`.
 Read \`${componentsFolder}/styles/\` to see the variable names a theme defines. Do
 not redefine a \`--sdn-*\` variable in your own CSS. Set the theme attribute and let
 the generated stylesheet supply the values.
+
+## Do not select generated classes
+
+Do not write a selector, className, or query that uses a generated instance
+class. Those names end with \`--\` and a short hash, such as \`sdn-frame--zkmp\`.
+Do not select a shared generated class such as \`sdn-dialog-settings\` or
+\`sdn-dialog-about\`. That name comes from a style match. It is not the component
+name. A later export can merge, split, or rename it.
+
+Select a node with a \`data-seldon-ref\` name, an app class you pass in, or a
+role your controller sets. A class such as \`.sdn-button\` or \`.sdn-bar\` names a
+component type. Use it only when every instance of that type should match.
 `
 }

--- a/packages/factory/export/types.ts
+++ b/packages/factory/export/types.ts
@@ -73,7 +73,7 @@ export type ExportOptions = {
  * Identifier for an export platform. Adding a platform means adding an id here
  * and a matching entry in the platform registry (`platforms/registry.ts`).
  */
-export type PlatformId = "react" | "swift" | "vue" | "svelte"
+export type PlatformId = "react" | "swift" | "vue" | "svelte" | "html"
 
 /** Whether a platform can export today or is registered for a future release. */
 export type PlatformStatus = "available" | "planned"

--- a/packages/factory/export/vue/assets/get-fonts-component.ts
+++ b/packages/factory/export/vue/assets/get-fonts-component.ts
@@ -1,0 +1,26 @@
+import { collectRemoteFontUrls } from "../../shared/collect-remote-font-urls"
+
+import type { ExportOptions, FileToExport } from "../../types"
+import type { Workspace } from "@seldon/core"
+
+/**
+ * Builds the exported `Fonts.vue` component from the workspace's font
+ * collections. Family selection matches the React `Fonts` component through
+ * {@link collectRemoteFontUrls}.
+ */
+export function getFontsComponent(workspace: Workspace, options: ExportOptions): FileToExport {
+  const hrefsLiteral = JSON.stringify(collectRemoteFontUrls(workspace, options), null, 2)
+  const content = `<script setup lang="ts">
+const hrefs: string[] = ${hrefsLiteral}
+</script>
+
+<template>
+  <link v-for="href in hrefs" :key="href" rel="stylesheet" :href="href" />
+</template>
+`
+
+  return {
+    path: `${options.output.componentsFolder}/Fonts.vue`.replaceAll("//", "/"),
+    content,
+  }
+}

--- a/packages/factory/export/vue/export-vue.ts
+++ b/packages/factory/export/vue/export-vue.ts
@@ -19,11 +19,13 @@ import {
 } from "../react/generation/inserts/insert-license"
 import { generateRefsRegistry } from "../shared/generate-refs-registry"
 import { generateFrameComponent } from "./assets/generate-frame"
+import { getFontsComponent } from "./assets/get-fonts-component"
 import { getVueIcons } from "./assets/get-vue-icons"
 import { getVueUtilityFiles } from "./assets/get-vue-utility-files"
 import { getComponentsToExport } from "./discovery/get-components-to-export"
 import { formatVue } from "./format-vue"
 import { generateComponentFiles } from "./generation/generate-component-files"
+import { generateReadmeFile } from "./generation/generate-readme-file"
 
 import type { RefViewSource } from "../shared/generate-refs-registry"
 import type { ExportOptions, FileToExport } from "../types"
@@ -33,7 +35,8 @@ import type { Workspace } from "@seldon/core"
  * Exports a workspace to a Vue project. This is the Vue analog of
  * {@link exportReact}: it reuses the shared CSS pipeline, theme stylesheets,
  * discovery IR, style registry, and refs registry verbatim, and emits `.vue`
- * single-file components in place of `.tsx`.
+ * single-file components in place of `.tsx`. It also writes `Fonts.vue` and a
+ * Vue package README.
  */
 export async function exportVue(input: Workspace, options: ExportOptions): Promise<FileToExport[]> {
   const filesToExport: FileToExport[] = []
@@ -93,6 +96,7 @@ export async function exportVue(input: Workspace, options: ExportOptions): Promi
       nodeTreeDepths,
       stateClasses,
       descendantStateClasses,
+      options.formatConfigRoot,
     ),
   })
 
@@ -100,6 +104,7 @@ export async function exportVue(input: Workspace, options: ExportOptions): Promi
     workspace,
     options.output.componentsFolder,
     options.exportAllThemes !== false,
+    options.formatConfigRoot,
   )
 
   filesToExport.push(...themeStylesheets)
@@ -142,6 +147,18 @@ export async function exportVue(input: Workspace, options: ExportOptions): Promi
     filesToExport.push(...(await generateRefsRegistry(refSources, nodeIdToClass, options)))
   } catch {
     // Failed to generate refs registry
+  }
+
+  try {
+    filesToExport.push(getFontsComponent(workspace, options))
+  } catch {
+    // Failed to generate fonts component
+  }
+
+  try {
+    filesToExport.push(generateReadmeFile(options))
+  } catch {
+    // Failed to generate README
   }
 
   filesToExport.push(...imageFiles)

--- a/packages/factory/export/vue/generation/generate-readme-file.ts
+++ b/packages/factory/export/vue/generation/generate-readme-file.ts
@@ -1,0 +1,273 @@
+import type { ExportOptions, FileToExport } from "../../types"
+
+/**
+ * Writes the package README for a Vue export. The examples use the Vue slot
+ * contract: `className`, per-slot props, `null` to suppress, and `seldonRefs`.
+ */
+export function generateReadmeFile(options: ExportOptions): FileToExport {
+  const content = `# Seldon Components
+
+This guide covers the Vue components this export wrote.
+
+## Overview
+
+Each component is a single-file component with typed props.
+
+- \`className\` joins with the generated variant class
+- Schema slots render by default. Pass \`null\` to hide one
+- Optional slots stay hidden until you pass props or a matching \`seldonRefs\` entry
+- Styles come from the generated CSS classes and theme files
+
+## Basic usage
+
+Import a component from its level folder.
+
+\`\`\`vue
+<script setup lang="ts">
+import CardProduct from "./parts/CardProduct.vue"
+</script>
+
+<template>
+  <CardProduct />
+</template>
+\`\`\`
+
+Override a slot by passing an object. Hide a schema slot with \`null\`.
+
+\`\`\`vue
+<template>
+  <CardProduct
+    :text-tagline="{ children: 'New Product' }"
+    :text-title="{ children: 'Custom Title' }"
+    :description="{ children: 'Product description here' }"
+    :button="{ onClick: () => alert('Clicked!') }"
+    :icon="{ icon: 'material-star' }"
+    :text-label="{ children: 'Buy Now' }"
+    :button2="null"
+  />
+</template>
+\`\`\`
+
+## Schema slots and optional slots
+
+Schema slots come from the component schema. They have defaults and render unless you pass \`null\`.
+
+\`\`\`vue
+<template>
+  <CardProduct />
+  <CardProduct :text-tagline="{ children: 'Custom tagline' }" :bar="null" />
+</template>
+\`\`\`
+
+Optional slots were added in the workspace outside the schema. They stay hidden until you pass their prop or address them through \`seldonRefs\`.
+
+\`\`\`vue
+<template>
+  <CardProduct
+    :button4="{ onClick: () => alert('Extra action!') }"
+    :icon4="{ icon: 'material-favorite' }"
+  />
+</template>
+\`\`\`
+
+An empty object is enough to show an optional slot with its default content. Omit the prop to keep the slot hidden. Pass \`null\` to hide a schema slot.
+
+## Drive slots by ref
+
+Components that compose children declare \`seldonRefs\`. Keys are the \`data-seldon-ref\` names on descendants. The merge helpers apply a matching entry after the slot prop.
+
+\`\`\`vue
+<script setup lang="ts">
+import CardProduct from "./parts/CardProduct.vue"
+
+const seldonRefs = {
+  textTitle: { children: "Override by ref" },
+}
+</script>
+
+<template>
+  <CardProduct :seldon-refs="seldonRefs" />
+</template>
+\`\`\`
+
+A \`null\` slot prop still hides the slot even when a ref entry exists.
+
+Named Vue slots appear on empty frames that carry a ref. Use the ref name as the slot name to inject content there.
+
+\`\`\`vue
+<template>
+  <CardProduct>
+    <template #extraRegion>
+      <MyContent />
+    </template>
+  </CardProduct>
+</template>
+\`\`\`
+
+## Common patterns
+
+### Text
+
+\`\`\`vue
+<template>
+  <CardProduct
+    :text-tagline="{ children: 'Limited Time Offer' }"
+    :text-title="{ children: 'Premium Headphones' }"
+    :description="{ children: 'High-quality audio experience.' }"
+  />
+</template>
+\`\`\`
+
+### Actions
+
+\`\`\`vue
+<template>
+  <CardProduct
+    :button="{ onClick: () => window.open('/product/123') }"
+    :icon="{ icon: 'material-shoppingCart' }"
+    :text-label="{ children: 'Add to Cart' }"
+    :button2="{ onClick: () => setFavorite(true) }"
+    :icon2="{ icon: 'material-favorite' }"
+    :text-label2="{ children: 'Save' }"
+  />
+</template>
+\`\`\`
+
+### Class names
+
+Pass \`className\` on the root or on a slot. Target a node by \`data-seldon-ref\` or by a class you pass in. Generated instance class names change when styles merge or split.
+
+\`\`\`vue
+<template>
+  <CardProduct
+    class-name="my-custom-card"
+    :text-tagline="{ children: 'New Release', className: 'highlight-text' }"
+  />
+</template>
+\`\`\`
+
+### Conditional slots
+
+\`\`\`vue
+<script setup lang="ts">
+const showActions = true
+const isLoggedIn = false
+const extraRefs = isLoggedIn
+  ? {
+      button4: { onClick: () => toggleFavorite() },
+      icon4: { icon: "material-favorite" },
+    }
+  : undefined
+</script>
+
+<template>
+  <CardProduct
+    :text-tagline="{ children: 'Featured Product' }"
+    :text-title="{ children: 'Product Name' }"
+    :bar="showActions ? undefined : null"
+    :seldon-refs="extraRefs"
+  />
+</template>
+\`\`\`
+
+## Icons
+
+Pass an icon id on the icon slot. Common ids include \`material-add\`, \`material-favorite\`, \`material-shoppingCart\`, \`material-arrowForward\`, \`material-star\`, and \`material-check\`.
+
+\`\`\`vue
+<template>
+  <CardProduct
+    :icon="{ icon: 'material-star' }"
+    :icon2="{ icon: 'material-favorite' }"
+    :icon3="{ icon: 'material-shoppingCart' }"
+  />
+</template>
+\`\`\`
+
+The export ships one \`Icon.vue\` renderer and geometry in \`icons/index.ts\`.
+
+## Styles
+
+Import \`styles.css\` and each \`styles/{slug}.css\` file this export wrote.
+
+\`\`\`css
+.sdn-card-product {
+}
+.sdn-button {
+}
+.sdn-button-iconic {
+}
+.sdn-button-iconic--abc12 {
+}
+\`\`\`
+
+The default \`seldon\` theme uses bare \`--sdn-\` variables in \`styles/seldon.css\`. Every other theme uses a \`--sdn-{slug}-\` prefix in \`styles/{slug}.css\`.
+
+\`\`\`css
+:root {
+  --sdn-swatch-background: /* background color */
+  --sdn-swatch-primary: /* brand color */
+  --sdn-font-size-medium: /* font size step */
+  --sdn-font-family-primary: /* brand typeface */
+  --sdn-padding-cozy: /* padding step */
+  --sdn-gap-comfortable: /* gap step */
+}
+\`\`\`
+
+Use those variables in your own CSS. Select a node by \`data-seldon-ref\` or by a class you pass in.
+
+## TypeScript
+
+Each file uses \`defineProps\` with typed slots. Import the component from its path.
+
+\`\`\`ts
+import CardProduct from "./parts/CardProduct.vue"
+import type { SeldonRefs } from "./utils/class-names"
+\`\`\`
+
+## Fonts
+
+Mount \`Fonts.vue\` once in the app when the export ran with remote fonts enabled.
+
+\`\`\`vue
+<script setup lang="ts">
+import Fonts from "./Fonts.vue"
+</script>
+
+<template>
+  <Fonts />
+</template>
+\`\`\`
+
+Local and system families need no host link. Remote families only emit links when \`enableRemoteFonts\` is on.
+
+## Troubleshooting
+
+### A slot does not render
+
+Check whether the slot is a schema slot or an optional slot. Schema slots render unless you pass \`null\`. Optional slots render only when you pass props or a matching \`seldonRefs\` entry. An empty object still shows the slot with its default content.
+
+### Styles look wrong
+
+Import \`styles.css\` and each theme file. Check for class conflicts with your own CSS. Target a node by \`data-seldon-ref\` or by a class you pass in.
+
+### Types fail
+
+Import from the matching level folder. Slot props are objects or \`null\`. Use \`seldonRefs\` for overrides keyed by \`data-seldon-ref\`.
+
+## Files this export writes
+
+- \`Fonts.vue\` loads remote font host links
+- \`styles.css\` holds reset, base, and component rules
+- \`styles/{slug}.css\` holds theme token variables
+- \`utils/class-names.ts\` holds \`combineClassNames\`, \`mergeSlot\`, and \`mergeOptionalSlot\`
+- Each component file is a typed single-file component
+
+For more about Seldon, visit [github.com/SeldonDigital/seldon](https://github.com/SeldonDigital/seldon)
+`
+
+  return {
+    path: `${options.output.componentsFolder}/README.md`,
+    content,
+  }
+}

--- a/packages/factory/styles/css-properties/get-border-styles.test.ts
+++ b/packages/factory/styles/css-properties/get-border-styles.test.ts
@@ -54,4 +54,24 @@ describe("getBorderStyles", () => {
   it("returns no styles when no border is set", () => {
     expect(getBorderStyles(context({} as unknown as Properties))).toEqual({})
   })
+
+  it("emits a side look when border is the cleared none look", () => {
+    const properties = {
+      border: {
+        preset: { type: ValueType.THEME_CATEGORICAL, value: "@border.none" },
+      },
+      borderLeft: {
+        preset: { type: ValueType.THEME_CATEGORICAL, value: "@border.hairline" },
+      },
+    } as unknown as Properties
+
+    const styles = getBorderStyles(context(properties))
+
+    expect(styles.borderLeftWidth).toBe("var(--hairline)")
+    expect(styles.borderLeftStyle).toBe("solid")
+    expect(styles.borderLeftColor).toBeDefined()
+    expect(styles.borderTopWidth).toBeUndefined()
+    expect(styles.borderRightWidth).toBeUndefined()
+    expect(styles.borderBottomWidth).toBeUndefined()
+  })
 })

--- a/packages/factory/styles/css-properties/get-border-styles.ts
+++ b/packages/factory/styles/css-properties/get-border-styles.ts
@@ -1,6 +1,7 @@
 import { ValueType } from "@seldon/core"
 import { resolveValue } from "@seldon/core/helpers/resolution/resolve-value"
 import { getThemeOption } from "@seldon/core/helpers/theme/get-theme-option"
+import { isBuiltInClearedLookToken } from "@seldon/core/themes/looks"
 
 import { getComputedCssValue } from "../computed-variables"
 import { getBorderWidthCSSValue } from "./get-border-width-css-value"
@@ -67,6 +68,18 @@ export function getBorderStyles({
 }
 
 /**
+ * A cleared `@border.none` on `border` does not paint any side. Side compounds
+ * stay independent, so they still resolve when that all-sides look is none.
+ */
+function shorthandAppliesToSides(shorthand: BorderCompound | undefined): boolean {
+  const preset = resolveValue(shorthand?.preset)
+
+  if (!preset) return true
+
+  return !isBuiltInClearedLookToken("border", preset.value)
+}
+
+/**
  * Resolve the styles for one border side, layering the side compound over the
  * `border` shorthand and finally the theme border preset.
  */
@@ -80,15 +93,17 @@ function getBorderSideStyles(
 ): CSSObject {
   const capitalizedSide = side.charAt(0).toUpperCase() + side.slice(1)
   const styles: CSSObject = {}
-
-  const preset = resolveValue(sideBorder?.preset) || resolveValue(shorthand?.preset)
+  const inheritShorthand = shorthandAppliesToSides(shorthand)
+  const preset =
+    resolveValue(sideBorder?.preset) ||
+    (inheritShorthand ? resolveValue(shorthand?.preset) : undefined)
   const themeBorder: ThemeBorder | undefined = preset
     ? getThemeOption(preset.value, theme)
     : undefined
 
   const width =
     resolveValue(sideBorder?.width) ||
-    resolveValue(shorthand?.width) ||
+    (inheritShorthand ? resolveValue(shorthand?.width) : undefined) ||
     resolveValue(themeBorder?.parameters.width)
 
   if (width) {
@@ -101,7 +116,7 @@ function getBorderSideStyles(
 
   const style =
     resolveValue(sideBorder?.style) ||
-    resolveValue(shorthand?.style) ||
+    (inheritShorthand ? resolveValue(shorthand?.style) : undefined) ||
     resolveValue(themeBorder?.parameters.style)
 
   if (style) {
@@ -110,17 +125,17 @@ function getBorderSideStyles(
 
   const color =
     resolveValue(sideBorder?.color) ||
-    resolveValue(shorthand?.color) ||
+    (inheritShorthand ? resolveValue(shorthand?.color) : undefined) ||
     resolveValue(themeBorder?.parameters.color)
 
   const brightness =
     resolveValue(sideBorder?.brightness) ||
-    resolveValue(shorthand?.brightness) ||
+    (inheritShorthand ? resolveValue(shorthand?.brightness) : undefined) ||
     resolveValue(themeBorder?.parameters.brightness)
 
   const opacity =
     resolveValue(sideBorder?.opacity) ||
-    resolveValue(shorthand?.opacity) ||
+    (inheritShorthand ? resolveValue(shorthand?.opacity) : undefined) ||
     resolveValue(themeBorder?.parameters.opacity)
 
   if (color) {
@@ -139,7 +154,7 @@ function getBorderSideStyles(
     // skipping EMPTY cells the same way `resolveValue` does.
     const original = [
       computeContext?.properties[SIDE_COMPOUND_KEY[side]]?.color,
-      computeContext?.properties.border?.color,
+      inheritShorthand ? computeContext?.properties.border?.color : undefined,
       themeBorder?.parameters.color,
     ].find((cell) => !!cell && cell.type !== ValueType.EMPTY)
     const themed =


### PR DESCRIPTION
## 📝 Description

Adds HTML+CSS as an export platform (flattened fragments, shared CSS) and lets each workspace pick its own Export To path under one project Root Folder, so `.seldon` stays at the repo root while Vue and HTML output can land in different folders. The export dialog scans the chosen root and prefills App Framework, Component Type, and Export To unless the user already changed them.

Also brings Vue export and editor closer to React: shared remote font URL collection, Vue package README, canvas resize anchoring, and dirty-gated remote workspace refresh. Fixes border sides reading Default instead of None when the compound is `@border.none`, and stops unused combobox option annotations from showing as Label.

## 🔗 Related Issues

## 🧪 Type of Change

- 🐛 Bug fix
- ✨ New feature
- 📚 Documentation update

## 📦 Affected Packages

- `@seldon/core`
- `@seldon/factory`
- `@seldon/editor`
- `@seldon/ai`

## 📸 Screenshots/Videos

_N/A_

## 🔍 Code Quality Checklist

- Code follows the project's style guidelines
- Self-review of the code has been performed
- Code is properly commented, particularly in hard-to-understand areas
- No console.log statements or debugging code left in
- TypeScript types are properly defined, no use of "as any"
- No unused imports or variables

## 📋 Breaking Changes

_None_

## 🚀 Deployment Notes

_None_

## 📚 Documentation Updates

Updated export and property docs for HTML+CSS, Vue README and font links, `outputFolder` on workspace export settings, and border-side Default vs None. Factory and editor shared READMEs mention the new export path behavior.

## ⚠️ Additional Notes

_None_

---

I have read the CLA and I agree to its terms.

Github: AndreiSeldon
Organization: SeldonDigital